### PR TITLE
Fix admin order address field

### DIFF
--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -4,7 +4,7 @@
   <div class="bg-white p-4 rounded shadow">
     <p><strong>Клиент:</strong> <?= htmlspecialchars($order['client_name']) ?></p>
     <p><strong>Телефон:</strong> <?= htmlspecialchars($order['phone']) ?></p>
-    <p><strong>Адрес:</strong> <?= htmlspecialchars($order['street']) ?></p>
+    <p><strong>Адрес:</strong> <?= htmlspecialchars($order['address']) ?></p>
     <p><strong>Статус:</strong> <?= htmlspecialchars($order['status']) ?></p>
   </div>
   <div class="bg-white p-4 rounded shadow">


### PR DESCRIPTION
## Summary
- correct address field key in admin order page

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e672642d0832cb40b47f7a73bbc8d