### PR TITLE
Update preorder selection logic

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -86,7 +86,7 @@ class ClientController
              FROM products p
              JOIN product_types t ON t.id = p.product_type_id
              WHERE p.is_active = 1
-               AND p.delivery_date IS NULL
+               AND (p.delivery_date IS NULL OR p.delivery_date > '$today')
              ORDER BY p.id DESC
              LIMIT 10"
         )->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- extend home page preorder query to include products with a future delivery date

## Testing
- `composer install` *(fails: missing ext-dom)*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: PDOException could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684d4c413f34832c99913ffbdc81ad1c