### PR TITLE
Adjust order card layout

### DIFF
--- a/src/Views/client/orders.php
+++ b/src/Views/client/orders.php
@@ -36,24 +36,46 @@ function status_classes(string $status): string {
       <div class="space-y-2">
         <?php foreach ($ordersAwaiting as $order): ?>
           <?php $info = order_status_info($order['status']); ?>
-          <a href="/orders/<?= $order['id'] ?>" class="order-card flex justify-between items-center p-3 rounded-lg shadow hover:shadow-md transition-colors <?= $info['bg'] ?>" data-status="<?= $order['status'] ?>" data-id="<?= $order['id'] ?>">
-            <div class="flex flex-col flex-1">
+          <a href="/orders/<?= $order['id'] ?>" class="order-card flex p-3 rounded-lg shadow hover:shadow-md transition-colors <?= $info['bg'] ?>" data-status="<?= $order['status'] ?>" data-id="<?= $order['id'] ?>">
+          <div class="flex flex-col flex-1">
+            <div class="flex justify-between items-center gap-2 flex-wrap">
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="material-icons-round text-lg">shopping_bag</span>
                 <span class="font-semibold">#<?= $order['id'] ?>:</span>
+                <span>
+                  <?php if (!empty($order['delivery_date'])): ?>
+                    <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['delivery_slot'])): ?> <?= htmlspecialchars(format_slot($order['delivery_slot'])) ?><?php endif; ?>
+                  <?php endif; ?>
+                </span>
                 <span class="order-date hidden"><?= date('d.m.Y H:i', strtotime($order['created_at'])) ?></span>
               </div>
-              <?php foreach ($order['items'] as $idx => $it): ?>
-                <div class="flex items-center gap-2<?= $idx === 0 ? '' : ' pl-7' ?>">
-                  <?php $boxes = isset($it['boxes']) ? $it['boxes'] : ($it['box_size']>0 ? round($it['quantity']/$it['box_size'],1) : $it['quantity']); ?>
-                  <span><?= htmlspecialchars($it['product_name']) ?><?php if(!empty($it['variety'])): ?> «<?= htmlspecialchars($it['variety']) ?>»<?php endif; ?><?php if(!empty($it['box_size']) && !empty($it['box_unit'])): ?> <?= $it['box_size'] . $it['box_unit'] ?><?php endif; ?>, <?= $it['quantity'] ?>кг (<?= $boxes ?> ящ.), <?= number_format($it['quantity'] * $it['unit_price'], 0, '.', ' ') ?>₽</span>
-                </div>
-              <?php endforeach; ?>
+              <span class="status-badge text-sm px-2 py-0.5 rounded-full <?= status_classes($order['status']) ?>">
+                <?= order_status_info($order['status'])['label'] ?>
+              </span>
             </div>
-            <span class="status-badge text-sm px-2 py-0.5 rounded-full <?= status_classes($order['status']) ?>">
-              <?= order_status_info($order['status'])['label'] ?>
-            </span>
-          </a>
+            <?php foreach ($order['items'] as $idx => $it): ?>
+              <?php $boxes = isset($it['boxes']) ? $it['boxes'] : ($it['box_size']>0 ? round($it['quantity']/$it['box_size'],1) : $it['quantity']); ?>
+              <div class="flex items-center gap-2<?= $idx === 0 ? '' : ' pl-7' ?>">
+                <span><?= htmlspecialchars($it['product_name']) ?><?php if(!empty($it['variety'])): ?> «<?= htmlspecialchars($it['variety']) ?>»<?php endif; ?> <?= htmlspecialchars($it['quantity']) ?>кг (<?= $boxes ?> ящ.)</span>
+              </div>
+            <?php endforeach; ?>
+            <?php
+              $rawSum = 0;
+              foreach ($order['items'] as $tmp) {
+                $rawSum += $tmp['quantity'] * $tmp['unit_price'];
+              }
+              $discount = max(0, $rawSum - $order['total_amount']);
+            ?>
+            <div class="flex justify-between items-center pt-1 border-t border-gray-200 mt-1 font-semibold">
+              <?php if ($discount > 0): ?>
+                <span>Скидка: -<?= number_format($discount, 0, '.', ' ') ?> 🍓</span>
+              <?php else: ?>
+                <span>Стоимость заказа:</span>
+              <?php endif; ?>
+              <span><?= number_format($order['total_amount'], 0, '.', ' ') ?> ₽</span>
+            </div>
+          </div>
+        </a>
         <?php endforeach; ?>
       </div>
     <?php endif; ?>
