### PR TITLE
Revamp admin orders listing

### DIFF
--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -1,29 +1,34 @@
 <?php /** @var array $orders */ ?>
-<table class="min-w-full bg-white rounded shadow overflow-hidden">
-  <thead class="bg-gray-200 text-gray-700">
-    <tr>
-      <th class="p-2">#</th>
-      <th class="p-2">Клиент</th>
-      <th class="p-2">Сумма</th>
-      <th class="p-2">Статус</th>
-      <th class="p-2">Дата</th>
-      <th class="p-2">Курьер</th>
-      <th class="p-2">Действия</th>
-    </tr>
-  </thead>
-  <tbody>
-    <?php foreach($orders as $o): ?>
-    <tr class="border-b hover:bg-gray-50">
-      <td class="p-2"><?= $o['id'] ?></td>
-      <td class="p-2"><?= htmlspecialchars($o['client_name']) ?></td>
-      <td class="p-2"><?= $o['total_amount'] ?> ₽</td>
-      <td class="p-2"><?= htmlspecialchars($o['status']) ?></td>
-      <td class="p-2"><?= $o['created_at'] ?></td>
-      <td class="p-2"><?= htmlspecialchars($o['courier_name'] ?? '-') ?></td>
-      <td class="p-2">
-        <a href="/admin/orders/<?= $o['id'] ?>" class="text-[#C86052] hover:underline">Открыть</a>
-      </td>
-    </tr>
-    <?php endforeach; ?>
-  </tbody>
-</table>
+<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+  <?php foreach ($orders as $o): ?>
+    <div class="bg-white rounded shadow p-4 flex flex-col hover:shadow-md transition-shadow">
+      <div class="flex justify-between items-center mb-2">
+        <span class="font-semibold">#<?= $o['id'] ?></span>
+        <span class="text-sm text-gray-500"><?= $o['created_at'] ?></span>
+      </div>
+      <div class="font-medium text-gray-800 mb-1">
+        <?= htmlspecialchars($o['client_name']) ?>
+      </div>
+      <div class="text-sm text-gray-600 mb-1">
+        <?= htmlspecialchars($o['status']) ?>
+      </div>
+      <div class="text-lg font-semibold mb-1">
+        <?= $o['total_amount'] ?> ₽
+      </div>
+      <div class="text-sm text-gray-500 mb-4">
+        Курьер: <?= htmlspecialchars($o['courier_name'] ?? '-') ?>
+      </div>
+      <div class="flex justify-end space-x-2 mt-auto">
+        <a href="/admin/orders/<?= $o['id'] ?>" class="text-[#C86052] hover:text-[#B44D47] flex items-center" title="Открыть">
+          <span class="material-icons">open_in_new</span>
+        </a>
+        <form action="/admin/orders/delete" method="post">
+          <input type="hidden" name="order_id" value="<?= $o['id'] ?>">
+          <button type="submit" class="text-red-500 hover:text-red-700 flex items-center" title="Удалить">
+            <span class="material-icons">delete</span>
+          </button>
+        </form>
+      </div>
+    </div>
+  <?php endforeach; ?>
+</div>


### PR DESCRIPTION
## Summary
- modernize admin orders layout using a grid of cards
- add action icons and remove the old table

## Testing
- `php ./vendor/bin/phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684338fb5da4832cbff706e6c2978224