### PR TITLE
Add order deletion functionality

### DIFF
--- a/index.php
+++ b/index.php
@@ -226,6 +226,9 @@ switch ("$method $uri") {
     case 'POST /admin/orders/status':
         (new App\Controllers\OrdersController($pdo))->updateStatus();
         break;
+    case 'POST /admin/orders/delete':
+        (new App\Controllers\OrdersController($pdo))->delete();
+        break;
 
     case 'GET /admin/slots':
         (new App\Controllers\SlotsController($pdo))->index();

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -313,4 +313,31 @@ class OrdersController
         header("Location: /orders/thankyou");
         exit;
     }
+
+    // Удаление заказа (POST, админ)
+    public function delete(): void
+    {
+        $orderId = (int)($_POST['order_id'] ?? 0);
+        if ($orderId) {
+            // Удаляем связанные записи в order_items
+            $stmt = $this->pdo->prepare(
+                "DELETE FROM order_items WHERE order_id = ?"
+            );
+            $stmt->execute([$orderId]);
+
+            // Удаляем связанные транзакции баллов
+            $stmt = $this->pdo->prepare(
+                "DELETE FROM points_transactions WHERE order_id = ?"
+            );
+            $stmt->execute([$orderId]);
+
+            // Удаляем сам заказ
+            $stmt = $this->pdo->prepare(
+                "DELETE FROM orders WHERE id = ?"
+            );
+            $stmt->execute([$orderId]);
+        }
+        header('Location: /admin/orders');
+        exit;
+    }
 }

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -22,6 +22,10 @@
       <td class="p-2"><?= htmlspecialchars($o['courier_name'] ?? '-') ?></td>
       <td class="p-2">
         <a href="/admin/orders/<?= $o['id'] ?>" class="text-[#C86052] hover:underline">Открыть</a>
+        <form action="/admin/orders/delete" method="post" class="inline-block ml-2" onsubmit="return confirm('Удалить заказ?');">
+          <input type="hidden" name="order_id" value="<?= $o['id'] ?>">
+          <button type="submit" class="text-red-600 hover:underline">Удалить</button>
+        </form>
       </td>
     </tr>
     <?php endforeach; ?>

--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -34,5 +34,9 @@
       </select>
       <button class="bg-gray-300 px-3 py-1 rounded hover:bg-gray-400 ml-2">Обновить</button>
     </form>
+    <form action="/admin/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
+      <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
+      <button class="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Удалить</button>
+    </form>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- allow admins to delete orders
- wire new route to OrdersController::delete
- show delete button in orders list and details

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432d59e7fc832cbeed6b898f181ea1