### PR TITLE
Support multiple delivery addresses

### DIFF
--- a/database/2025_06_addresses.sql
+++ b/database/2025_06_addresses.sql
@@ -1,0 +1,4 @@
+ALTER TABLE addresses
+  ADD COLUMN recipient_name varchar(100) NOT NULL DEFAULT '',
+  ADD COLUMN recipient_phone varchar(20) NOT NULL DEFAULT '',
+  ADD COLUMN is_primary tinyint(1) NOT NULL DEFAULT 0;

--- a/index.php
+++ b/index.php
@@ -270,6 +270,14 @@ switch ("$method $uri") {
         requireClient();
         (new App\Controllers\UsersController($pdo))->saveAddress();
         break;
+    case 'POST /profile/set-primary':
+        requireClient();
+        (new App\Controllers\UsersController($pdo))->setPrimaryAddress();
+        break;
+    case 'POST /profile/delete-address':
+        requireClient();
+        (new App\Controllers\UsersController($pdo))->deleteAddress();
+        break;
 
     case 'GET /checkout':
         requireClient();

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -111,10 +111,10 @@ public function register(): void
 
         // 2) Сохраняем адрес
         $stmt = $this->pdo->prepare("
-            INSERT INTO addresses (user_id, street, created_at)
-            VALUES (?, ?, NOW())
+            INSERT INTO addresses (user_id, street, recipient_name, recipient_phone, is_primary, created_at)
+            VALUES (?, ?, ?, ?, 1, NOW())
         ");
-        $stmt->execute([$userId, $address]);
+        $stmt->execute([$userId, $address, $name, $phone]);
 
         // 3) Если есть пригласивший, фиксируем связь в таблице referrals
         if ($referredBy !== null) {

--- a/src/Views/client/checkout.php
+++ b/src/Views/client/checkout.php
@@ -167,14 +167,18 @@ $couponError     = $couponError     ?? null;
             <span class="material-icons-round text-lg mr-2 align-middle">location_on</span>
             Адрес доставки
           </h3>
-          <div class="relative">
-            <input type="text"
-                   name="address_id[default]"
-                   required
-                   value="<?= htmlspecialchars($address) ?>"
-                   placeholder="Введите адрес доставки"
-                   class="w-full border-2 border-gray-200 rounded-2xl px-4 py-3 pr-10 focus:ring-2 focus:ring-red-500 focus:border-red-500 outline-none transition-all">
-            <span class="material-icons-round absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400">place</span>
+          <div class="space-y-2">
+            <select name="address_id[default]" id="addressSelect" class="w-full border-2 border-gray-200 rounded-2xl px-4 py-3 focus:ring-2 focus:ring-red-500 focus:border-red-500 outline-none">
+              <?php foreach ($addresses as $a): ?>
+                <option value="<?= $a['id'] ?>" <?= $a['is_primary'] ? 'selected' : '' ?>><?= htmlspecialchars($a['street']) ?> (<?= htmlspecialchars($a['recipient_name']) ?>)</option>
+              <?php endforeach; ?>
+              <option value="new">Другой адрес</option>
+            </select>
+            <div id="newAddressBlock" class="space-y-2 hidden">
+              <input type="text" name="new_address" placeholder="Адрес" class="w-full border-2 border-gray-200 rounded-2xl px-4 py-3 focus:ring-2 focus:ring-red-500 focus:border-red-500 outline-none">
+              <input type="text" name="recipient_name" value="<?= htmlspecialchars($userName) ?>" placeholder="Имя получателя" class="w-full border-2 border-gray-200 rounded-2xl px-4 py-3 focus:ring-2 focus:ring-red-500 focus:border-red-500 outline-none">
+              <input type="tel" name="recipient_phone" value="<?= htmlspecialchars($addresses[0]['recipient_phone'] ?? '') ?>" placeholder="Телефон" class="w-full border-2 border-gray-200 rounded-2xl px-4 py-3 focus:ring-2 focus:ring-red-500 focus:border-red-500 outline-none">
+            </div>
           </div>
         </div>
 
@@ -266,3 +270,19 @@ $couponError     = $couponError     ?? null;
 
   </div>
 </main>
+
+<script>
+  const select = document.getElementById('addressSelect');
+  const block = document.getElementById('newAddressBlock');
+  function toggleBlock() {
+    if (select.value === 'new') {
+      block.classList.remove('hidden');
+    } else {
+      block.classList.add('hidden');
+    }
+  }
+  if (select) {
+    select.addEventListener('change', toggleBlock);
+    toggleBlock();
+  }
+</script>

--- a/src/Views/client/profile.php
+++ b/src/Views/client/profile.php
@@ -2,6 +2,7 @@
 /**
  * @var array  $user          // ['id'=>..., 'name'=>..., 'phone'=>..., 'referral_code'=>..., 'points_balance'=>..., 'referred_by'=>...]
  * @var string $address
+ * @var array  $addresses
  * @var array  $transactions  // каждая транзакция ['id'=>..., 'amount'=>..., 'transaction_type'=>..., 'description'=>..., 'created_at'=>..., 'order_id'=>...]
  */
 ?>
@@ -35,21 +36,26 @@
             <?= htmlspecialchars($user['phone'] ?? 'Не указан') ?>
           </div>
         </div>
-        <form action="/profile" method="post" class="space-y-4">
-          <div class="flex items-start space-x-4">
-            <div class="w-12 h-12 bg-gradient-to-br from-orange-400 to-red-500 rounded-2xl flex items-center justify-center flex-shrink-0 mt-1">
-              <span class="material-icons-round text-white">home</span>
+        <div class="space-y-2">
+          <?php foreach ($addresses as $addr): ?>
+            <div class="border rounded-2xl p-3 <?= $addr['is_primary'] ? 'bg-emerald-50' : '' ?>">
+              <div class="font-semibold text-gray-800"><?= htmlspecialchars($addr['street']) ?></div>
+              <div class="text-sm text-gray-600"><?= htmlspecialchars($addr['recipient_name']) ?>, <?= htmlspecialchars($addr['recipient_phone']) ?></div>
+              <?php if (!$addr['is_primary']): ?>
+                <form action="/profile/set-primary" method="post" class="inline">
+                  <input type="hidden" name="id" value="<?= $addr['id'] ?>">
+                  <button class="text-emerald-600 text-sm">Сделать основным</button>
+                </form>
+                <form action="/profile/delete-address" method="post" class="inline ml-2">
+                  <input type="hidden" name="id" value="<?= $addr['id'] ?>">
+                  <button class="text-red-600 text-sm">Удалить</button>
+                </form>
+              <?php else: ?>
+                <span class="text-emerald-600 text-sm font-semibold">Основной</span>
+              <?php endif; ?>
             </div>
-            <textarea
-              name="address"
-              rows="3"
-              class="flex-1 border border-gray-300 rounded-2xl px-4 py-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all resize-none"
-            ><?= htmlspecialchars($address) ?></textarea>
-          </div>
-          <div class="flex justify-end">
-            <button type="submit" class="bg-emerald-500 text-white px-4 py-2 rounded-lg hover:bg-emerald-600 transition">Обновить</button>
-          </div>
-        </form>
+          <?php endforeach; ?>
+        </div>
         <div class="flex items-center space-x-4">
           <div class="w-12 h-12 bg-gradient-to-br from-pink-400 to-red-500 rounded-2xl flex items-center justify-center flex-shrink-0">
             <span class="text-xl">🍓</span>


### PR DESCRIPTION
## Summary
- add migration to extend `addresses` table
- insert address details on registration and user creation
- allow adding additional addresses and set primary
- update checkout to select or add address
- list delivery addresses in profile

## Testing
- `composer install` *(fails: ext-dom)*
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68563b767398832cbfd9e8dedeed7d1c