### PR TITLE
Fix duplicate referrals

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -119,7 +119,7 @@ public function register(): void
         // 3) Если есть пригласивший, фиксируем связь в таблице referrals
         if ($referredBy !== null) {
             $stmt = $this->pdo->prepare("
-                INSERT INTO referrals (referrer_id, referred_id, created_at)
+                INSERT IGNORE INTO referrals (referrer_id, referred_id, created_at)
                 VALUES (?, ?, NOW())
             ");
             $stmt->execute([$referredBy, $userId]);

--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -712,7 +712,7 @@ public function cart(): void
             "UPDATE users SET referred_by = ?, has_used_referral_coupon = 1 WHERE id = ?"
         )->execute([$referrerId, $userId]);
         $this->pdo->prepare(
-            "INSERT INTO referrals (referrer_id, referred_id, created_at) VALUES (?, ?, NOW())"
+            "INSERT IGNORE INTO referrals (referrer_id, referred_id, created_at) VALUES (?, ?, NOW())"
         )->execute([$referrerId, $userId]);
     } elseif ($referredBy !== null && $usedReferralCoupon === 0 && $couponCode !== '') {
         $this->pdo->prepare(


### PR DESCRIPTION
## Summary
- avoid referral insert constraint violations when registering or placing an order

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684f000740ec832c81aea36adeca2caa