### PR TITLE
Fix PIN reset code verification

### DIFF
--- a/index.php
+++ b/index.php
@@ -162,6 +162,9 @@ switch ("$method $uri") {
     case 'POST /api/verify-reg-code':
         (new App\Controllers\AuthController($pdo, $smsConfig))->verifyRegistrationCode();
         break;
+    case 'POST /api/verify-reset-code':
+        (new App\Controllers\AuthController($pdo, $smsConfig))->verifyResetPinCode();
+        break;
 
     // Восстановление PIN-кода
     case 'GET /reset-pin':

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -253,6 +253,17 @@ public function register(): void
         echo json_encode(['success' => $valid]);
     }
 
+    // Проверка кода для сброса PIN
+    public function verifyResetPinCode(): void
+    {
+        $phone = $this->normalizePhone($_POST['phone'] ?? '');
+        $code  = trim($_POST['code'] ?? '');
+        $valid = isset($_SESSION['reset_phone'], $_SESSION['reset_code']) &&
+            $_SESSION['reset_phone'] === $phone && $_SESSION['reset_code'] == $code;
+        header('Content-Type: application/json');
+        echo json_encode(['success' => $valid]);
+    }
+
     // Страница восстановления PIN
     public function showResetPinForm(): void
     {

--- a/src/Views/client/reset_pin.php
+++ b/src/Views/client/reset_pin.php
@@ -81,7 +81,7 @@ function verifyResetCode(){
   const code=Array.from(codeInputs).map(i=>i.value).join('');
   if(code.length!==4)return;
   const phone=phoneInput.value.replace(/\D/g,'');
-  fetch('/api/verify-reg-code',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'phone='+phone+'&code='+code})
+  fetch('/api/verify-reset-code',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'phone='+phone+'&code='+code})
     .then(r=>r.json()).then(d=>{
       if(d.success){
         newPinBlock.classList.remove('opacity-50');


### PR DESCRIPTION
## Summary
- add `/api/verify-reset-code` route
- implement `verifyResetPinCode` in AuthController
- call new API endpoint from reset_pin view

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684db8e12d00832ca1cd65b11941e8af