### PR TITLE
Add placeholder delivery date

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'placeholder_date' => '2025-05-15',
+];

--- a/index.php
+++ b/index.php
@@ -35,6 +35,9 @@ if (!empty($_SESSION['user_id'])) {
 $telegramConfig = require __DIR__ . '/config/telegram.php';
 // Конфиг SMS.RU
 $smsConfig = require __DIR__ . '/config/sms.php';
+// Общие константы
+$constants = require __DIR__ . '/config/constants.php';
+define('PLACEHOLDER_DATE', $constants['placeholder_date']);
 // -----
 
 

--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -182,7 +182,7 @@ public function cart(): void
         } else {
             $prodDate = $row['delivery_date'];
             if ($prodDate === null) {
-                $deliveryDate = null;
+                $deliveryDate = PLACEHOLDER_DATE;
             } elseif ($prodDate > $today) {
                 $deliveryDate = $prodDate;
             } else {
@@ -378,8 +378,8 @@ public function cart(): void
         // 2) Прикрепляем к каждому товару дату из сессии (или сегодняшнюю, если до этого не указывалось)
         foreach ($rawItems as &$it) {
             $pid = $it['product_id'];
-            $it['delivery_date'] = $_SESSION['delivery_date'][$pid] 
-                                  ?? date('Y-m-d');
+            $it['delivery_date'] = $_SESSION['delivery_date'][$pid]
+                                  ?? PLACEHOLDER_DATE;
         }
         unset($it);
     
@@ -548,7 +548,7 @@ public function cart(): void
     $itemsByDate = [];
     foreach ($rawItems as $it) {
         $pid = $it['product_id'];
-        $dateKey = $_SESSION['delivery_date'][$pid] ?? date('Y-m-d');
+        $dateKey = $_SESSION['delivery_date'][$pid] ?? PLACEHOLDER_DATE;
         if (!isset($itemsByDate[$dateKey])) {
             $itemsByDate[$dateKey] = [];
         }

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -262,8 +262,8 @@ class OrdersController
             // Сохраняем заказ
             $stmtOrder = $this->pdo->prepare(
                 "INSERT INTO orders
-                 (user_id, address_id, slot_id, status, total_amount, discount_applied, points_used, points_accrued, delivery_date, delivery_slot, created_at)
-                 VALUES (?, ?, ?, 'new', ?, ?, ?, 0, CURDATE(), '', NOW())"
+                (user_id, address_id, slot_id, status, total_amount, discount_applied, points_used, points_accrued, delivery_date, delivery_slot, created_at)
+                 VALUES (?, ?, ?, 'new', ?, ?, ?, 0, ?, '', NOW())"
             );
             $stmtOrder->execute([
                 $user['id'],
@@ -271,7 +271,8 @@ class OrdersController
                 $_POST['slot_id'] ?? null,
                 $totalAmount,
                 $discount,
-                $pointsUsed
+                $pointsUsed,
+                PLACEHOLDER_DATE
             ]);
             $orderId = (int)$this->pdo->lastInsertId();
 
@@ -345,7 +346,8 @@ class OrdersController
 
         $deliveryDate = $order['delivery_date'] ?? null;
         $deliverySlot = $order['delivery_slot'] ?? '';
-        if ($deliveryDate) {
+        $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
+        if ($deliveryDate && $deliveryDate !== $placeholder) {
             $deliveryText = date('d.m.Y', strtotime($deliveryDate));
             if ($deliverySlot !== '') {
                 $deliveryText .= ' ' . $deliverySlot;

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -20,6 +20,8 @@
     $img       = $p['image_path']        ?? '/assets/placeholder.png';
     $today     = date('Y-m-d');
     $d         = $p['delivery_date']     ?? null;
+    $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
+    $showDate = $d !== null && $d !== $placeholder;
     $active    = (int)($p['is_active']    ?? 0);
     $price     = floatval($p['price']     ?? 0);
     $sale      = floatval($p['sale_price']?? 0);
@@ -42,17 +44,17 @@
       </span>
     <?php else: ?>
       <!-- Бейджик даты / наличия -->
-      <?php if ($d !== null && $d <= $today): ?>
+      <?php if ($showDate && $d <= $today): ?>
         <span class="absolute top-3 left-3 bg-green-100 text-green-800 text-xs font-semibold px-2 py-1 rounded-full">
           В наличии
         </span>
-      <?php elseif ($d !== null): ?>
+      <?php elseif ($showDate): ?>
         <span class="absolute top-3 left-3 bg-orange-100 text-orange-800 text-xs font-semibold px-2 py-1 rounded-full">
           <?= date('d.m.Y', strtotime($d)) ?>
         </span>
       <?php else: ?>
         <span class="absolute top-3 left-3 bg-blue-100 text-blue-800 text-xs font-semibold px-2 py-1 rounded-full">
-          Под заказ
+          Ближайшая возможная дата
         </span>
       <?php endif; ?>
 

--- a/src/Views/client/cart.php
+++ b/src/Views/client/cart.php
@@ -38,7 +38,8 @@
         // Подготовка опций дат
         $options = [];
         $d = $it['delivery_date']; // может быть null или строка 'YYYY-MM-DD'
-        if ($d === null) {
+        $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
+        if ($d === null || $d === $placeholder) {
           // Под заказ: select станет disabled
           $options = [];
         } else {
@@ -122,7 +123,7 @@
                 </option>
               <?php endforeach; ?>
             <?php else: ?>
-              <option>По мере поступления</option>
+              <option>Ближайшая возможная дата</option>
             <?php endif; ?>
           </select>
         </div>

--- a/src/Views/client/checkout.php
+++ b/src/Views/client/checkout.php
@@ -66,8 +66,8 @@ $couponError     = $couponError     ?? null;
         <?php foreach ($groups as $dateKey => $block): ?>
           <?php
             // Определяем читабельную метку даты
-            if ($dateKey === 'on_demand') {
-              $label = 'По мере поступления';
+            if ($dateKey === 'on_demand' || $dateKey === (defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15')) {
+              $label = 'Ближайшая возможная дата';
               $emoji = '📦';
             } elseif ($dateKey === $today) {
               $label = 'Сегодня';

--- a/src/Views/client/order_show.php
+++ b/src/Views/client/order_show.php
@@ -67,7 +67,13 @@ $discount = max(0, $rawSum - $order['total_amount']);
       </p>
       <p class="text-gray-700 mb-2 flex items-center">
         <span class="material-icons-round align-middle mr-2">calendar_today</span>
-        Дата: <?= date('d.m.Y', strtotime($order['delivery_date'])) ?>
+        <?php $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15'; ?>
+        Дата:
+        <?php if ($order['delivery_date'] === $placeholder): ?>
+          Ближайшая возможная дата
+        <?php else: ?>
+          <?= date('d.m.Y', strtotime($order['delivery_date'])) ?>
+        <?php endif; ?>
       </p>
       <p class="text-gray-700 flex items-center">
         <span class="material-icons-round align-middle mr-2">schedule</span>

--- a/src/Views/client/orders.php
+++ b/src/Views/client/orders.php
@@ -62,9 +62,15 @@ function status_classes(string $status): string {
             </ul>
           </div>
           <?php if (!empty($order['delivery_date'])): ?>
+            <?php $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15'; ?>
             <div class="mt-2 text-sm text-gray-600 flex items-center">
               <span class="material-icons-round mr-1 text-base">local_shipping</span>
-              Доставка: <?= date('d.m.Y', strtotime($order['delivery_date'])) ?><?php if($order['delivery_slot']): ?>, <?= htmlspecialchars($order['delivery_slot']) ?><?php endif; ?>
+              Доставка:
+              <?php if ($order['delivery_date'] === $placeholder): ?>
+                Ближайшая возможная дата
+              <?php else: ?>
+                <?= date('d.m.Y', strtotime($order['delivery_date'])) ?>
+              <?php endif; ?><?php if($order['delivery_slot']): ?>, <?= htmlspecialchars($order['delivery_slot']) ?><?php endif; ?>
             </div>
           <?php else: ?>
             <button class="mt-2 text-sm text-blue-600 underline">Выбрать слот</button>


### PR DESCRIPTION
## Summary
- introduce `config/constants.php` with placeholder date constant
- use `PLACEHOLDER_DATE` while processing carts and orders
- display "Ближайшая возможная дата" to clients when date is the placeholder
- update telegram notification and order creation logic

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f1df2e1f0832c960ba18e30815cb6