### PR TITLE
Format delivery slot display with minutes

### DIFF
--- a/index.php
+++ b/index.php
@@ -164,6 +164,20 @@ function order_status_info(string $status): array
     };
 }
 
+// Преобразует слот вида "09-12" в формат "09:00 - 12:00"
+function format_slot(?string $slot): string
+{
+    if (!$slot) {
+        return '';
+    }
+    if (preg_match('/^(\d{1,2})-(\d{1,2})$/', $slot, $m)) {
+        $from = str_pad($m[1], 2, '0', STR_PAD_LEFT) . ':00';
+        $to   = str_pad($m[2], 2, '0', STR_PAD_LEFT) . ':00';
+        return "$from - $to";
+    }
+    return $slot;
+}
+
 switch ("$method $uri") {
 
 

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -383,7 +383,7 @@ class OrdersController
             $deliveryText = 'Ближайшая возможная дата';
         }
         if ($deliverySlot !== '') {
-            $deliveryText .= ' ' . $deliverySlot;
+            $deliveryText .= ' ' . format_slot($deliverySlot);
         }
 
         $line1 = $order['phone'] . ', ' . $order['name'];

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -52,10 +52,10 @@
         <td class="p-3 text-gray-600"><?= date('d.m H:i', strtotime($o['created_at'])) ?></td>
         <td class="p-3 text-gray-600">
           <?php if ($o['delivery_date']): ?>
-            <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars($o['delivery_slot']) ?>
+            <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_slot($o['delivery_slot'])) ?>
           <?php endif; ?>
         </td>
-        <td class="p-3 text-gray-600"><?= htmlspecialchars($o['delivery_slot']) ?></td>
+        <td class="p-3 text-gray-600"><?= htmlspecialchars(format_slot($o['delivery_slot'])) ?></td>
         <td class="p-3 text-gray-600"><?= htmlspecialchars($o['client_name']) ?></td>
         <td class="p-3 text-gray-600"><?= htmlspecialchars($o['phone']) ?></td>
         <td class="p-3 text-gray-600"><?= htmlspecialchars($o['address']) ?></td>

--- a/src/Views/client/order_show.php
+++ b/src/Views/client/order_show.php
@@ -60,7 +60,7 @@ $discount = max(0, $rawSum - $order['total_amount']);
         <?php if ($order['delivery_date'] === $placeholder): ?>
           Ближайшая возможная дата
         <?php else: ?>
-          <?= date('d.m.Y', strtotime($order['delivery_date'])) ?> <?= htmlspecialchars($order['delivery_slot']) ?>
+          <?= date('d.m.Y', strtotime($order['delivery_date'])) ?> <?= htmlspecialchars(format_slot($order['delivery_slot'])) ?>
         <?php endif; ?>
       </p>
       <p class="text-gray-700 mb-2 flex items-center">

--- a/src/Views/client/orders.php
+++ b/src/Views/client/orders.php
@@ -69,7 +69,7 @@ function status_classes(string $status): string {
               <span class="font-semibold">#<?= $order['id'] ?>:</span>
               <span>
                 <?php if (!empty($order['delivery_date'])): ?>
-                  <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['delivery_slot'])): ?> <?= htmlspecialchars($order['delivery_slot']) ?><?php endif; ?>
+                  <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['delivery_slot'])): ?> <?= htmlspecialchars(format_slot($order['delivery_slot'])) ?><?php endif; ?>
                 <?php endif; ?>
               </span>
               <span class="order-date hidden"><?= date('d.m.Y H:i', strtotime($order['created_at'])) ?></span>


### PR DESCRIPTION
## Summary
- add `format_slot` helper to render times with minutes
- update admin and client order views to use the helper
- adjust Telegram order notification to format slot

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685755f40f08832c8a956b6e755a3b1d