### PR TITLE
Add theme switcher and dark mode

### DIFF
--- a/src/Views/client/profile.php
+++ b/src/Views/client/profile.php
@@ -204,23 +204,40 @@
           Быстрые действия
         </h2>
       </div>
-      <div class="p-6 grid grid-cols-2 gap-4">
-        <a href="/orders"
-           class="flex flex-col items-center p-4 bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl hover:shadow-lg transition-all hover:scale-105 group">
-          <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-indigo-500 rounded-2xl flex items-center justify-center mb-3 group-hover:scale-110 transition-transform">
-            <span class="material-icons-round text-white">receipt_long</span>
-          </div>
-          <span class="font-semibold text-gray-800 text-sm text-center">Мои заказы</span>
-        </a>
-        <a href="/catalog"
-           class="flex flex-col items-center p-4 bg-gradient-to-br from-red-50 to-pink-50 rounded-2xl hover:shadow-lg transition-all hover:scale-105 group">
-          <div class="w-12 h-12 bg-gradient-to-br from-red-500 to-pink-500 rounded-2xl flex items-center justify-center mb-3 group-hover:scale-110 transition-transform">
-            <span class="material-icons-round text-white">store</span>
-          </div>
-          <span class="font-semibold text-gray-800 text-sm text-center">Каталог</span>
-        </a>
+    <div class="p-6 grid grid-cols-2 gap-4">
+      <a href="/orders"
+         class="flex flex-col items-center p-4 bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl hover:shadow-lg transition-all hover:scale-105 group">
+        <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-indigo-500 rounded-2xl flex items-center justify-center mb-3 group-hover:scale-110 transition-transform">
+          <span class="material-icons-round text-white">receipt_long</span>
+        </div>
+        <span class="font-semibold text-gray-800 text-sm text-center">Мои заказы</span>
+      </a>
+      <a href="/catalog"
+         class="flex flex-col items-center p-4 bg-gradient-to-br from-red-50 to-pink-50 rounded-2xl hover:shadow-lg transition-all hover:scale-105 group">
+        <div class="w-12 h-12 bg-gradient-to-br from-red-500 to-pink-500 rounded-2xl flex items-center justify-center mb-3 group-hover:scale-110 transition-transform">
+          <span class="material-icons-round text-white">store</span>
+        </div>
+        <span class="font-semibold text-gray-800 text-sm text-center">Каталог</span>
+      </a>
+    </div>
+  </div>
+
+  <!-- Настройки -->
+  <div class="bg-white rounded-3xl shadow-lg overflow-hidden">
+    <div class="bg-gradient-to-r from-gray-50 to-emerald-50 px-6 py-4 border-b border-gray-100">
+      <h2 class="font-bold text-gray-800 flex items-center">
+        <span class="material-icons-round mr-2 text-emerald-500">tune</span>
+        Настройки
+      </h2>
+    </div>
+    <div class="p-6">
+      <div class="flex space-x-2">
+        <button type="button" class="theme-btn px-4 py-2 rounded-full border" data-theme-value="light">Светлая</button>
+        <button type="button" class="theme-btn px-4 py-2 rounded-full border" data-theme-value="dark">Темная</button>
+        <button type="button" class="theme-btn px-4 py-2 rounded-full border" data-theme-value="system">Система</button>
       </div>
     </div>
+  </div>
 
     <!-- Дополнительная информация -->
     <div class="bg-gradient-to-r from-indigo-50 to-purple-50 rounded-3xl p-6 text-center">
@@ -251,4 +268,28 @@
     navigator.clipboard.writeText(code)
       .then(() => alert('Купон скопирован в буфер обмена!'));
   }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const btns = document.querySelectorAll('.theme-btn');
+    const saved = localStorage.getItem('theme') || 'system';
+    highlight(saved);
+
+    btns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const val = btn.dataset.themeValue;
+        setTheme(val);
+        highlight(val);
+      });
+    });
+
+    function highlight(val) {
+      btns.forEach(b => {
+        if (b.dataset.themeValue === val) {
+          b.classList.add('berry-gradient', 'text-white');
+        } else {
+          b.classList.remove('berry-gradient', 'text-white');
+        }
+      });
+    }
+  });
 </script>

--- a/src/Views/layouts/admin_main.php
+++ b/src/Views/layouts/admin_main.php
@@ -1,11 +1,24 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="ru" data-theme="dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Админка BerryGo – <?= htmlspecialchars($pageTitle) ?></title>
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Round" rel="stylesheet">
+  <style>
+    [data-theme='dark'] body {
+      background-color: #1f2937;
+      color: #f1f5f9;
+    }
+    [data-theme='dark'] .bg-white { background-color: #374151; }
+    [data-theme='dark'] .bg-gray-100 { background-color: #1f2937; }
+    [data-theme='dark'] .bg-gray-50 { background-color: #111827; }
+    [data-theme='dark'] .text-gray-700 { color: #e5e7eb; }
+    [data-theme='dark'] .text-gray-600 { color: #d1d5db; }
+    [data-theme='dark'] .text-gray-500 { color: #9ca3af; }
+    [data-theme='dark'] .border-gray-200 { border-color: #374151; }
+  </style>
 </head>
 <body class="flex flex-col min-h-screen bg-gray-100 font-sans">
 

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -32,7 +32,7 @@
   }
 ?>
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="ru" data-theme="light">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
@@ -134,7 +134,42 @@
       -ms-overflow-style: none;
       scrollbar-width: none;
     }
+
+    [data-theme='dark'] body {
+      background: linear-gradient(135deg, #1a1a1a 0%, #2c2c2c 100%);
+      color: #f1f5f9;
+    }
+    [data-theme='dark'] .bg-white { background-color: #1f2937; }
+    [data-theme='dark'] .bg-gray-50 { background-color: #111827; }
+    [data-theme='dark'] .text-gray-800 { color: #f8fafc; }
+    [data-theme='dark'] .text-gray-700 { color: #f1f5f9; }
+    [data-theme='dark'] .text-gray-600 { color: #e5e7eb; }
+    [data-theme='dark'] .text-gray-500 { color: #d1d5db; }
+    [data-theme='dark'] .border-gray-100 { border-color: #374151; }
+    [data-theme='dark'] .border-gray-300 { border-color: #4b5563; }
   </style>
+
+  <script>
+    function setTheme(mode) {
+      if (mode === 'system') {
+        localStorage.setItem('theme', 'system');
+        mode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      } else {
+        localStorage.setItem('theme', mode);
+      }
+      document.documentElement.setAttribute('data-theme', mode);
+    }
+
+    (function() {
+      const saved = localStorage.getItem('theme');
+      if (saved === 'light' || saved === 'dark') {
+        document.documentElement.setAttribute('data-theme', saved);
+      } else {
+        const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        document.documentElement.setAttribute('data-theme', prefers);
+      }
+    })();
+  </script>
   
   <!-- <script>
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- add system `data-theme` attribute and dark theme styles
- add JS theme helper to apply light/dark/system modes
- add Settings block on profile with buttons for theme
- force dark theme for admin layout

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f038d2c00832c908e5f1f93c83cc9