### PR TITLE
Improve admin dashboard purchase summary

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -17,22 +17,65 @@ class AdminController
      */
     public function dashboard(): void
     {
-        // Здесь вы можете подготовить любые данные для дашборда:
+        // === Статистика по заказам ===
+
+        // Сегодняшняя дата
+        $today = date('Y-m-d');
+
+        // Сумма выручки за сегодня
+        $stmt = $this->pdo->prepare(
+            "SELECT SUM(total_amount) FROM orders WHERE DATE(created_at) = ?"
+        );
+        $stmt->execute([$today]);
+        $todayRevenue = (int)($stmt->fetchColumn() ?: 0);
+
+        // Количество заказов за сегодня
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM orders WHERE DATE(created_at) = ?"
+        );
+        $stmt->execute([$today]);
+        $todayOrders = (int)($stmt->fetchColumn() ?: 0);
+
+        // Средний чек (по всем заказам)
+        $stmt = $this->pdo->query(
+            "SELECT AVG(total_amount) FROM orders"
+        );
+        $averageCheck = (int)($stmt->fetchColumn() ?: 0);
+
         $stats = [
-            'today_revenue' => '—',
-            'today_orders'  => '—',
-            'average_check' => '—',
-        ];
-        $chartData = [
-            'labels' => [],  // метки для графика
-            'values' => [],  // значения
+            'today_revenue' => $todayRevenue,
+            'today_orders'  => $todayOrders,
+            'average_check' => $averageCheck,
         ];
 
-        // Вызываем viewAdmin, который обернёт содержимое в admin_main.php
+        // === Необходимое количество товаров по принятым заказам ===
+        $stmt = $this->pdo->query(
+            "SELECT
+                CONCAT(pt.name, ' ', p.variety) AS product,
+                SUM(oi.quantity)                AS qty,
+                p.unit                          AS unit
+             FROM order_items oi
+             JOIN orders o       ON o.id = oi.order_id
+             JOIN products p     ON p.id = oi.product_id
+             JOIN product_types pt ON pt.id = p.product_type_id
+             WHERE o.status IN ('processing','assigned')
+             GROUP BY oi.product_id, product, p.unit
+             ORDER BY product"
+        );
+        $purchaseList = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        // Данные для графика (заглушка)
+        $chartData = [
+            'labels' => [],
+            'values' => [],
+        ];
+
+        // Отображаем дашборд
         viewAdmin('dashboard', [
-            'pageTitle' => 'Панель управления',
-            'stats'     => $stats,
-            'chartData' => $chartData,
+            'pageTitle'    => 'Панель управления',
+            'stats'        => $stats,
+            'chartData'    => $chartData,
+            'purchaseList' => $purchaseList,
         ]);
     }
 }

--- a/src/Views/admin/dashboard.php
+++ b/src/Views/admin/dashboard.php
@@ -1,5 +1,7 @@
 <?php
-// Здесь могут быть данные: $stats, $chartData и т.п.
+/** @var array $stats */
+/** @var array $chartData */
+/** @var array $purchaseList */
 ?>
 <div class="space-y-6">
   <div class="grid grid-cols-3 gap-4">
@@ -22,6 +24,30 @@
     <h3 class="text-lg font-medium mb-2">Выручка за 7 дней</h3>
     <canvas id="revenueChart" class="w-full h-64"></canvas>
   </div>
+
+  <?php if (!empty($purchaseList)): ?>
+  <div class="bg-white p-4 rounded shadow">
+    <h3 class="text-lg font-medium mb-2">Закупка по принятым заказам</h3>
+    <table class="min-w-full text-sm">
+      <thead>
+        <tr>
+          <th class="p-2 text-left">Товар</th>
+          <th class="p-2 text-left">Количество</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($purchaseList as $row): ?>
+        <tr class="border-b">
+          <td class="p-2"><?= htmlspecialchars($row['product']) ?></td>
+          <td class="p-2">
+            <?= $row['qty'] ?> <?= htmlspecialchars($row['unit']) ?>
+          </td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <?php endif; ?>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- compute daily stats and required purchase quantities in `AdminController`
- display purchase list on `dashboard.php`

## Testing
- `php -l src/Controllers/AdminController.php`
- `php -l src/Views/admin/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_684324e02708832cbe2497b2e4a80eb6