### PR TITLE
Fix admin order item display

### DIFF
--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -12,7 +12,7 @@
     <ul class="divide-y">
       <?php foreach ($items as $it): ?>
       <li class="py-2 flex justify-between">
-        <span><?= htmlspecialchars($it['name']) ?> (<?= $it['quantity'] ?> <?= $it['unit'] ?>)</span>
+        <span><?= htmlspecialchars($it['product_name']) ?> (<?= $it['quantity'] ?> <?= $it['unit'] ?>)</span>
         <span><?= $it['unit_price'] ?> ₽</span>
       </li>
       <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- fix item field name in admin order page

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e36f69680832cb3595aead4ac6431