### PR TITLE
Fix model namespaces

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -1,5 +1,5 @@
 <?php
-namespace Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/src/Models/PointsTransaction.php
+++ b/src/Models/PointsTransaction.php
@@ -1,5 +1,5 @@
 <?php
-namespace Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
@@ -20,6 +20,6 @@ class PointsTransaction extends Model
 
     public function order()
     {
-        return $this->belongsTo(\Models\Order::class, 'order_id');
+        return $this->belongsTo(Order::class, 'order_id');
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1,5 +1,5 @@
 <?php
-namespace Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
@@ -31,7 +31,7 @@ class User extends Model
     // Транзакции баллов
     public function pointsTransactions()
     {
-        return $this->hasMany(\Models\PointsTransaction::class, 'user_id');
+        return $this->hasMany(PointsTransaction::class, 'user_id');
     }
     
     public function isFirstReferredOrder(): bool


### PR DESCRIPTION
## Summary
- fix namespaces of Eloquent models so PSR-4 autoload works

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*
- `php -l src/Models/Order.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843201c6a5c832cb2a350acd5607021