### PR TITLE
Add SMS verification and PIN reset

### DIFF
--- a/config/sms.php
+++ b/config/sms.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'api_id' => '4f14fa2d-ed20-ebc4-2928-55a31be83b4a'
+];

--- a/index.php
+++ b/index.php
@@ -33,6 +33,8 @@ if (!empty($_SESSION['user_id'])) {
 // -------------------------------------------------------
 // 2) Подключаем конфиг Telegram
 $telegramConfig = require __DIR__ . '/config/telegram.php';
+// Конфиг SMS.RU
+$smsConfig = require __DIR__ . '/config/sms.php';
 // -----
 
 
@@ -151,6 +153,25 @@ switch ("$method $uri") {
         break;
     case 'POST /login':
         (new App\Controllers\AuthController($pdo))->login();
+        break;
+
+    // СМС подтверждения при регистрации
+    case 'POST /api/send-reg-code':
+        (new App\Controllers\AuthController($pdo, $smsConfig))->sendRegistrationCode();
+        break;
+    case 'POST /api/verify-reg-code':
+        (new App\Controllers\AuthController($pdo, $smsConfig))->verifyRegistrationCode();
+        break;
+
+    // Восстановление PIN-кода
+    case 'GET /reset-pin':
+        (new App\Controllers\AuthController($pdo, $smsConfig))->showResetPinForm();
+        break;
+    case 'POST /reset-pin/send-code':
+        (new App\Controllers\AuthController($pdo, $smsConfig))->sendResetPinCode();
+        break;
+    case 'POST /reset-pin':
+        (new App\Controllers\AuthController($pdo, $smsConfig))->resetPin();
         break;
 
     // Выход

--- a/src/Helpers/SmsRu.php
+++ b/src/Helpers/SmsRu.php
@@ -1,0 +1,29 @@
+<?php
+namespace App\Helpers;
+
+class SmsRu
+{
+    private string $apiId;
+
+    public function __construct(string $apiId)
+    {
+        $this->apiId = $apiId;
+    }
+
+    public function send(string $phone, string $message): bool
+    {
+        $query = http_build_query([
+            'api_id' => $this->apiId,
+            'to'     => $phone,
+            'msg'    => $message,
+            'json'   => 1,
+        ]);
+
+        $response = @file_get_contents('https://sms.ru/sms/send?' . $query);
+        if ($response === false) {
+            return false;
+        }
+        $data = json_decode($response, true);
+        return isset($data['status']) && $data['status'] === 'OK';
+    }
+}

--- a/src/Views/client/login.php
+++ b/src/Views/client/login.php
@@ -84,11 +84,14 @@
     <!-- Регистрация -->
     <div class="text-center mt-6">
 
-      <a href="/register" 
+      <a href="/register"
          class="inline-flex items-center px-6 py-3 bg-white border-2 border-gray-200 rounded-2xl font-medium text-gray-700 hover:border-red-200 hover:text-red-500 transition-all shadow-lg hover:shadow-xl space-x-2">
         <span class="material-icons-round">person_add</span>
         <span>Зарегистрироваться</span>
       </a>
+      <div class="mt-3">
+        <a href="/reset-pin" class="text-sm text-red-500 hover:underline">Забыли PIN-код?</a>
+      </div>
     </div>
 
   </div>

--- a/src/Views/client/reset_pin.php
+++ b/src/Views/client/reset_pin.php
@@ -1,0 +1,89 @@
+<?php /** @var string|null $error */ ?>
+<main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 flex flex-col items-center justify-center px-4 py-4 fixed inset-0 overflow-auto">
+  <div class="w-full max-w-md relative z-10">
+    <div class="text-center mb-8">
+      <h1 class="text-3xl font-bold bg-gradient-to-r from-red-500 to-pink-500 bg-clip-text text-transparent mb-2">
+        Восстановление PIN
+      </h1>
+    </div>
+    <?php if (!empty($_GET['error'])): ?>
+      <div class="bg-gradient-to-r from-red-50 to-pink-50 border-l-4 border-red-400 p-4 rounded-2xl mb-6 animate-shake">
+        <div class="flex items-center">
+          <span class="material-icons-round text-red-500 mr-3">error</span>
+          <p class="text-red-700 font-medium"><?= htmlspecialchars($_GET['error']) ?></p>
+        </div>
+      </div>
+    <?php endif; ?>
+    <div class="bg-white rounded-3xl shadow-2xl p-8 backdrop-blur-sm">
+      <form id="resetForm" action="/reset-pin" method="post" class="space-y-6">
+        <div class="space-y-2">
+          <label class="flex items-center text-sm font-semibold text-gray-700">
+            <span class="material-icons-round mr-2 text-red-500">phone</span>
+            Номер телефона
+          </label>
+          <div class="relative">
+            <div class="absolute left-4 top-1/2 transform -translate-y-1/2 flex items-center">
+              <span class="text-gray-700 font-semibold">+7</span>
+            </div>
+            <input id="phone" name="phone" type="tel" maxlength="10" inputmode="numeric" pattern="\d{10}" placeholder="902 923 7794" required class="w-full pl-16 pr-4 py-4 text-lg border-2 border-gray-100 rounded-2xl focus:border-red-500 focus:ring-2 focus:ring-red-100 outline-none transition-all text-gray-800 placeholder-gray-400">
+          </div>
+          <button type="button" id="sendCode" class="mt-3 w-full bg-red-500 text-white py-2 rounded-2xl">Получить код</button>
+        </div>
+        <div id="codeBlock" class="space-y-2 hidden">
+          <label class="flex items-center text-sm font-semibold text-gray-700">
+            <span class="material-icons-round mr-2 text-red-500">message</span>
+            Код из SMS
+          </label>
+          <div class="flex space-x-3 justify-center">
+            <?php for ($i=0;$i<4;$i++): ?>
+              <input type="tel" maxlength="1" inputmode="numeric" data-code-input class="w-14 h-14 text-center text-2xl font-bold border-2 border-gray-200 rounded-2xl" />
+            <?php endfor; ?>
+          </div>
+          <button type="button" id="verifyCode" class="w-full bg-pink-500 text-white py-2 rounded-2xl">Проверить</button>
+        </div>
+        <div id="newPinBlock" class="space-y-2 hidden">
+          <label class="flex items-center text-sm font-semibold text-gray-700">
+            <span class="material-icons-round mr-2 text-red-500">lock</span>
+            Новый PIN
+          </label>
+          <div class="flex space-x-3 justify-center">
+            <?php for ($i=0;$i<4;$i++): ?>
+              <input type="tel" maxlength="1" inputmode="numeric" data-pin-input class="w-14 h-14 text-center text-2xl font-bold border-2 border-gray-200 rounded-2xl" />
+            <?php endfor; ?>
+          </div>
+          <input type="hidden" name="pin" id="pinHidden">
+          <input type="hidden" name="code" id="codeHidden">
+          <button type="submit" class="w-full bg-gradient-to-r from-red-500 to-pink-500 text-white py-2 rounded-2xl">Сохранить PIN</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</main>
+<script>
+const phoneInput = document.getElementById('phone');
+phoneInput.addEventListener('input',()=>{phoneInput.value=phoneInput.value.replace(/\D/g,'').slice(0,10);});
+const sendBtn=document.getElementById('sendCode');
+const codeBlock=document.getElementById('codeBlock');
+const verifyBtn=document.getElementById('verifyCode');
+const newPinBlock=document.getElementById('newPinBlock');
+const codeInputs=document.querySelectorAll('input[data-code-input]');
+const pinInputs=document.querySelectorAll('input[data-pin-input]');
+const codeHidden=document.getElementById('codeHidden');
+const pinHidden=document.getElementById('pinHidden');
+
+sendBtn.addEventListener('click',()=>{
+  const phone=phoneInput.value.replace(/\D/g,'');
+  if(phone.length!==10)return alert('Введите номер');
+  fetch('/reset-pin/send-code',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'phone='+phone})
+    .then(r=>r.json()).then(()=>{codeBlock.classList.remove('hidden');});
+});
+verifyBtn.addEventListener('click',()=>{
+  const code=Array.from(codeInputs).map(i=>i.value).join('');
+  const phone=phoneInput.value.replace(/\D/g,'');
+  fetch('/api/verify-reg-code',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'phone='+phone+'&code='+code})
+    .then(r=>r.json()).then(d=>{if(d.success){newPinBlock.classList.remove('hidden');codeHidden.value=code;codeBlock.classList.add('hidden');}else{alert('Неверный код');}});
+});
+pinInputs.forEach((el,idx)=>{
+  el.addEventListener('input',()=>{el.value=el.value.replace(/\D/,'').slice(0,1);if(el.value&&idx<pinInputs.length-1)pinInputs[idx+1].focus();pinHidden.value=Array.from(pinInputs).map(i=>i.value).join('');});
+});
+</script>


### PR DESCRIPTION
## Summary
- integrate sms.ru API config and helper
- add registration phone confirmation with SMS
- implement PIN reset flow with SMS verification
- link reset page from login

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b16afe034832c893fc90fd0fd8a24