### PR TITLE
Fix revenue chart in admin dashboard

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -109,14 +109,31 @@ class AdminController
         );
         $purchaseList = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-        // Данные для графика (заглушка)
-        
-        
-        
-        
+        // === Выручка по дням за последнюю неделю ===
+        $rows = $this->pdo->query(
+            "SELECT DATE(created_at) AS day, SUM(total_amount) AS revenue
+             FROM orders
+             WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL 6 DAY)
+             GROUP BY day
+             ORDER BY day"
+        )->fetchAll(PDO::FETCH_ASSOC);
+
+        $revenueByDay = [];
+        foreach ($rows as $row) {
+            $revenueByDay[$row['day']] = (int) $row['revenue'];
+        }
+
+        $labels = [];
+        $values = [];
+        for ($i = 6; $i >= 0; $i--) {
+            $date = date('Y-m-d', strtotime("-$i days"));
+            $labels[] = date('d.m', strtotime($date));
+            $values[] = $revenueByDay[$date] ?? 0;
+        }
+
         $chartData = [
-            'labels' => [],
-            'values' => [],
+            'labels' => $labels,
+            'values' => $values,
         ];
 
         // Отображаем дашборд


### PR DESCRIPTION
## Summary
- compute revenue by day for the last week in `AdminController`
- feed labels and values to the dashboard chart

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684f0ef3de34832ca4a831f02757d720