### PR TITLE
Fix missing layout for reset-pin route

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -256,7 +256,9 @@ public function register(): void
     // Страница восстановления PIN
     public function showResetPinForm(): void
     {
-        include 'src/Views/client/reset_pin.php';
+        view('client/reset_pin', [
+            'error' => $_GET['error'] ?? null,
+        ]);
     }
 
     // Отправка кода для смены PIN

--- a/src/Views/client/reset_pin.php
+++ b/src/Views/client/reset_pin.php
@@ -6,11 +6,11 @@
         Восстановление PIN
       </h1>
     </div>
-    <?php if (!empty($_GET['error'])): ?>
+    <?php if (!empty($error)): ?>
       <div class="bg-gradient-to-r from-red-50 to-pink-50 border-l-4 border-red-400 p-4 rounded-2xl mb-6 animate-shake">
         <div class="flex items-center">
           <span class="material-icons-round text-red-500 mr-3">error</span>
-          <p class="text-red-700 font-medium"><?= htmlspecialchars($_GET['error']) ?></p>
+          <p class="text-red-700 font-medium"><?= htmlspecialchars($error) ?></p>
         </div>
       </div>
     <?php endif; ?>


### PR DESCRIPTION
## Summary
- render reset PIN page using the main layout
- display error from controller

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684d5b27a34c832cad842fd7ebb5ea23