### PR TITLE
Remove dark mode options from profile

### DIFF
--- a/src/Views/client/profile.php
+++ b/src/Views/client/profile.php
@@ -222,22 +222,6 @@
     </div>
   </div>
 
-  <!-- Настройки -->
-  <div class="bg-white rounded-3xl shadow-lg overflow-hidden">
-    <div class="bg-gradient-to-r from-gray-50 to-emerald-50 px-6 py-4 border-b border-gray-100">
-      <h2 class="font-bold text-gray-800 flex items-center">
-        <span class="material-icons-round mr-2 text-emerald-500">tune</span>
-        Настройки
-      </h2>
-    </div>
-    <div class="p-6">
-      <div class="flex space-x-2">
-        <button type="button" class="theme-btn px-4 py-2 rounded-full border" data-theme-value="light">Светлая</button>
-        <button type="button" class="theme-btn px-4 py-2 rounded-full border" data-theme-value="dark">Темная</button>
-        <button type="button" class="theme-btn px-4 py-2 rounded-full border" data-theme-value="system">Система</button>
-      </div>
-    </div>
-  </div>
 
     <!-- Дополнительная информация -->
     <div class="bg-gradient-to-r from-indigo-50 to-purple-50 rounded-3xl p-6 text-center">
@@ -269,27 +253,4 @@
       .then(() => alert('Купон скопирован в буфер обмена!'));
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const btns = document.querySelectorAll('.theme-btn');
-    const saved = localStorage.getItem('theme') || 'system';
-    highlight(saved);
-
-    btns.forEach(btn => {
-      btn.addEventListener('click', () => {
-        const val = btn.dataset.themeValue;
-        setTheme(val);
-        highlight(val);
-      });
-    });
-
-    function highlight(val) {
-      btns.forEach(b => {
-        if (b.dataset.themeValue === val) {
-          b.classList.add('berry-gradient', 'text-white');
-        } else {
-          b.classList.remove('berry-gradient', 'text-white');
-        }
-      });
-    }
-  });
 </script>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -32,7 +32,7 @@
   }
 ?>
 <!DOCTYPE html>
-<html lang="ru" data-theme="light">
+<html lang="ru">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
@@ -135,41 +135,8 @@
       scrollbar-width: none;
     }
 
-    [data-theme='dark'] body {
-      background: linear-gradient(135deg, #1a1a1a 0%, #2c2c2c 100%);
-      color: #f1f5f9;
-    }
-    [data-theme='dark'] .bg-white { background-color: #1f2937; }
-    [data-theme='dark'] .bg-gray-50 { background-color: #111827; }
-    [data-theme='dark'] .text-gray-800 { color: #f8fafc; }
-    [data-theme='dark'] .text-gray-700 { color: #f1f5f9; }
-    [data-theme='dark'] .text-gray-600 { color: #e5e7eb; }
-    [data-theme='dark'] .text-gray-500 { color: #d1d5db; }
-    [data-theme='dark'] .border-gray-100 { border-color: #374151; }
-    [data-theme='dark'] .border-gray-300 { border-color: #4b5563; }
   </style>
 
-  <script>
-    function setTheme(mode) {
-      if (mode === 'system') {
-        localStorage.setItem('theme', 'system');
-        mode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      } else {
-        localStorage.setItem('theme', mode);
-      }
-      document.documentElement.setAttribute('data-theme', mode);
-    }
-
-    (function() {
-      const saved = localStorage.getItem('theme');
-      if (saved === 'light' || saved === 'dark') {
-        document.documentElement.setAttribute('data-theme', saved);
-      } else {
-        const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        document.documentElement.setAttribute('data-theme', prefers);
-      }
-    })();
-  </script>
   
   <!-- <script>
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- remove theme switcher block from `/profile`
- drop dark mode styles and script from main layout

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684f0f46a69c832c8612152d81e2dd50