@@ -62,32 +84,45 @@ function status_classes(string $status): string {
     <div id="ordersContainer" class="mt-4 space-y-2">
       <?php foreach ($orders as $order): ?>
         <?php $info = order_status_info($order['status']); ?>
-        <a href="/orders/<?= $order['id'] ?>" class="order-card flex justify-between items-center p-3 rounded-lg shadow hover:shadow-md transition-colors <?= $info['bg'] ?>" data-status="<?= $order['status'] ?>" data-id="<?= $order['id'] ?>">
+        <a href="/orders/<?= $order['id'] ?>" class="order-card flex p-3 rounded-lg shadow hover:shadow-md transition-colors <?= $info['bg'] ?>" data-status="<?= $order['status'] ?>" data-id="<?= $order['id'] ?>">
           <div class="flex flex-col flex-1">
-            <div class="flex items-center gap-2 flex-wrap">
-              <span class="material-icons-round text-lg">shopping_bag</span>
-              <span class="font-semibold">#<?= $order['id'] ?>:</span>
-              <span>
-                <?php if (!empty($order['delivery_date'])): ?>
-                  <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['delivery_slot'])): ?> <?= htmlspecialchars(format_slot($order['delivery_slot'])) ?><?php endif; ?>
-                <?php endif; ?>
+            <div class="flex justify-between items-center gap-2 flex-wrap">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="material-icons-round text-lg">shopping_bag</span>
+                <span class="font-semibold">#<?= $order['id'] ?>:</span>
+                <span>
+                  <?php if (!empty($order['delivery_date'])): ?>
+                    <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['delivery_slot'])): ?> <?= htmlspecialchars(format_slot($order['delivery_slot'])) ?><?php endif; ?>
+                  <?php endif; ?>
+                </span>
+                <span class="order-date hidden"><?= date('d.m.Y H:i', strtotime($order['created_at'])) ?></span>
+              </div>
+              <span class="status-badge text-sm px-2 py-0.5 rounded-full <?= status_classes($order['status']) ?>">
+                <?= order_status_info($order['status'])['label'] ?>
               </span>
-              <span class="order-date hidden"><?= date('d.m.Y H:i', strtotime($order['created_at'])) ?></span>
             </div>
             <?php foreach ($order['items'] as $idx => $it): ?>
               <?php $boxes = isset($it['boxes']) ? $it['boxes'] : ($it['box_size']>0 ? round($it['quantity']/$it['box_size'],1) : $it['quantity']); ?>
               <div class="flex items-center gap-2<?= $idx === 0 ? '' : ' pl-7' ?>">
-                <span><?= htmlspecialchars($it['product_name']) ?><?php if(!empty($it['variety'])): ?> «<?= htmlspecialchars($it['variety']) ?>»<?php endif; ?><?php if(!empty($it['box_size']) && !empty($it['box_unit'])): ?> <?= $it['box_size'] . $it['box_unit'] ?><?php endif; ?>, <?= $it['quantity'] ?>кг (<?= $boxes ?> ящ.), <?= number_format($it['quantity'] * $it['unit_price'], 0, '.', ' ') ?>₽</span>
+                <span><?= htmlspecialchars($it['product_name']) ?><?php if(!empty($it['variety'])): ?> «<?= htmlspecialchars($it['variety']) ?>»<?php endif; ?> <?= htmlspecialchars($it['quantity']) ?>кг (<?= $boxes ?> ящ.)</span>
               </div>
             <?php endforeach; ?>
+            <?php
+              $rawSum = 0;
+              foreach ($order['items'] as $tmp) {
+                $rawSum += $tmp['quantity'] * $tmp['unit_price'];
+              }
+              $discount = max(0, $rawSum - $order['total_amount']);
+            ?>
             <div class="flex justify-between items-center pt-1 border-t border-gray-200 mt-1 font-semibold">
-              <span>Стоимость заказа:</span>
+              <?php if ($discount > 0): ?>
+                <span>Скидка: -<?= number_format($discount, 0, '.', ' ') ?> 🍓</span>
+              <?php else: ?>
+                <span>Стоимость заказа:</span>
+              <?php endif; ?>
               <span><?= number_format($order['total_amount'], 0, '.', ' ') ?> ₽</span>
             </div>
           </div>
-          <span class="status-badge text-sm px-2 py-0.5 rounded-full <?= status_classes($order['status']) ?>">
-            <?= order_status_info($order['status'])['label'] ?>
-          </span>
         </a>
       <?php endforeach; ?>
     </div>


### PR DESCRIPTION
## Summary
- tweak order listing layout to show status badge on the first line
- hide base weight and item price
- display discount if present and final order cost

## Testing
- `composer install` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857649b7468832cbdd02bd64e0f09fe