### PR TITLE
Fix admin order address field

### DIFF
--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -4,7 +4,7 @@
   <div class="bg-white p-4 rounded shadow">
     <p><strong>Клиент:</strong> <?= htmlspecialchars($order['client_name']) ?></p>
     <p><strong>Телефон:</strong> <?= htmlspecialchars($order['phone']) ?></p>
-    <p><strong>Адрес:</strong> <?= htmlspecialchars($order['street']) ?></p>
+    <p><strong>Адрес:</strong> <?= htmlspecialchars($order['address']) ?></p>
     <p><strong>Статус:</strong> <?= htmlspecialchars($order['status']) ?></p>
   </div>
   <div class="bg-white p-4 rounded shadow">


### PR DESCRIPTION
## Summary
- show admin order address with correct key

## Testing
- `phpunit --configuration phpunit.xml tests` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844210ebdd4832c8027a55bc56aec42