### PR TITLE
Update materials carousel on homepage

### DIFF
--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -37,22 +37,17 @@
 
   <!-- Материалы -->
   <?php if (!empty($materials)): ?>
-  <section class="px-4 mb-8">
+  <section class="px-4 mb-8 hidden md:block">
     <h2 class="text-2xl font-bold text-gray-800 mb-4">📚 Полезные материалы</h2>
-    <div class="scroll-wrapper relative">
-      <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
-        <span class="material-icons-round text-gray-600">chevron_left</span>
-      </button>
-      <button data-dir="right" class="hidden md:flex items-center justify-center w-8 h-8 absolute right-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
-        <span class="material-icons-round text-gray-600">chevron_right</span>
-      </button>
+    <div class="scroll-wrapper relative dots-carousel">
       <div class="scroll-row flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory">
         <?php foreach ($materials as $m): ?>
-          <div class="flex-none w-[66vw] sm:w-1/2 md:w-1/3 snap-start h-full">
+          <div class="flex-none w-[60vw] snap-start h-full">
             <?php $material = $m; include __DIR__ . '/_material_card.php'; ?>
           </div>
         <?php endforeach; ?>
       </div>
+      <div class="dots flex justify-center mt-2 space-x-2"></div>
     </div>
   </section>
   <?php endif; ?>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -683,6 +683,39 @@
   });
 </script>
 
+<script>
+  // Dots navigation for materials carousel
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.dots-carousel').forEach(wrapper => {
+      const row = wrapper.querySelector('.scroll-row');
+      const dotsContainer = wrapper.querySelector('.dots');
+      const slides = row.children.length;
+      for (let i = 0; i < slides; i++) {
+        const dot = document.createElement('button');
+        dot.className = 'w-2 h-2 rounded-full bg-gray-300';
+        if (i === 0) dot.classList.replace('bg-gray-300', 'bg-gray-700');
+        dotsContainer.appendChild(dot);
+        dot.addEventListener('click', () => {
+          row.scrollTo({left: i * row.clientWidth, behavior: 'smooth'});
+        });
+      }
+
+      row.addEventListener('scroll', () => {
+        const index = Math.round(row.scrollLeft / row.clientWidth);
+        dotsContainer.querySelectorAll('button').forEach((d, idx) => {
+          if (idx === index) {
+            d.classList.add('bg-gray-700');
+            d.classList.remove('bg-gray-300');
+          } else {
+            d.classList.add('bg-gray-300');
+            d.classList.remove('bg-gray-700');
+          }
+        });
+      });
+    });
+  });
+</script>
+
 
 
 


### PR DESCRIPTION
## Summary
- hide materials section on mobile
- change material card width to 60% of the viewport
- replace side arrows with dots under the carousel

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: PDOException could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6859482d1f6c832cb685316a32fe85f9