### PR TITLE
Add material aliases and product display

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ table:
 ```sql
 ALTER TABLE orders ADD COLUMN coupon_code VARCHAR(50) DEFAULT NULL;
 ```
+
+To enable human readable URLs for materials, add the `alias` column to the
+`materials` table:
+
+```sql
+ALTER TABLE materials
+  ADD COLUMN alias VARCHAR(255) NOT NULL AFTER category_id,
+  ADD UNIQUE KEY alias (alias);
+```

--- a/database/2025_08_content.sql
+++ b/database/2025_08_content.sql
@@ -8,6 +8,7 @@ CREATE TABLE content_categories (
 CREATE TABLE materials (
     id INT AUTO_INCREMENT PRIMARY KEY,
     category_id INT NOT NULL,
+    alias VARCHAR(255) NOT NULL,
     image_path VARCHAR(255) DEFAULT NULL,
     title VARCHAR(255) NOT NULL,
     short_desc TEXT,
@@ -20,5 +21,6 @@ CREATE TABLE materials (
     product3_id INT DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY alias (alias),
     FOREIGN KEY (category_id) REFERENCES content_categories(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/2025_09_material_alias.sql
+++ b/database/2025_09_material_alias.sql
@@ -1,0 +1,3 @@
+ALTER TABLE materials
+  ADD COLUMN alias VARCHAR(255) NOT NULL AFTER category_id,
+  ADD UNIQUE KEY alias (alias);

--- a/index.php
+++ b/index.php
@@ -279,8 +279,8 @@ switch ("$method $uri") {
         (new App\Controllers\ClientController($pdo))->showOrder($orderId);
         break;
 
-    case (bool) preg_match('#^GET /content/[^/]+/(\d+)$#', "$method $uri", $m):
-        (new App\Controllers\ClientController($pdo))->showMaterial((int)$m[1]);
+    case (bool) preg_match('#^GET /content/([^/]+)/([^/]+)$#', "$method $uri", $m):
+        (new App\Controllers\ClientController($pdo))->showMaterial($m[1], $m[2]);
         break;
 
     case 'GET /favorites':

--- a/src/Controllers/ContentController.php
+++ b/src/Controllers/ContentController.php
@@ -111,6 +111,7 @@ class ContentController
         $id         = $_POST['id'] ?? null;
         $categoryId = (int)($_POST['category_id'] ?? 0);
         $title      = trim($_POST['title'] ?? '');
+        $alias      = trim($_POST['alias'] ?? '');
         $shortDesc  = trim($_POST['short_desc'] ?? '');
         $text       = trim($_POST['text'] ?? '');
         $metaTitle  = trim($_POST['meta_title'] ?? '');
@@ -155,17 +156,17 @@ class ContentController
         }
 
         if ($id) {
-            $sql = "UPDATE materials SET category_id=?, title=?, short_desc=?, text=?, meta_title=?, meta_description=?, meta_keywords=?, product1_id=?, product2_id=?, product3_id=?";
-            $params = [$categoryId, $title, $shortDesc, $text, $metaTitle, $metaDesc, $metaKeys, $prod1, $prod2, $prod3];
+            $sql = "UPDATE materials SET category_id=?, title=?, alias=?, short_desc=?, text=?, meta_title=?, meta_description=?, meta_keywords=?, product1_id=?, product2_id=?, product3_id=?";
+            $params = [$categoryId, $title, $alias, $shortDesc, $text, $metaTitle, $metaDesc, $metaKeys, $prod1, $prod2, $prod3];
             if ($imagePath) { $sql .= ", image_path=?"; $params[] = $imagePath; }
             $sql .= " WHERE id=?";
             $params[] = (int)$id;
             $stmt = $this->pdo->prepare($sql);
             $stmt->execute($params);
         } else {
-            $columns = "category_id,title,short_desc,text,meta_title,meta_description,meta_keywords,product1_id,product2_id,product3_id";
-            $placeholders = "?,?,?,?,?,?,?,?,?,?";
-            $params = [$categoryId,$title,$shortDesc,$text,$metaTitle,$metaDesc,$metaKeys,$prod1,$prod2,$prod3];
+            $columns = "category_id,title,alias,short_desc,text,meta_title,meta_description,meta_keywords,product1_id,product2_id,product3_id";
+            $placeholders = "?,?,?,?,?,?,?,?,?,?,?";
+            $params = [$categoryId,$title,$alias,$shortDesc,$text,$metaTitle,$metaDesc,$metaKeys,$prod1,$prod2,$prod3];
             if ($imagePath) { $columns .= ",image_path"; $placeholders .= ",?"; $params[] = $imagePath; }
             $sql = "INSERT INTO materials ($columns) VALUES ($placeholders)";
             $stmt = $this->pdo->prepare($sql);

--- a/src/Views/admin/content/material_edit.php
+++ b/src/Views/admin/content/material_edit.php
@@ -20,6 +20,10 @@
     <input name="title" type="text" value="<?= htmlspecialchars($material['title'] ?? '') ?>" class="w-full border px-2 py-1 rounded" required>
   </div>
   <div>
+    <label class="block mb-1">Алиас</label>
+    <input name="alias" type="text" value="<?= htmlspecialchars($material['alias'] ?? '') ?>" class="w-full border px-2 py-1 rounded" required>
+  </div>
+  <div>
     <label class="block mb-1">Короткое описание</label>
     <textarea name="short_desc" rows="2" class="w-full border px-2 py-1 rounded"><?= htmlspecialchars($material['short_desc'] ?? '') ?></textarea>
   </div>

--- a/src/Views/client/_material_card.php
+++ b/src/Views/client/_material_card.php
@@ -1,7 +1,7 @@
 <?php
 /** @var array $material */
 ?>
-<a href="/content/<?= urlencode($material['alias']) ?>/<?= $material['id'] ?>" class="block bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-shadow duration-200 h-full overflow-hidden">
+<a href="/content/<?= urlencode($material['cat_alias']) ?>/<?= urlencode($material['mat_alias']) ?>" class="block bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-shadow duration-200 h-full overflow-hidden">
   <?php if (!empty($material['image_path'])): ?>
     <img src="<?= htmlspecialchars($material['image_path']) ?>" alt="<?= htmlspecialchars($material['title']) ?>" class="w-full h-40 object-cover">
   <?php endif; ?>

--- a/src/Views/client/material.php
+++ b/src/Views/client/material.php
@@ -1,4 +1,5 @@
 <?php /** @var array $material */ ?>
+<?php /** @var array $products */ ?>
 <main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 min-h-screen pb-24">
   <article class="max-w-screen-md mx-auto px-4 pt-6 space-y-4">
     <h1 class="text-3xl font-bold text-gray-800 mb-4">
@@ -17,5 +18,19 @@
         <?= nl2br(htmlspecialchars($material['text'])) ?>
       </div>
     <?php endif; ?>
+
+    <?php if (!empty($products)): ?>
+      <h2 class="text-2xl font-bold text-gray-800 mt-6 mb-4">Товары из статьи</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <?php foreach ($products as $p): ?>
+          <?php include __DIR__ . '/_card.php'; ?>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="mt-8 flex justify-center space-x-4">
+      <a href="/" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">На главную</a>
+      <a href="/catalog" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">В каталог</a>
+    </div>
   </article>
 </main>


### PR DESCRIPTION
## Summary
- add alias column for materials and migration
- document new field in README
- show products linked to material on material page
- support URLs like `/content/<category>/<material>`
- update admin form for material alias

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68593511b4c0832cbad1c71e99ffa138