### PR TITLE
Fix admin notifications on order creation

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -539,6 +539,7 @@ public function cart(): void
     }
 
     // 9) СОЗДАЁМ ЗАКАЗЫ ПО КАЖДОЙ ДАТЕ, учитываем дату и слот
+    $createdOrderIds = [];
         foreach ($itemsByDate as $dateKey => $block) {
         // (7.1) Считаем сумму по блоку и применяем скидку
         $blockSum = 0;
@@ -575,6 +576,7 @@ public function cart(): void
             $deliverySlot
         ]);
         $orderId = (int)$this->pdo->lastInsertId();
+        $createdOrderIds[] = $orderId;
 
         // (7.3) Вставляем позиции в order_items
         $stmtItem = $this->pdo->prepare(
@@ -598,6 +600,12 @@ public function cart(): void
     $this->refreshCartTotal();
 
     $this->pdo->commit();
+
+    // Оповещаем администраторов о новых заказах
+    $ordersController = new OrdersController($this->pdo);
+    foreach ($createdOrderIds as $oid) {
+        $ordersController->notifyAdmins($oid);
+    }
 
     header('Location: /orders');
     exit;

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -284,7 +284,7 @@ class OrdersController
     }
 
     // Уведомление администраторам
-protected function notifyAdmins(int $orderId): void
+    public function notifyAdmins(int $orderId): void
     {
         $cfg    = require __DIR__ . '/../../config/telegram.php';
         $token  = $cfg['bot_token'];


### PR DESCRIPTION
## Summary
- make order notifications callable outside of `OrdersController`
- notify admins about each newly created order in `ClientController`

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684eb2288830832c8072458712e27156