### PR TITLE
Fix home page product status

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -27,8 +27,18 @@ class ClientController
     public function home(): void
     {
         $popular = $this->pdo->query(
-            "SELECT p.id, t.name AS product, p.variety, p.description, p.origin_country,
-                    p.box_size, p.box_unit, p.price, p.image_path, p.delivery_date
+            "SELECT p.id,
+                    t.name AS product,
+                    p.variety,
+                    p.description,
+                    p.origin_country,
+                    p.box_size,
+                    p.box_unit,
+                    p.price,
+                    p.sale_price,
+                    p.is_active,
+                    p.image_path,
+                    p.delivery_date
              FROM products p
              JOIN product_types t ON t.id = p.product_type_id
              ORDER BY p.id DESC


### PR DESCRIPTION
## Summary
- select product activity and sale price when querying popular products

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: Class "Illuminate\Database\Eloquent\Model" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f7c6ad58832c8a359d5e651bfef2