### PR TITLE
Remove redirect after adding item to cart

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -190,7 +190,10 @@ public function cart(): void
         }
 
         $this->refreshCartTotal();
-        header('Location: /cart');
+
+        // После добавления не переходим в корзину, а возвращаемся на предыдущую страницу
+        $referer = $_SERVER['HTTP_REFERER'] ?? '/';
+        header('Location: ' . $referer);
         exit;
     }
 


### PR DESCRIPTION
## Summary
- stop redirecting to cart after adding an item
- return to referring page instead

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Class "Illuminate\Database\Eloquent\Model" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fa5aa9c4832c96a34550f6dec792