### PR TITLE
Fix awaiting orders list

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -875,10 +875,11 @@ public function showOrder(int $orderId): void
         );
         $awaiting = [];
         $rest = [];
+        $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
         foreach ($orders as &$o) {
             $itemsStmt->execute([$o['id']]);
             $o['items'] = $itemsStmt->fetchAll(PDO::FETCH_ASSOC);
-            if (empty($o['delivery_date'])) {
+            if (empty($o['delivery_date']) || $o['delivery_date'] === $placeholder) {
                 $awaiting[] = $o;
             } else {
                 $rest[] = $o;


### PR DESCRIPTION
## Summary
- treat placeholder delivery date as empty when grouping orders on /orders page
- keep orders with no real date in "awaiting" block

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68502671e0b8832caf5f7b4ced3bc08d