### PR TITLE
Fix PIN reset verification

### DIFF
--- a/index.php
+++ b/index.php
@@ -162,6 +162,9 @@ switch ("$method $uri") {
     case 'POST /api/verify-reg-code':
         (new App\Controllers\AuthController($pdo, $smsConfig))->verifyRegistrationCode();
         break;
+    case 'POST /api/verify-reset-code':
+        (new App\Controllers\AuthController($pdo, $smsConfig))->verifyResetPinCode();
+        break;
 
     // Восстановление PIN-кода
     case 'GET /reset-pin':

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -279,6 +279,17 @@ public function register(): void
         echo json_encode(['success' => $ok]);
     }
 
+    // Проверка кода для восстановления PIN
+    public function verifyResetPinCode(): void
+    {
+        $phone = $this->normalizePhone($_POST['phone'] ?? '');
+        $code  = trim($_POST['code'] ?? '');
+        $valid = isset($_SESSION['reset_phone'], $_SESSION['reset_code']) &&
+            $_SESSION['reset_phone'] === $phone && $_SESSION['reset_code'] == $code;
+        header('Content-Type: application/json');
+        echo json_encode(['success' => $valid]);
+    }
+
     // Смена PIN после подтверждения
     public function resetPin(): void
     {

--- a/src/Views/client/reset_pin.php
+++ b/src/Views/client/reset_pin.php
@@ -81,7 +81,7 @@ function verifyResetCode(){
   const code=Array.from(codeInputs).map(i=>i.value).join('');
   if(code.length!==4)return;
   const phone=phoneInput.value.replace(/\D/g,'');
-  fetch('/api/verify-reg-code',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'phone='+phone+'&code='+code})
+  fetch('/api/verify-reset-code',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'phone='+phone+'&code='+code})
     .then(r=>r.json()).then(d=>{
       if(d.success){
         newPinBlock.classList.remove('opacity-50');

--- a/tests/AuthControllerTest.php
+++ b/tests/AuthControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\AuthController;
+use PDO;
+
+class AuthControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        if (!class_exists('App\\Controllers\\AuthController')) {
+            require_once __DIR__ . '/../src/Controllers/AuthController.php';
+            require_once __DIR__ . '/../src/Helpers/SmsRu.php';
+        }
+        $_SESSION = [];
+        $_POST = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        $_POST = [];
+    }
+
+    public function testVerifyResetPinCode(): void
+    {
+        $_SESSION['reset_phone'] = '79029237794';
+        $_SESSION['reset_code'] = '1234';
+        $_POST['phone'] = '79029237794';
+        $_POST['code'] = '1234';
+
+        $controller = new AuthController(new PDO('sqlite::memory:'));
+        ob_start();
+        @$controller->verifyResetPinCode();
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+
+        $this->assertSame(['success' => true], $data);
+    }
+}


### PR DESCRIPTION
## Summary
- add API endpoint to verify reset PIN code
- fix reset form JS to use new endpoint
- cover AuthController verifyResetPinCode with a test

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684dba83d784832c86fafa86322a732a