### PR TITLE
Исправлено отображение даты в уведомлении Telegram

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -342,18 +342,16 @@ class OrdersController
         $stmtItems->execute([$orderId]);
         $item = $stmtItems->fetch(\PDO::FETCH_ASSOC);
 
-        $createdAt = date('d.m.Y H:i', strtotime($order['created_at']));
-
         $deliveryDate = $order['delivery_date'] ?? null;
         $deliverySlot = $order['delivery_slot'] ?? '';
         $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
         if ($deliveryDate && $deliveryDate !== $placeholder) {
             $deliveryText = date('d.m.Y', strtotime($deliveryDate));
-            if ($deliverySlot !== '') {
-                $deliveryText .= ' ' . $deliverySlot;
-            }
         } else {
-            $deliveryText = $createdAt;
+            $deliveryText = 'Ближайшая возможная дата';
+        }
+        if ($deliverySlot !== '') {
+            $deliveryText .= ' ' . $deliverySlot;
         }
 
         $line1 = $order['phone'] . ', ' . $order['name'];


### PR DESCRIPTION
## Summary
- fix Telegram admin notification to display delivery date (or placeholder) instead of order creation date

## Testing
- `composer install` *(fails: composer not available)*

------
https://chatgpt.com/codex/tasks/task_e_684f8eeda6a8832c87086bc7bbe64d0e