### PR TITLE
Add materials display and breadcrumb navigation

### DIFF
--- a/index.php
+++ b/index.php
@@ -279,6 +279,10 @@ switch ("$method $uri") {
         (new App\Controllers\ClientController($pdo))->showOrder($orderId);
         break;
 
+    case (bool) preg_match('#^GET /content/[^/]+/(\d+)$#', "$method $uri", $m):
+        (new App\Controllers\ClientController($pdo))->showMaterial((int)$m[1]);
+        break;
+
     case 'GET /favorites':
         requireClient();
         (new App\Controllers\ClientController($pdo))->favorites();

--- a/src/Views/client/_material_card.php
+++ b/src/Views/client/_material_card.php
@@ -1,0 +1,16 @@
+<?php
+/** @var array $material */
+?>
+<a href="/content/<?= urlencode($material['alias']) ?>/<?= $material['id'] ?>" class="block bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-shadow duration-200 h-full overflow-hidden">
+  <?php if (!empty($material['image_path'])): ?>
+    <img src="<?= htmlspecialchars($material['image_path']) ?>" alt="<?= htmlspecialchars($material['title']) ?>" class="w-full h-40 object-cover">
+  <?php endif; ?>
+  <div class="p-3 sm:p-4">
+    <h3 class="text-base sm:text-lg font-semibold text-gray-800 mb-2">
+      <?= htmlspecialchars($material['title']) ?>
+    </h3>
+    <?php if (!empty($material['short_desc'])): ?>
+      <p class="text-sm text-gray-600"><?= htmlspecialchars($material['short_desc']) ?></p>
+    <?php endif; ?>
+  </div>
+</a>

--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -147,6 +147,28 @@
     </div>
   </section>
 
+  <!-- Материалы -->
+  <?php if (!empty($materials)): ?>
+  <section class="px-4 mb-8">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4">📚 Полезные материалы</h2>
+    <div class="scroll-wrapper relative">
+      <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_left</span>
+      </button>
+      <button data-dir="right" class="hidden md:flex items-center justify-center w-8 h-8 absolute right-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_right</span>
+      </button>
+      <div class="scroll-row flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory">
+        <?php foreach ($materials as $m): ?>
+          <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
+            <?php $material = $m; include __DIR__ . '/_material_card.php'; ?>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    </div>
+  </section>
+  <?php endif; ?>
+
   <!-- Преимущества -->
   <section class="px-4 mb-8">
     <div class="bg-gradient-to-r from-emerald-50 to-teal-50 rounded-3xl p-8">

--- a/src/Views/client/material.php
+++ b/src/Views/client/material.php
@@ -1,0 +1,21 @@
+<?php /** @var array $material */ ?>
+<main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 min-h-screen pb-24">
+  <article class="max-w-screen-md mx-auto px-4 pt-6 space-y-4">
+    <h1 class="text-3xl font-bold text-gray-800 mb-4">
+      <?= htmlspecialchars($material['title']) ?>
+    </h1>
+    <?php if (!empty($material['image_path'])): ?>
+      <img src="<?= htmlspecialchars($material['image_path']) ?>" alt="<?= htmlspecialchars($material['title']) ?>" class="w-full rounded-2xl shadow-lg">
+    <?php endif; ?>
+    <?php if (!empty($material['short_desc'])): ?>
+      <p class="text-gray-700 text-lg">
+        <?= htmlspecialchars($material['short_desc']) ?>
+      </p>
+    <?php endif; ?>
+    <?php if (!empty($material['text'])): ?>
+      <div class="prose prose-sm max-w-none">
+        <?= nl2br(htmlspecialchars($material['text'])) ?>
+      </div>
+    <?php endif; ?>
+  </article>
+</main>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -243,6 +243,33 @@
 
   <!-- Контент -->
   <div class="pt-16">
+    <?php if ($path !== '/') : ?>
+      <?php
+        $crumbs = $breadcrumbs ?? [];
+        if (empty($crumbs)) {
+            $segments = array_filter(explode('/', trim($path, '/')));
+            $accum = '';
+            foreach ($segments as $i => $seg) {
+                $accum .= '/' . $seg;
+                $label = ($i === count($segments)-1 && !empty($meta['h1'])) ? $meta['h1'] : $seg;
+                $crumbs[] = ['label' => $label, 'url' => $i < count($segments)-1 ? $accum : null];
+            }
+        }
+      ?>
+      <nav class="px-4 pb-2 text-sm text-gray-500" aria-label="Breadcrumb">
+        <a href="/" class="text-red-500 hover:underline">BerryGO</a>
+        <?php foreach ($crumbs as $bc): ?>
+          <span class="mx-1">/</span>
+          <?php if (!empty($bc['url'])): ?>
+            <a href="<?= htmlspecialchars($bc['url']) ?>" class="hover:underline">
+              <?= htmlspecialchars($bc['label']) ?>
+            </a>
+          <?php else: ?>
+            <?= htmlspecialchars($bc['label']) ?>
+          <?php endif; ?>
+        <?php endforeach; ?>
+      </nav>
+    <?php endif; ?>
     <?= $content ?>
     <?php if (!empty($meta['text'])): ?>
       <div class="hidden lg:block max-w-screen-lg mx-auto px-4 pb-24 text-gray-700 text-sm">


### PR DESCRIPTION
## Summary
- query latest materials in `ClientController`
- add route and controller action to view a material
- list materials on the homepage in a horizontal swipe row
- implement breadcrumb navigation for all pages

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_685927e77218832c8f83b0629df24796