### PR TITLE
Handle invite code via session on homepage

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,6 +6,14 @@ error_reporting(E_ALL);
 // Запуск сессии
 session_start();
 
+// Сохраняем пригласительный код из URL в сессию (если передан)
+if (isset($_GET['invite'])) {
+    $invite = trim((string)$_GET['invite']);
+    if ($invite !== '') {
+        $_SESSION['invite_code'] = $invite;
+    }
+}
+
 // 1) Подключаем конфигурацию БД и создаём PDO
 $dbConfig = require __DIR__ . '/config/database.php';
 $dsn = "mysql:host={$dbConfig['host']};dbname={$dbConfig['dbname']};charset={$dbConfig['charset']}";

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -141,6 +141,7 @@ public function register(): void
     $_SESSION['points_balance'] = 0;
 
     unset($_SESSION['reg_verified'], $_SESSION['reg_phone'], $_SESSION['reg_code']);
+    unset($_SESSION['invite_code']);
 
     header('Location: /');
     exit;

--- a/src/Views/client/profile.php
+++ b/src/Views/client/profile.php
@@ -120,7 +120,7 @@
           </div>
           <p class="text-center">Подарите другу 10 % скидку на первый заказ и получайте клубнички за каждый его заказ!</p>
           <p class="text-center">Скопируйте ссылку и отправьте другу:</p>
-          <?php $refLink = "https://berrygo.ru/register?invite=" . urlencode($user['referral_code']); ?>
+          <?php $refLink = "https://berrygo.ru/?invite=" . urlencode($user['referral_code']); ?>
           <div class="text-center">
             <button onclick="copyInviteLink()" class="bg-white/80 rounded-lg px-3 py-2 text-sm text-gray-800 hover:bg-pink-100 transition break-all">
               <?= htmlspecialchars($refLink) ?>

--- a/src/Views/client/register.php
+++ b/src/Views/client/register.php
@@ -30,8 +30,8 @@
     <?php endif; ?>
 
     <?php
-      // Берём значение invite из GET-параметра (раньше был ref)
-      $invite_from_get = trim($_GET['invite'] ?? '');
+      // Берём пригласительный код из GET-параметра или из сессии
+      $invite_from_get = trim($_GET['invite'] ?? ($_SESSION['invite_code'] ?? ''));
     ?>
 
     <!-- Форма регистрации -->

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -531,7 +531,7 @@
 
         <!-- Ссылка-приглашение -->
         <div class="relative flex flex-col sm:flex-row items-stretch sm:items-center space-y-2 sm:space-y-0 sm:space-x-2">
-            <?php $inviteLink = "https://berrygo.ru/register?invite=" . urlencode($_SESSION['referral_code'] ?? ''); ?>
+            <?php $inviteLink = "https://berrygo.ru/?invite=" . urlencode($_SESSION['referral_code'] ?? ''); ?>
             <input
               id="inviteLinkInput"
               type="text"


### PR DESCRIPTION
## Summary
- store invite codes from query parameters into session in `index.php`
- clear stored invite after user registration
- pre-fill invite field from session on register page
- change referral links to point to home page with invite

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6856da61a034832c9ff95aa5281a69aa