### PR TITLE
Accrue points on order completion

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -590,30 +590,6 @@ public function cart(): void
             ]);
         }
 
-        // (7.4) Начисляем реферальный бонус пригласившему, если он есть
-        if ($referredBy) {
-            $refBonus = (int) floor($finalSum * 0.03);
-            if ($refBonus > 0) {
-                // Обновляем баланс пригласившего
-                $this->pdo->prepare(
-                  "UPDATE users SET points_balance = points_balance + ? WHERE id = ?"
-                )->execute([$refBonus, $referredBy]);
-
-                // Вставляем транзакцию с transaction_type = 'accrual'
-                $stmtRefTx = $this->pdo->prepare(
-                  "INSERT INTO points_transactions
-                     (user_id, amount, transaction_type, description, order_id, created_at)
-                   VALUES (?, ?, 'accrual', ?, ?, NOW())"
-                );
-                $desc = "Бонус за заказ №{$orderId}";
-                $stmtRefTx->execute([$referredBy, $refBonus, $desc, $orderId]);
-
-                // Обновляем поле points_accrued в самом заказе
-                $this->pdo->prepare(
-                    "UPDATE orders SET points_accrued = ? WHERE id = ?"
-                )->execute([$refBonus, $orderId]);
-            }
-        }
     }
 
     // 10) Очищаем корзину


### PR DESCRIPTION
## Summary
- move referral bonus logic out of checkout
- when admin marks an order as delivered, award 5% bonus to the user
- give 3% referral bonus at this moment and record it on the order

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684c6ec0115c832ca981c51c45d8b278