### PR TITLE
Refactor header install button

### DIFF
--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -149,17 +149,16 @@
 
   <!-- Header -->
 <header class="fixed top-0 left-0 right-0 glass-effect flex items-center justify-between p-4 z-20 border-b border-white/20">
-  <a href="/" id="logoLink" class="group flex items-center space-x-3" style="display:none;">
+  <a href="/" id="logoLink" class="flex items-center">
     <div class="w-10 h-10 berry-gradient rounded-2xl flex items-center justify-center floating-animation">
       <img src="/assets/berrygo_strawberry.svg" alt="BerryGo" class="w-6 h-6 filter brightness-0 invert">
     </div>
-    <span class="font-bold text-xl bg-gradient-to-r from-red-500 to-pink-500 bg-clip-text text-transparent">BerryGo</span>
   </a>
-  <button id="installLogoBtn" class="group flex items-center space-x-3 install-pulse" style="display:none;">
-    <div class="w-10 h-10 berry-gradient rounded-2xl flex items-center justify-center floating-animation">
-      <img src="/assets/berrygo_strawberry.svg" alt="BerryGo" class="w-6 h-6 filter brightness-0 invert">
-    </div>
-    <span id="installLogoBtnText" class="font-bold text-xl bg-gradient-to-r from-red-500 to-pink-500 bg-clip-text text-transparent transition-opacity duration-500">BerryGo</span>
+  <button id="installLogoBtn" class="group flex flex-col items-center text-center space-y-0 install-pulse" style="display:none;">
+    <span id="installLogoBtnText" class="font-bold text-sm leading-tight bg-gradient-to-r from-red-500 to-pink-500 bg-clip-text text-transparent transition-opacity duration-500">
+      Установите<br>приложение
+    </span>
+    <span class="material-icons-round text-red-500 mt-1">install_mobile</span>
   </button>
 
   <div class="flex items-center space-x-3">
@@ -382,18 +381,15 @@
     let deferredPrompt = null;
     const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
 
-    const logoLink = document.getElementById('logoLink');
     const installLogoBtn = document.getElementById('installLogoBtn');
     const installLogoBtnText = document.getElementById('installLogoBtnText');
 
     function showInstalled() {
-      if (logoLink) logoLink.style.display = 'flex';
       if (installLogoBtn) installLogoBtn.style.display = 'none';
     }
 
     function showInstall() {
       if (installLogoBtn) installLogoBtn.style.display = 'flex';
-      if (logoLink) logoLink.style.display = 'none';
     }
 
     window.addEventListener('beforeinstallprompt', (e) => {
@@ -415,16 +411,7 @@
         showInstall();
       }
 
-      let alt = false;
-      setInterval(() => {
-        if (!installLogoBtnText) return;
-        installLogoBtnText.classList.add('opacity-0');
-        setTimeout(() => {
-          installLogoBtnText.textContent = alt ? 'BerryGo' : 'Установите приложение';
-          installLogoBtnText.classList.remove('opacity-0');
-          alt = !alt;
-        }, 500);
-      }, 3000);
+
 
       installLogoBtn?.addEventListener('click', () => {
         if (deferredPrompt) {


### PR DESCRIPTION
## Summary
- update header layout so logo icon links to homepage
- display install button text on two lines with icon
- simplify PWA install toggle logic

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685933f59400832ca1f1b8dd47756df6