### PR TITLE
Fix breadcrumb overlap with header

### DIFF
--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -255,7 +255,7 @@
             }
         }
       ?>
-      <nav class="px-4 pb-2 text-sm text-gray-500 mt-2" aria-label="Breadcrumb">
+      <nav class="px-4 pb-2 text-sm text-gray-500 mt-4" aria-label="Breadcrumb">
         <a href="/" class="text-red-500 hover:underline">BerryGO</a>
         <?php foreach ($crumbs as $bc): ?>
           <span class="mx-1">/</span>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -255,7 +255,7 @@
             }
         }
       ?>
-      <nav class="px-4 pb-2 text-sm text-gray-500" aria-label="Breadcrumb">
+      <nav class="px-4 pb-2 text-sm text-gray-500 mt-2" aria-label="Breadcrumb">
         <a href="/" class="text-red-500 hover:underline">BerryGO</a>
         <?php foreach ($crumbs as $bc): ?>
           <span class="mx-1">/</span>


### PR DESCRIPTION
## Summary
- add margin to breadcrumbs nav so it sits below the fixed header

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859393479f8832c8f0b29839d860d5e