### PR TITLE
Improve promos and add desktop swipe

### DIFF
--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -75,16 +75,24 @@
   <!-- Sale Products -->
   <section class="px-4 mb-8">
     <h2 class="text-2xl font-bold text-gray-800 mb-4">💥 Товары со скидкой</h2>
-    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
-      <?php foreach ($saleProducts as $p): ?>
+    <div class="scroll-wrapper relative">
+      <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_left</span>
+      </button>
+      <button data-dir="right" class="hidden md:flex items-center justify-center w-8 h-8 absolute right-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_right</span>
+      </button>
+      <div class="scroll-row flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
+        <?php foreach ($saleProducts as $p): ?>
+          <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
+            <?php include __DIR__ . '/_card.php'; ?>
+          </div>
+        <?php endforeach; ?>
         <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
-          <?php include __DIR__ . '/_card.php'; ?>
+        <div class="h-full flex items-center justify-center bg-red-50 rounded-2xl shadow-lg p-4 text-center">
+          <p class="text-sm font-semibold text-red-800">Акционная клубника в Красноярске: купите спелую фермерскую ягоду со скидкой до 25 %! Лучшие сорта Клери и Черный принц по невероятно выгодным ценам. Успейте заказать сегодня — акция действует до конца недели, пока ягоды не разобрали! 🍓</p>
         </div>
-      <?php endforeach; ?>
-      <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
-        <div class="h-full flex items-center justify-center bg-white rounded-2xl shadow-lg p-4 text-center">
-          <p class="text-sm text-gray-600">Узнайте о наших горячих предложениях!</p>
-        </div>
+      </div>
       </div>
     </div>
   </section>
@@ -92,16 +100,24 @@
   <!-- In Stock Products -->
   <section class="px-4 mb-8">
     <h2 class="text-2xl font-bold text-gray-800 mb-4">📦 В наличии</h2>
-    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
-      <?php foreach ($inStockProducts as $p): ?>
+    <div class="scroll-wrapper relative">
+      <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_left</span>
+      </button>
+      <button data-dir="right" class="hidden md:flex items-center justify-center w-8 h-8 absolute right-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_right</span>
+      </button>
+      <div class="scroll-row flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
+        <?php foreach ($inStockProducts as $p): ?>
+          <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
+            <?php include __DIR__ . '/_card.php'; ?>
+          </div>
+        <?php endforeach; ?>
         <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
-          <?php include __DIR__ . '/_card.php'; ?>
+        <div class="h-full flex items-center justify-center bg-green-50 rounded-2xl shadow-lg p-4 text-center">
+          <p class="text-sm font-semibold text-green-800">Клубника в наличии в Красноярске: мгновенная доставка за 24 ч — прямо с фермы к вашему столу! Сорта Клери и Черный принц в фасовках от 1 кг. Купите клубнику онлайн с удобной оплатой и гарантий качества каждой ягодки. 🍓🚀</p>
         </div>
-      <?php endforeach; ?>
-      <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
-        <div class="h-full flex items-center justify-center bg-white rounded-2xl shadow-lg p-4 text-center">
-          <p class="text-sm text-gray-600">Все товары из этого раздела готовы к отправке.</p>
-        </div>
+      </div>
       </div>
     </div>
   </section>
@@ -109,16 +125,24 @@
   <!-- Preorder Products -->
   <section class="px-4 mb-8">
     <h2 class="text-2xl font-bold text-gray-800 mb-4">🛒 Под заказ</h2>
-    <div class="flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
-      <?php foreach ($preorderProducts as $p): ?>
+    <div class="scroll-wrapper relative">
+      <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_left</span>
+      </button>
+      <button data-dir="right" class="hidden md:flex items-center justify-center w-8 h-8 absolute right-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_right</span>
+      </button>
+      <div class="scroll-row flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
+        <?php foreach ($preorderProducts as $p): ?>
+          <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
+            <?php include __DIR__ . '/_card.php'; ?>
+          </div>
+        <?php endforeach; ?>
         <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
-          <?php include __DIR__ . '/_card.php'; ?>
+        <div class="h-full flex items-center justify-center bg-blue-50 rounded-2xl shadow-lg p-4 text-center">
+          <p class="text-sm font-semibold text-blue-800">Клубника другие ягоды и фрукты под заказ с доставкой в Красноярске: эксклюзивные сорта и объёмы от 1 кг. Идеально для праздников, корпоративов и подарков! Заранее выберите свой идеальный набор — индивидуальная упаковка, свежесть гарантирована, доставка в удобное время. 🍓✨</p>
         </div>
-      <?php endforeach; ?>
-      <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
-        <div class="h-full flex items-center justify-center bg-white rounded-2xl shadow-lg p-4 text-center">
-          <p class="text-sm text-gray-600">Здесь собраны товары, которые мы привезём под заказ.</p>
-        </div>
+      </div>
       </div>
     </div>
   </section>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -633,6 +633,21 @@
   });
 </script>
 
+<script>
+  // Scroll arrows for product rows on desktop
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.scroll-wrapper').forEach(wrapper => {
+      const row = wrapper.querySelector('.scroll-row');
+      wrapper.querySelectorAll('button[data-dir]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const dir = btn.dataset.dir === 'left' ? -1 : 1;
+          row.scrollBy({left: dir * row.clientWidth, behavior: 'smooth'});
+        });
+      });
+    });
+  });
+</script>
+
 
 
 


### PR DESCRIPTION
## Summary
- highlight informational promo blocks
- enable swipe with arrow buttons on desktop product rows
- add JS to control arrows

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68577ee91534832caa286100e8f2c773