### PR TITLE
Improve admin order details layout

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -47,7 +47,7 @@ class OrdersController
         $order = $stmt->fetch(PDO::FETCH_ASSOC);
 
         $stmt = $this->pdo->prepare(
-            "SELECT oi.quantity, oi.unit_price, t.name AS product_name, p.unit\n" .
+            "SELECT oi.quantity, oi.unit_price, t.name AS product_name, p.unit, p.variety, p.box_size, p.box_unit\n" .
             "FROM order_items oi\n" .
             "JOIN products p ON p.id = oi.product_id\n" .
             "JOIN product_types t ON t.id = p.product_type_id\n" .

--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -1,10 +1,10 @@
 <?php /** @var array $order @var array $items */ ?>
 <div class="space-y-4">
-  <div class="flex justify-between bg-white p-4 rounded shadow">
-    <div>
-      <div class="font-semibold mb-1">Заказ #<?= $order['id'] ?></div>
-      <div><?= htmlspecialchars($order['client_name']) ?></div>
-      <div><?= htmlspecialchars($order['phone']) ?></div>
+  <div class="flex justify-between items-center bg-white p-4 rounded shadow">
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="font-semibold">Заказ #<?= $order['id'] ?></span>
+      <span><?= htmlspecialchars($order['client_name']) ?></span>
+      <span><?= htmlspecialchars($order['phone']) ?></span>
     </div>
     <div class="flex items-start">
       <?php $info = order_status_info($order['status']); ?>
@@ -16,9 +16,17 @@
 
   <div class="bg-white p-4 rounded shadow space-y-1">
     <?php foreach ($items as $it): ?>
+      <?php $lineCost = $it['quantity'] * $it['unit_price']; ?>
       <div class="flex justify-between py-1">
-        <span><?= htmlspecialchars($it['product_name']) ?> (<?= $it['quantity'] ?> <?= $it['unit'] ?>)</span>
-        <span><?= $it['unit_price'] ?> ₽</span>
+        <span>
+          <?= htmlspecialchars($it['product_name']) ?>
+          <?php if (!empty($it['variety'])): ?> <?= htmlspecialchars($it['variety']) ?><?php endif; ?>
+          <?php if (!empty($it['box_size']) && !empty($it['box_unit'])): ?>
+            <?= ' ' . $it['box_size'] . ' ' . htmlspecialchars($it['box_unit']) ?>
+          <?php endif; ?>
+          × <?= $it['quantity'] ?>
+        </span>
+        <span><?= number_format($lineCost, 0, '.', ' ') ?> ₽</span>
       </div>
     <?php endforeach; ?>
 
@@ -48,21 +56,32 @@
     </div>
   </div>
 
-  <div class="flex flex-wrap gap-2">
-    <?php foreach (['processing' => 'Принят', 'assigned' => 'Обработан', 'delivered' => 'Выполнен', 'cancelled' => 'Отменен'] as $st => $label): ?>
+  <div class="flex flex-wrap gap-2 items-center">
+    <?php $btnClasses = [
+        'processing' => 'bg-yellow-700 hover:bg-yellow-800',
+        'assigned'   => 'bg-green-700 hover:bg-green-800',
+        'delivered'  => 'bg-gray-700 hover:bg-gray-800',
+        'cancelled'  => 'bg-gray-600 hover:bg-gray-700',
+    ]; ?>
+    <?php foreach ([
+        'processing' => 'Принят',
+        'assigned'   => 'Обработан',
+        'delivered'  => 'Выполнен',
+        'cancelled'  => 'Отменен'
+      ] as $st => $label): ?>
       <form action="/admin/orders/status" method="post">
         <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
         <input type="hidden" name="status" value="<?= $st ?>">
-        <button class="status-btn px-3 py-1 rounded" type="submit"><?= $label ?></button>
+        <button class="px-3 py-1 rounded text-white <?= $btnClasses[$st] ?>" type="submit"><?= $label ?></button>
       </form>
     <?php endforeach; ?>
-    <form action="/admin/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
+    <form class="ml-auto" action="/admin/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
       <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
-      <button class="status-btn bg-red-600 hover:bg-red-700 px-3 py-1 rounded" type="submit">Удалить</button>
+      <button class="px-3 py-1 rounded text-white bg-red-700 hover:bg-red-800" type="submit">Удалить</button>
     </form>
   </div>
 
   <div>
-    <a href="/admin/orders" class="status-btn px-4 py-2 rounded inline-block">Вернуться к заказам</a>
+    <a href="/admin/orders" class="inline-block px-4 py-2 rounded text-white bg-purple-700 hover:bg-purple-800">Вернуться к заказам</a>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- improve order card layout for admin
- show product variety and weight info
- colorize status buttons
- adjust delete and back buttons

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684fdc5f9214832c84596e28b440a12a