### PR TITLE
Add colorized order statuses and admin action buttons

### DIFF
--- a/index.php
+++ b/index.php
@@ -106,6 +106,43 @@ function requireClient(): void
     }
 }
 
+// Информация о статусе заказа: название, классы бейджа и фона
+function order_status_info(string $status): array
+{
+    return match($status) {
+        'new' => [
+            'label'  => 'Новый заказ',
+            'badge'  => 'bg-red-100 text-red-800',
+            'bg'     => 'bg-red-50',
+        ],
+        'processing' => [
+            'label' => 'Принят',
+            'badge' => 'bg-yellow-100 text-yellow-800',
+            'bg'    => 'bg-yellow-50',
+        ],
+        'assigned' => [
+            'label' => 'Обработан',
+            'badge' => 'bg-green-100 text-green-800',
+            'bg'    => 'bg-green-50',
+        ],
+        'delivered' => [
+            'label' => 'Выполнен',
+            'badge' => 'bg-gray-200 text-gray-800',
+            'bg'    => 'bg-gray-100',
+        ],
+        'cancelled' => [
+            'label' => 'Отменен',
+            'badge' => 'text-gray-500',
+            'bg'    => '',
+        ],
+        default => [
+            'label' => $status,
+            'badge' => 'bg-gray-100 text-gray-800',
+            'bg'    => '',
+        ],
+    };
+}
+
 switch ("$method $uri") {
 
 

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -1,12 +1,15 @@
 <?php /** @var array $orders */ ?>
 <ul class="bg-white rounded shadow divide-y">
   <?php foreach ($orders as $o): ?>
-    <li class="p-4 flex items-center justify-between hover:bg-gray-50">
+    <?php $info = order_status_info($o['status']); ?>
+    <li class="p-4 flex items-center justify-between hover:bg-gray-50 <?= $info['bg'] ?>">
       <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm md:text-base">
         <span class="font-semibold">#<?= $o['id'] ?></span>
         <span><?= htmlspecialchars($o['client_name']) ?></span>
         <span><?= $o['total_amount'] ?> ₽</span>
-        <span><?= htmlspecialchars($o['status']) ?></span>
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium <?= $info['badge'] ?>">
+          <?= $info['label'] ?>
+        </span>
         <span class="text-gray-500"><?= $o['created_at'] ?></span>
         <span><?= htmlspecialchars($o['courier_name'] ?? '-') ?></span>
       </div>

--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -5,7 +5,12 @@
     <p><strong>Клиент:</strong> <?= htmlspecialchars($order['client_name']) ?></p>
     <p><strong>Телефон:</strong> <?= htmlspecialchars($order['phone']) ?></p>
     <p><strong>Адрес:</strong> <?= htmlspecialchars($order['address']) ?></p>
-    <p><strong>Статус:</strong> <?= htmlspecialchars($order['status']) ?></p>
+    <?php $info = order_status_info($order['status']); ?>
+    <p><strong>Статус:</strong>
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-sm font-medium <?= $info['badge'] ?>">
+        <?= $info['label'] ?>
+      </span>
+    </p>
   </div>
   <div class="bg-white p-4 rounded shadow">
     <h3 class="font-medium mb-2">Товары</h3>
@@ -40,16 +45,14 @@
       <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
       <button class="bg-[#C86052] text-white px-4 py-2 rounded hover:bg-[#B44D47]">Назначить курьера</button>
     </form>
-    <form action="/admin/orders/status" method="post">
-      <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
-      <select name="status" class="border px-2 py-1 rounded">
-        <?php foreach (['new','processing','assigned','delivered','cancelled'] as $st): ?>
-          <option value="<?= $st ?>" <?= $order['status']===$st?'selected':'' ?>><?= $st ?></option>
-        <?php endforeach; ?>
-      </select>
-      <button class="bg-gray-300 px-3 py-1 rounded hover:bg-gray-400 ml-2">Обновить</button>
-    </form>
-        <form action="/admin/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
+    <?php foreach (['processing' => 'Принят', 'assigned' => 'Обработан', 'delivered' => 'Выполнен', 'cancelled' => 'Отменен'] as $st => $label): ?>
+      <form action="/admin/orders/status" method="post">
+        <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
+        <input type="hidden" name="status" value="<?= $st ?>">
+        <button class="bg-gray-300 px-3 py-1 rounded hover:bg-gray-400" type="submit"><?= $label ?></button>
+      </form>
+    <?php endforeach; ?>
+    <form action="/admin/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
       <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
       <button class="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Удалить</button>
     </form>

--- a/src/Views/client/order_show.php
+++ b/src/Views/client/order_show.php
@@ -34,9 +34,13 @@ $discount = max(0, $rawSum - $order['total_amount']);
       <div class="relative z-10 flex justify-between items-center">
         <div>
           <h2 class="text-2xl font-bold mb-2">📦 Заказ №<?= htmlspecialchars($order['id']) ?></h2>
+          <?php $info = order_status_info($order['status']); ?>
           <p class="text-white/80 text-sm">
-            <?= date('d.m.Y H:i', strtotime($order['created_at'])) ?> 
-            • Статус: <span class="font-semibold"><?= htmlspecialchars($order['status']) ?></span>
+            <?= date('d.m.Y H:i', strtotime($order['created_at'])) ?>
+            • Статус:
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium <?= $info['badge'] ?>">
+              <?= $info['label'] ?>
+            </span>
           </p>
         </div>
         <?php if ($userName): ?>

--- a/src/Views/client/orders.php
+++ b/src/Views/client/orders.php
@@ -65,8 +65,9 @@
       <!-- Список заказов -->
       <div class="space-y-4">
         <?php foreach ($orders as $index => $o): ?>
-          <a href="/orders/<?= $o['id'] ?>" 
-             class="block bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all hover:-translate-y-1 overflow-hidden group">
+          <?php $info = order_status_info($o['status']); ?>
+          <a href="/orders/<?= $o['id'] ?>"
+             class="block rounded-2xl shadow-lg hover:shadow-xl transition-all hover:-translate-y-1 overflow-hidden group <?= $info['bg'] ?>">
             
             <!-- Заголовок заказа -->
             <div class="p-6 pb-4">
@@ -92,12 +93,11 @@
                   <?php
                   $status = $o['status'];
                   $statusConfig = [
-                    'pending' => ['bg-yellow-100', 'text-yellow-800', 'hourglass_empty', 'Ожидает'],
-                    'confirmed' => ['bg-blue-100', 'text-blue-800', 'check_circle', 'Подтвержден'],
-                    'preparing' => ['bg-orange-100', 'text-orange-800', 'kitchen', 'Готовится'],
-                    'ready' => ['bg-green-100', 'text-green-800', 'done_all', 'Готов'],
-                    'delivered' => ['bg-emerald-100', 'text-emerald-800', 'local_shipping', 'Доставлен'],
-                    'cancelled' => ['bg-red-100', 'text-red-800', 'cancel', 'Отменен']
+                    'new' => ['bg-red-100', 'text-red-800', 'fiber_new', 'Новый заказ'],
+                    'processing' => ['bg-yellow-100', 'text-yellow-800', 'hourglass_empty', 'Принят'],
+                    'assigned' => ['bg-green-100', 'text-green-800', 'check_circle', 'Обработан'],
+                    'delivered' => ['bg-gray-200', 'text-gray-800', 'done_all', 'Выполнен'],
+                    'cancelled' => ['bg-gray-50', 'text-gray-500', 'cancel', 'Отменен']
                   ];
                   $config = $statusConfig[$status] ?? ['bg-gray-100', 'text-gray-800', 'help', $status];
                   ?>
@@ -115,15 +115,14 @@
             </div>
 
             <!-- Прогресс-бар (для активных заказов) -->
-            <?php if (in_array($status, ['pending', 'confirmed', 'preparing', 'ready'])): ?>
+            <?php if (in_array($status, ['new', 'processing', 'assigned'])): ?>
               <div class="px-6 pb-4">
                 <div class="bg-gray-100 rounded-full h-2 overflow-hidden">
                   <?php
                   $progress = [
-                    'pending' => 25,
-                    'confirmed' => 50, 
-                    'preparing' => 75,
-                    'ready' => 100
+                    'new' => 33,
+                    'processing' => 66,
+                    'assigned' => 100
                   ][$status] ?? 0;
                   ?>
                   <div class="h-full bg-gradient-to-r from-blue-500 to-indigo-500 rounded-full transition-all duration-1000" 

--- a/src/Views/client/profile.php
+++ b/src/Views/client/profile.php
@@ -72,9 +72,9 @@
             <?php
             $status = $ao['status'];
             $cfg = [
-              'new' => ['bg-red-100','text-red-800','Новый'],
-              'processing' => ['bg-yellow-100','text-yellow-800','В обработке'],
-              'assigned' => ['bg-green-100','text-green-800','Назначен'],
+              'new' => ['bg-red-100','text-red-800','Новый заказ'],
+              'processing' => ['bg-yellow-100','text-yellow-800','Принят'],
+              'assigned' => ['bg-green-100','text-green-800','Обработан'],
             ][$status] ?? ['bg-gray-100','text-gray-800',$status];
             ?>
             <div class="p-4 rounded-2xl border flex items-center justify-between">

--- a/src/Views/client/v2/orders.php
+++ b/src/Views/client/v2/orders.php
@@ -2,10 +2,11 @@
 <?php
 function status_classes(string $status): string {
     return match($status) {
-        'new' => 'bg-teal-100 text-teal-800',
+        'new' => 'bg-red-100 text-red-800',
         'processing' => 'bg-yellow-100 text-yellow-800',
-        'delivered' => 'bg-emerald-100 text-emerald-800',
-        'cancelled' => 'bg-red-100 text-red-800',
+        'assigned' => 'bg-green-100 text-green-800',
+        'delivered' => 'bg-gray-200 text-gray-800',
+        'cancelled' => 'text-gray-500',
         default => 'bg-gray-100 text-gray-800',
     };
 }
@@ -18,8 +19,9 @@ function status_classes(string $status): string {
         <select id="statusFilter" class="border rounded-lg px-3 py-2 text-sm">
           <option value="">Все статусы</option>
           <option value="new">Новые</option>
-          <option value="processing">В обработке</option>
-          <option value="delivered">Доставленные</option>
+          <option value="processing">Принятые</option>
+          <option value="assigned">Обработанные</option>
+          <option value="delivered">Выполненные</option>
           <option value="cancelled">Отмененные</option>
         </select>
         <button id="sortBtn" class="flex items-center border rounded-lg px-3 py-2 text-sm text-gray-600">
@@ -32,7 +34,8 @@ function status_classes(string $status): string {
     <!-- Orders list -->
     <div id="ordersContainer" class="mt-4 space-y-4">
       <?php foreach ($orders as $order): ?>
-        <div class="order-card bg-white rounded-2xl shadow p-3 sm:p-4 hover:-translate-y-1 hover:shadow-lg transition-transform" data-status="<?= $order['status'] ?>" data-id="<?= $order['id'] ?>">
+        <?php $info = order_status_info($order['status']); ?>
+        <div class="order-card rounded-2xl shadow p-3 sm:p-4 hover:-translate-y-1 hover:shadow-lg transition-transform <?= $info['bg'] ?>" data-status="<?= $order['status'] ?>" data-id="<?= $order['id'] ?>">
           <div class="flex justify-between items-start">
             <div class="flex items-center space-x-2">
               <span class="material-icons-round text-lg">shopping_bag</span>
@@ -44,7 +47,7 @@ function status_classes(string $status): string {
           </div>
           <div class="mt-2">
             <span class="status-badge inline-block text-sm px-2 py-0.5 rounded-full <?= status_classes($order['status']) ?>">
-              <?= strtoupper($order['status']) ?>
+              <?= order_status_info($order['status'])['label'] ?>
             </span>
           </div>
           <div class="mt-2">


### PR DESCRIPTION
## Summary
- map order statuses to Russian labels and color classes
- use new status info in admin orders list and details
- replace status dropdown with action buttons on admin order page
- show localized status badges with colored backgrounds in client views
- update filters and progress bars for new statuses

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef531dd18832c80789c02d573c8d7