### PR TITLE
Add PHP tag to AuthMiddleware

### DIFF
--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -1,3 +1,4 @@
+<?php
 class AuthMiddleware {
     public function handle($role, $next) {
         if (empty($_SESSION['user_id']) || $_SESSION['role'] !== $role) {


### PR DESCRIPTION
## Summary
- prepend standard PHP opening tag to `AuthMiddleware`

## Testing
- `php -l src/Middleware/AuthMiddleware.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684323bd54e0832cba5d3089e9a257c6