### PR TITLE
Add PHPUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# YagodGO Web App
+
+This project contains a simple PHP application for the YagodGO delivery service.
+
+## Running tests
+
+Install dependencies using Composer and run PHPUnit:
+
+```bash
+composer install
+vendor/bin/phpunit
+```

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
     "bramus/router": "^1.6",
     "vlucas/phpdotenv": "^5.5"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^9.6"
+  },
   "autoload": {
     "psr-4": {
       "App\\": "src/"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class OrderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists('App\\Models\\Order')) {
+            require_once __DIR__ . '/../src/Models/Order.php';
+            class_alias('Models\\Order', 'App\\Models\\Order');
+        }
+    }
+
+    public function testCalculateReferralDiscount(): void
+    {
+        $this->assertSame(10, \App\Models\Order::calculateReferralDiscount(100));
+        $this->assertSame(0, \App\Models\Order::calculateReferralDiscount(5));
+    }
+
+    public function testCalculateMaxPointsUsage(): void
+    {
+        $this->assertSame(30, \App\Models\Order::calculateMaxPointsUsage(100));
+    }
+
+    public function testCalculatePersonalBonus(): void
+    {
+        $this->assertSame(5, \App\Models\Order::calculatePersonalBonus(100));
+    }
+
+    public function testCalculateReferralBonus(): void
+    {
+        $this->assertSame(3, \App\Models\Order::calculateReferralBonus(100));
+    }
+}

--- a/tests/ReferralHelperTest.php
+++ b/tests/ReferralHelperTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use PDO;
+
+class ReferralHelperTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        if (!class_exists('App\\Helpers\\ReferralHelper')) {
+            require_once __DIR__ . '/../src/Helpers/ReferralHelper.php';
+        }
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, referral_code TEXT)');
+        $this->pdo->exec("INSERT INTO users (referral_code) VALUES ('ABCDEFG1'), ('ABCDEFG2')");
+    }
+
+    public function testGenerateUniqueCode(): void
+    {
+        $code = \App\Helpers\ReferralHelper::generateUniqueCode($this->pdo, 8);
+        $this->assertSame(8, strlen($code));
+        $this->assertMatchesRegularExpression('/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]+$/', $code);
+        $stmt = $this->pdo->prepare('SELECT COUNT(*) FROM users WHERE referral_code = ?');
+        $stmt->execute([$code]);
+        $this->assertSame('0', $stmt->fetchColumn());
+    }
+}


### PR DESCRIPTION
## Summary
- set up PHPUnit dev dependency
- add basic phpunit.xml configuration
- create Order and ReferralHelper unit tests
- document how to execute the tests

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68432425f2cc832caa7c26ef926dde75