### PR TITLE
Fix order queries to fetch product names

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -50,9 +50,10 @@ class OrdersController
 
         // Товары в заказе
         $stmt = $this->pdo->prepare(
-          "SELECT oi.quantity, oi.unit_price, p.name, p.unit
+          "SELECT oi.quantity, oi.unit_price, t.name AS name, p.unit
            FROM order_items oi
            JOIN products p ON p.id = oi.product_id
+           JOIN product_types t ON t.id = p.product_type_id
            WHERE oi.order_id = ?"
         );
         $stmt->execute([$id]);
@@ -117,9 +118,10 @@ class OrdersController
 
         // Получаем товары из корзины
         $stmt = $this->pdo->prepare(
-            "SELECT ci.product_id, p.name AS product, p.variety, ci.quantity, ci.unit_price, p.delivery_date
+            "SELECT ci.product_id, t.name AS product, p.variety, ci.quantity, ci.unit_price, p.delivery_date
              FROM cart_items ci
              JOIN products p ON p.id = ci.product_id
+             JOIN product_types t ON t.id = p.product_type_id
              WHERE ci.user_id = ?"
         );
         $stmt->execute([$user->id]);


### PR DESCRIPTION
## Summary
- fix order item listing by selecting product name via `product_types`
- include product type join for checkout cart view

## Testing
- `php -l src/Controllers/OrdersController.php`


------
https://chatgpt.com/codex/tasks/task_e_684327ecd4a8832c900091d55094bd94