### PR TITLE
Add basic content management

### DIFF
--- a/database/2025_08_content.sql
+++ b/database/2025_08_content.sql
@@ -1,0 +1,24 @@
+CREATE TABLE content_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    alias VARCHAR(255) NOT NULL,
+    UNIQUE KEY alias (alias)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE materials (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    category_id INT NOT NULL,
+    image_path VARCHAR(255) DEFAULT NULL,
+    title VARCHAR(255) NOT NULL,
+    short_desc TEXT,
+    text TEXT,
+    meta_title VARCHAR(255),
+    meta_description VARCHAR(255),
+    meta_keywords VARCHAR(255),
+    product1_id INT DEFAULT NULL,
+    product2_id INT DEFAULT NULL,
+    product3_id INT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (category_id) REFERENCES content_categories(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/index.php
+++ b/index.php
@@ -440,6 +440,31 @@ switch ("$method $uri") {
         (new App\Controllers\CouponsController($pdo))->generate();
         break;
 
+    case 'GET /admin/content':
+        requireAdmin();
+        (new App\Controllers\ContentController($pdo))->categories();
+        break;
+    case 'GET /admin/content/category/edit':
+        requireAdmin();
+        (new App\Controllers\ContentController($pdo))->editCategory();
+        break;
+    case 'POST /admin/content/category/save':
+        requireAdmin();
+        (new App\Controllers\ContentController($pdo))->saveCategory();
+        break;
+    case 'GET /admin/content/materials':
+        requireAdmin();
+        (new App\Controllers\ContentController($pdo))->materials();
+        break;
+    case 'GET /admin/content/materials/edit':
+        requireAdmin();
+        (new App\Controllers\ContentController($pdo))->editMaterial();
+        break;
+    case 'POST /admin/content/materials/save':
+        requireAdmin();
+        (new App\Controllers\ContentController($pdo))->saveMaterial();
+        break;
+
     case 'GET /admin/users':
         requireAdmin();
         (new App\Controllers\UsersController($pdo))->index();

--- a/src/Controllers/ContentController.php
+++ b/src/Controllers/ContentController.php
@@ -1,0 +1,177 @@
+<?php
+namespace App\Controllers;
+
+use PDO;
+
+class ContentController
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    // ===== CATEGORIES =====
+    public function categories(): void
+    {
+        $cats = $this->pdo->query("SELECT * FROM content_categories ORDER BY id DESC")
+            ->fetchAll(PDO::FETCH_ASSOC);
+
+        viewAdmin('content/categories_index', [
+            'pageTitle' => 'Контент – Категории',
+            'categories' => $cats,
+        ]);
+    }
+
+    public function editCategory(): void
+    {
+        $id = $_GET['id'] ?? null;
+        $category = null;
+        if ($id) {
+            $stmt = $this->pdo->prepare("SELECT * FROM content_categories WHERE id = ?");
+            $stmt->execute([(int)$id]);
+            $category = $stmt->fetch(PDO::FETCH_ASSOC);
+        }
+
+        viewAdmin('content/category_edit', [
+            'pageTitle' => $id ? 'Редактировать категорию' : 'Добавить категорию',
+            'category'  => $category,
+        ]);
+    }
+
+    public function saveCategory(): void
+    {
+        $id    = $_POST['id'] ?? null;
+        $name  = trim($_POST['name'] ?? '');
+        $alias = trim($_POST['alias'] ?? '');
+
+        if ($id) {
+            $stmt = $this->pdo->prepare(
+                "UPDATE content_categories SET name=?, alias=? WHERE id=?"
+            );
+            $stmt->execute([$name, $alias, (int)$id]);
+        } else {
+            $stmt = $this->pdo->prepare(
+                "INSERT INTO content_categories (name, alias) VALUES (?, ?)"
+            );
+            $stmt->execute([$name, $alias]);
+        }
+        header('Location: /admin/content');
+        exit;
+    }
+
+    // ===== MATERIALS =====
+    public function materials(): void
+    {
+        $catId = (int)($_GET['category_id'] ?? 0);
+        $stmtC = $this->pdo->prepare("SELECT * FROM content_categories WHERE id = ?");
+        $stmtC->execute([$catId]);
+        $category = $stmtC->fetch(PDO::FETCH_ASSOC);
+
+        $stmt = $this->pdo->prepare("SELECT * FROM materials WHERE category_id=? ORDER BY id DESC");
+        $stmt->execute([$catId]);
+        $materials = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        viewAdmin('content/materials_index', [
+            'pageTitle' => 'Материалы',
+            'category' => $category,
+            'materials' => $materials,
+        ]);
+    }
+
+    public function editMaterial(): void
+    {
+        $id = $_GET['id'] ?? null;
+        $catId = (int)($_GET['category_id'] ?? 0);
+        $material = null;
+        if ($id) {
+            $stmt = $this->pdo->prepare("SELECT * FROM materials WHERE id=?");
+            $stmt->execute([(int)$id]);
+            $material = $stmt->fetch(PDO::FETCH_ASSOC);
+            $catId = (int)($material['category_id'] ?? $catId);
+        }
+
+        $stmtC = $this->pdo->prepare("SELECT * FROM content_categories WHERE id = ?");
+        $stmtC->execute([$catId]);
+        $category = $stmtC->fetch(PDO::FETCH_ASSOC);
+
+        $products = (new ProductsController($this->pdo))->getAllActive();
+
+        viewAdmin('content/material_edit', [
+            'pageTitle' => $id ? 'Редактировать материал' : 'Добавить материал',
+            'material'  => $material,
+            'category'  => $category,
+            'products'  => $products,
+        ]);
+    }
+
+    public function saveMaterial(): void
+    {
+        $id         = $_POST['id'] ?? null;
+        $categoryId = (int)($_POST['category_id'] ?? 0);
+        $title      = trim($_POST['title'] ?? '');
+        $shortDesc  = trim($_POST['short_desc'] ?? '');
+        $text       = trim($_POST['text'] ?? '');
+        $metaTitle  = trim($_POST['meta_title'] ?? '');
+        $metaDesc   = trim($_POST['meta_description'] ?? '');
+        $metaKeys   = trim($_POST['meta_keywords'] ?? '');
+        $prod1      = (int)($_POST['product1_id'] ?? 0) ?: null;
+        $prod2      = (int)($_POST['product2_id'] ?? 0) ?: null;
+        $prod3      = (int)($_POST['product3_id'] ?? 0) ?: null;
+
+        $imagePath = null;
+        if (!empty($_FILES['image']['tmp_name'])) {
+            $tmp     = $_FILES['image']['tmp_name'];
+            $dstName = uniqid('mat_', true) . '.webp';
+            $dst     = __DIR__ . '/../../uploads/' . $dstName;
+            $src = @imagecreatefromstring(file_get_contents($tmp));
+            if ($src) {
+                $w = imagesx($src);
+                $h = imagesy($src);
+                $targetRatio = 16/9;
+                if ($w/$h > $targetRatio) {
+                    $newH = $h;
+                    $newW = (int)($h * $targetRatio);
+                    $x0 = (int)(($w - $newW)/2);
+                    $y0 = 0;
+                } else {
+                    $newW = $w;
+                    $newH = (int)($w / $targetRatio);
+                    $x0 = 0;
+                    $y0 = (int)(($h - $newH)/2);
+                }
+                $crop = imagecrop($src, [ 'x'=>$x0,'y'=>$y0,'width'=>$newW,'height'=>$newH ]);
+                if ($crop) {
+                    $resized = imagecreatetruecolor(640,360);
+                    imagecopyresampled($resized,$crop,0,0,0,0,640,360,$newW,$newH);
+                    imagewebp($resized,$dst,80);
+                    imagedestroy($crop);
+                    imagedestroy($resized);
+                    $imagePath = '/uploads/' . $dstName;
+                }
+                imagedestroy($src);
+            }
+        }
+
+        if ($id) {
+            $sql = "UPDATE materials SET category_id=?, title=?, short_desc=?, text=?, meta_title=?, meta_description=?, meta_keywords=?, product1_id=?, product2_id=?, product3_id=?";
+            $params = [$categoryId, $title, $shortDesc, $text, $metaTitle, $metaDesc, $metaKeys, $prod1, $prod2, $prod3];
+            if ($imagePath) { $sql .= ", image_path=?"; $params[] = $imagePath; }
+            $sql .= " WHERE id=?";
+            $params[] = (int)$id;
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute($params);
+        } else {
+            $columns = "category_id,title,short_desc,text,meta_title,meta_description,meta_keywords,product1_id,product2_id,product3_id";
+            $placeholders = "?,?,?,?,?,?,?,?,?,?";
+            $params = [$categoryId,$title,$shortDesc,$text,$metaTitle,$metaDesc,$metaKeys,$prod1,$prod2,$prod3];
+            if ($imagePath) { $columns .= ",image_path"; $placeholders .= ",?"; $params[] = $imagePath; }
+            $sql = "INSERT INTO materials ($columns) VALUES ($placeholders)";
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute($params);
+        }
+        header('Location: /admin/content/materials?category_id='.$categoryId);
+        exit;
+    }
+}

--- a/src/Views/admin/content/categories_index.php
+++ b/src/Views/admin/content/categories_index.php
@@ -1,0 +1,28 @@
+<?php /** @var array $categories */ ?>
+<a href="/admin/content/category/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
+  <span class="material-icons-round text-base mr-1">add</span> Добавить категорию
+</a>
+<table class="min-w-full bg-white rounded shadow overflow-hidden">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">Название</th>
+      <th class="p-3 text-left font-semibold">Алиас</th>
+      <th class="p-3 text-center font-semibold">Материалы</th>
+    </tr>
+  </thead>
+  <tbody>
+    <?php foreach ($categories as $c): ?>
+    <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <td class="p-3 font-medium text-gray-600">
+        <a href="/admin/content/category/edit?id=<?= $c['id'] ?>" class="text-[#C86052] hover:underline">
+          <?= htmlspecialchars($c['name']) ?>
+        </a>
+      </td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($c['alias']) ?></td>
+      <td class="p-3 text-center">
+        <a href="/admin/content/materials?category_id=<?= $c['id'] ?>" class="text-[#C86052] hover:underline">Открыть</a>
+      </td>
+    </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>

--- a/src/Views/admin/content/category_edit.php
+++ b/src/Views/admin/content/category_edit.php
@@ -1,0 +1,15 @@
+<?php /** @var array|null $category */ ?>
+<form action="/admin/content/category/save" method="post" class="space-y-4 bg-white p-6 rounded shadow max-w-md">
+  <?php if (!empty($category['id'])): ?>
+    <input type="hidden" name="id" value="<?= $category['id'] ?>">
+  <?php endif; ?>
+  <div>
+    <label class="block mb-1">Название</label>
+    <input name="name" type="text" value="<?= htmlspecialchars($category['name'] ?? '') ?>" class="w-full border px-2 py-1 rounded" required>
+  </div>
+  <div>
+    <label class="block mb-1">Алиас</label>
+    <input name="alias" type="text" value="<?= htmlspecialchars($category['alias'] ?? '') ?>" class="w-full border px-2 py-1 rounded" required>
+  </div>
+  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded hover:bg-[#B44D47]">Сохранить</button>
+</form>

--- a/src/Views/admin/content/material_edit.php
+++ b/src/Views/admin/content/material_edit.php
@@ -1,0 +1,70 @@
+<?php
+/** @var array|null $material */
+/** @var array $category */
+/** @var array $products */
+?>
+<form action="/admin/content/materials/save" method="post" enctype="multipart/form-data" class="space-y-4 bg-white p-6 rounded shadow max-w-lg">
+  <input type="hidden" name="category_id" value="<?= $category['id'] ?>">
+  <?php if (!empty($material['id'])): ?>
+    <input type="hidden" name="id" value="<?= $material['id'] ?>">
+  <?php endif; ?>
+  <div>
+    <label class="block mb-1">Изображение (16:9)</label>
+    <input name="image" type="file" accept="image/*" class="w-full">
+    <?php if (!empty($material['image_path'])): ?>
+      <img src="<?= htmlspecialchars($material['image_path']) ?>" class="mt-2 w-32 h-18 object-cover rounded">
+    <?php endif; ?>
+  </div>
+  <div>
+    <label class="block mb-1">Заголовок</label>
+    <input name="title" type="text" value="<?= htmlspecialchars($material['title'] ?? '') ?>" class="w-full border px-2 py-1 rounded" required>
+  </div>
+  <div>
+    <label class="block mb-1">Короткое описание</label>
+    <textarea name="short_desc" rows="2" class="w-full border px-2 py-1 rounded"><?= htmlspecialchars($material['short_desc'] ?? '') ?></textarea>
+  </div>
+  <div>
+    <label class="block mb-1">Текст</label>
+    <textarea name="text" rows="5" class="w-full border px-2 py-1 rounded"><?= htmlspecialchars($material['text'] ?? '') ?></textarea>
+  </div>
+  <div>
+    <label class="block mb-1">Meta title</label>
+    <input name="meta_title" type="text" value="<?= htmlspecialchars($material['meta_title'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+  </div>
+  <div>
+    <label class="block mb-1">Meta description</label>
+    <input name="meta_description" type="text" value="<?= htmlspecialchars($material['meta_description'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+  </div>
+  <div>
+    <label class="block mb-1">Meta keywords</label>
+    <input name="meta_keywords" type="text" value="<?= htmlspecialchars($material['meta_keywords'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+  </div>
+  <div>
+    <label class="block mb-1">Товар 1</label>
+    <select name="product1_id" class="w-full border px-2 py-1 rounded">
+      <option value="">-- не выбрано --</option>
+      <?php foreach ($products as $p): ?>
+        <option value="<?= $p['id'] ?>" <?= isset($material['product1_id']) && $material['product1_id']==$p['id'] ? 'selected' : '' ?>><?= htmlspecialchars($p['variety'] ?: $p['product']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div>
+    <label class="block mb-1">Товар 2</label>
+    <select name="product2_id" class="w-full border px-2 py-1 rounded">
+      <option value="">-- не выбрано --</option>
+      <?php foreach ($products as $p): ?>
+        <option value="<?= $p['id'] ?>" <?= isset($material['product2_id']) && $material['product2_id']==$p['id'] ? 'selected' : '' ?>><?= htmlspecialchars($p['variety'] ?: $p['product']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div>
+    <label class="block mb-1">Товар 3</label>
+    <select name="product3_id" class="w-full border px-2 py-1 rounded">
+      <option value="">-- не выбрано --</option>
+      <?php foreach ($products as $p): ?>
+        <option value="<?= $p['id'] ?>" <?= isset($material['product3_id']) && $material['product3_id']==$p['id'] ? 'selected' : '' ?>><?= htmlspecialchars($p['variety'] ?: $p['product']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded hover:bg-[#B44D47]">Сохранить</button>
+</form>

--- a/src/Views/admin/content/materials_index.php
+++ b/src/Views/admin/content/materials_index.php
@@ -1,0 +1,25 @@
+<?php /** @var array $materials */ ?>
+<?php /** @var array $category */ ?>
+<a href="/admin/content/materials/edit?category_id=<?= $category['id'] ?>" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
+  <span class="material-icons-round text-base mr-1">add</span> Добавить материал
+</a>
+<table class="min-w-full bg-white rounded shadow overflow-hidden">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">Заголовок</th>
+      <th class="p-3 text-left font-semibold">Дата</th>
+      <th class="p-3 text-center font-semibold">Редактировать</th>
+    </tr>
+  </thead>
+  <tbody>
+    <?php foreach ($materials as $m): ?>
+    <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($m['title']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars(substr($m['created_at'],0,10)) ?></td>
+      <td class="p-3 text-center">
+        <a href="/admin/content/materials/edit?id=<?= $m['id'] ?>&category_id=<?= $category['id'] ?>" class="text-[#C86052] hover:underline">Редактировать</a>
+      </td>
+    </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>

--- a/src/Views/layouts/admin_main.php
+++ b/src/Views/layouts/admin_main.php
@@ -244,6 +244,7 @@
         <a href="/admin/products" class="hover:underline">Товары</a>
         <a href="/admin/slots" class="hover:underline">Слоты</a>
         <a href="/admin/coupons" class="hover:underline">Промокоды</a>
+        <a href="/admin/content" class="hover:underline">Контент</a>
         <a href="/admin/users" class="hover:underline">Пользователи</a>
         <a href="/admin/settings" class="hover:underline">Настройки</a>
       </nav>
@@ -280,6 +281,10 @@
       <a href="/admin/coupons" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2">local_offer</span>
         <span class="menu-text">Промокоды</span>
+      </a>
+      <a href="/admin/content" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
+        <span class="material-icons-round mr-2">article</span>
+        <span class="menu-text">Контент</span>
       </a>
       <a href="/admin/users" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2">people</span>


### PR DESCRIPTION
## Summary
- add SQL schema for content categories and materials
- implement ContentController with category/material CRUD
- provide admin views for managing content
- add routes for new admin section and navigation links

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68591732b66c832caed48d687802a9bf