### PR TITLE
Enhance admin order list

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -17,12 +17,13 @@ class OrdersController
     public function index(): void
     {
         $stmt = $this->pdo->query(
-            "SELECT o.id, u.name AS client_name, o.total_amount, o.status, o.created_at,\n" .
-            "       c.name AS courier_name, o.discount_applied, o.points_used, o.points_accrued\n" .
+            "SELECT o.id, o.status, o.total_amount, o.delivery_date, o.delivery_slot,\n" .
+            "       u.name AS client_name, u.phone, a.street AS address,\n" .
+            "       o.created_at\n" .
             "FROM orders o\n" .
             "JOIN users u ON u.id = o.user_id\n" .
-            "LEFT JOIN users c ON c.id = o.assigned_to\n" .
-            "ORDER BY o.created_at DESC"
+            "LEFT JOIN addresses a ON a.id = o.address_id\n" .
+            "ORDER BY FIELD(o.status,'new','processing','assigned','delivered','cancelled'), o.created_at DESC"
         );
         $orders = $stmt->fetchAll(PDO::FETCH_ASSOC);
 

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -1,29 +1,105 @@
 <?php /** @var array $orders */ ?>
-<ul class="bg-white rounded shadow divide-y">
-  <?php foreach ($orders as $o): ?>
-    <?php $info = order_status_info($o['status']); ?>
-    <li class="p-4 flex items-center justify-between hover:bg-gray-50 transition-all duration-200 <?= $info['bg'] ?>">
-      <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm md:text-base">
-        <span class="font-semibold">#<?= $o['id'] ?></span>
-        <span><?= htmlspecialchars($o['client_name']) ?></span>
-        <span><?= $o['total_amount'] ?> ₽</span>
-        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium <?= $info['badge'] ?>">
-          <?= $info['label'] ?>
-        </span>
-        <span class="text-gray-500"><?= $o['created_at'] ?></span>
-        <span><?= htmlspecialchars($o['courier_name'] ?? '-') ?></span>
-      </div>
-      <div class="flex items-center space-x-2 ml-4">
-        <a href="/admin/orders/<?= $o['id'] ?>" class="text-[#C86052] hover:text-[#B44D47]" title="Открыть">
-          <span class="material-icons-round">open_in_new</span>
-        </a>
-        <form action="/admin/orders/delete" method="post">
-          <input type="hidden" name="order_id" value="<?= $o['id'] ?>">
-          <button type="submit" class="text-red-500 hover:text-red-700" title="Удалить">
-            <span class="material-icons-round">delete</span>
-          </button>
-        </form>
-      </div>
-    </li>
-  <?php endforeach; ?>
-</ul>
+<div class="mb-4 flex flex-col md:flex-row md:items-end md:justify-between gap-2">
+  <select id="statusFilter" class="border rounded px-3 py-2 text-sm">
+    <option value="">Все статусы</option>
+    <option value="new">Новые</option>
+    <option value="processing">Принятые</option>
+    <option value="assigned">Обработанные</option>
+    <option value="delivered">Выполненные</option>
+    <option value="cancelled">Отмененные</option>
+  </select>
+  <div class="flex items-center gap-2">
+    <button id="todayBtn" class="px-3 py-2 bg-gray-200 rounded text-sm">Сегодня</button>
+    <button id="tomorrowBtn" class="px-3 py-2 bg-gray-200 rounded text-sm">Завтра</button>
+    <input type="date" id="dateFrom" class="border rounded px-2 py-1 text-sm">
+    <span class="text-gray-500">-</span>
+    <input type="date" id="dateTo" class="border rounded px-2 py-1 text-sm">
+    <button id="clearDate" class="px-3 py-2 bg-gray-200 rounded text-sm">Без даты</button>
+  </div>
+</div>
+
+<table class="min-w-full bg-white rounded shadow overflow-hidden">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">№</th>
+      <th class="p-3 text-left font-semibold">Дата</th>
+      <th class="p-3 text-left font-semibold">Слот</th>
+      <th class="p-3 text-left font-semibold">Клиент</th>
+      <th class="p-3 text-left font-semibold">Телефон</th>
+      <th class="p-3 text-left font-semibold">Адрес</th>
+      <th class="p-3 text-left font-semibold">Сумма</th>
+    </tr>
+  </thead>
+  <tbody id="ordersTable">
+    <?php foreach ($orders as $o): ?>
+      <?php
+        $bg = in_array($o['status'], ['new','processing'], true) ? 'bg-gray-200' : '';
+        $dateAttr = $o['delivery_date'] ? date('Y-m-d', strtotime($o['delivery_date'])) : '';
+      ?>
+      <tr data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" class="border-b hover:bg-gray-50 cursor-pointer <?= $bg ?>" onclick="location.href='/admin/orders/<?= $o['id'] ?>'">
+        <td class="p-3 font-semibold">#<?= $o['id'] ?></td>
+        <td class="p-3 text-gray-600">
+          <?php if ($o['delivery_date']): ?>
+            <?= date('d.m', strtotime($o['delivery_date'])) ?>
+          <?php endif; ?>
+        </td>
+        <td class="p-3 text-gray-600"><?= htmlspecialchars($o['delivery_slot']) ?></td>
+        <td class="p-3 text-gray-600"><?= htmlspecialchars($o['client_name']) ?></td>
+        <td class="p-3 text-gray-600"><?= htmlspecialchars($o['phone']) ?></td>
+        <td class="p-3 text-gray-600"><?= htmlspecialchars($o['address']) ?></td>
+        <td class="p-3 text-gray-600"><?= $o['total_amount'] ?> ₽</td>
+      </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const statusFilter = document.getElementById('statusFilter');
+    const dateFrom = document.getElementById('dateFrom');
+    const dateTo = document.getElementById('dateTo');
+    const todayBtn = document.getElementById('todayBtn');
+    const tomorrowBtn = document.getElementById('tomorrowBtn');
+    const clearDate = document.getElementById('clearDate');
+    const rows = document.querySelectorAll('#ordersTable tr');
+
+    function applyFilters() {
+      const s = statusFilter.value;
+      const from = dateFrom.value;
+      const to = dateTo.value;
+      rows.forEach(row => {
+        const st = row.dataset.status;
+        const d = row.dataset.date;
+        let visible = true;
+        if (s && st !== s) visible = false;
+        if (from && (!d || d < from)) visible = false;
+        if (to && (!d || d > to)) visible = false;
+        row.style.display = visible ? '' : 'none';
+      });
+    }
+
+    statusFilter.addEventListener('change', applyFilters);
+    dateFrom.addEventListener('change', applyFilters);
+    dateTo.addEventListener('change', applyFilters);
+
+    todayBtn.addEventListener('click', () => {
+      const d = new Date().toISOString().slice(0,10);
+      dateFrom.value = d; dateTo.value = d;
+      applyFilters();
+    });
+
+    tomorrowBtn.addEventListener('click', () => {
+      const t = new Date();
+      t.setDate(t.getDate()+1);
+      const d = t.toISOString().slice(0,10);
+      dateFrom.value = d; dateTo.value = d;
+      applyFilters();
+    });
+
+    clearDate.addEventListener('click', () => {
+      dateFrom.value = '';
+      dateTo.value = '';
+      applyFilters();
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- add status-priority sorting to order query
- redesign admin order list with additional fields
- add date and status filters
- make each row clickable and remove action buttons

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684fc31917d8832cab4340a86ff2d28a