### PR TITLE
Equalize product card heights

### DIFF
--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -75,7 +75,7 @@
   <!-- Sale Products -->
   <section class="px-4 mb-8">
     <h2 class="text-2xl font-bold text-gray-800 mb-4">💥 Товары со скидкой</h2>
-    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory">
+    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
       <?php foreach ($saleProducts as $p): ?>
         <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
           <?php include __DIR__ . '/_card.php'; ?>
@@ -92,7 +92,7 @@
   <!-- In Stock Products -->
   <section class="px-4 mb-8">
     <h2 class="text-2xl font-bold text-gray-800 mb-4">📦 В наличии</h2>
-    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory">
+    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
       <?php foreach ($inStockProducts as $p): ?>
         <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
           <?php include __DIR__ . '/_card.php'; ?>
@@ -109,7 +109,7 @@
   <!-- Preorder Products -->
   <section class="px-4 mb-8">
     <h2 class="text-2xl font-bold text-gray-800 mb-4">🛒 Под заказ</h2>
-    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory">
+    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
       <?php foreach ($preorderProducts as $p): ?>
         <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
           <?php include __DIR__ . '/_card.php'; ?>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -607,6 +607,30 @@
   }
 </script>
 
+<script>
+  // Equalize heights of product cards on the home page
+  function equalizeProductRows() {
+    document.querySelectorAll('.eq-row').forEach(row => {
+      let max = 0;
+      const items = Array.from(row.children);
+      items.forEach(el => {
+        el.style.height = 'auto';
+        const h = el.offsetHeight;
+        if (h > max) max = h;
+      });
+      items.forEach(el => {
+        el.style.height = max + 'px';
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', equalizeProductRows);
+  window.addEventListener('resize', () => {
+    clearTimeout(window.eqResizeTimeout);
+    window.eqResizeTimeout = setTimeout(equalizeProductRows, 100);
+  });
+</script>
+
 
 
 


### PR DESCRIPTION
## Summary
- set `.eq-row` on product lists
- add JavaScript to equalize heights across each row

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c221ca4832c9ff69a31a601615f