### PR TITLE
Add Yandex Metrica ecommerce tracking

### DIFF
--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -136,7 +136,7 @@
 
       <!-- Кнопка «В корзину» или «Войдите» -->
       <?php if ((string)($_SESSION['role'] ?? '') === 'client' && $active): ?>
-        <form action="/cart/add" method="post" class="flex items-center space-x-2">
+        <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $p['id'] ?>" data-name="<?= htmlspecialchars($p['product'] . ($p['variety'] ? ' ' . $p['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
           <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
           <div class="flex items-center space-x-2">
             <button type="button"

--- a/src/Views/client/cart.php
+++ b/src/Views/client/cart.php
@@ -90,7 +90,7 @@
                 </button>
               </form>
             <?php else: ?>
-              <form action="/cart/remove" method="post">
+              <form action="/cart/remove" method="post" class="remove-from-cart-form" data-id="<?= $it['product_id'] ?>" data-name="<?= htmlspecialchars($it['product']) ?><?php if (!empty($it['variety'])): ?> <?= htmlspecialchars($it['variety']) ?><?php endif; ?>" data-price="<?= $unitPriceToUse ?>" data-qty="<?= $it['quantity'] ?>">
                 <input type="hidden" name="product_id" value="<?= $it['product_id'] ?>">
                 <button type="submit" class="w-8 h-8 flex items-center justify-center bg-gray-100 rounded-full">
                   <span class="material-icons-round text-gray-600">delete</span>

--- a/src/Views/client/favorites.php
+++ b/src/Views/client/favorites.php
@@ -54,7 +54,7 @@
             <div class="text-sm text-gray-500"><?= htmlspecialchars($kgPrice) ?> ₽/кг</div>
           </div>
 
-          <form action="/cart/add" method="post" class="mt-auto flex">
+          <form action="/cart/add" method="post" class="mt-auto flex add-to-cart-form" data-id="<?= $p['id'] ?>" data-name="<?= htmlspecialchars($p['product'] . ($p['variety'] ? ' ' . $p['variety'] : '')) ?>" data-price="<?= $boxPrice ?>">
             <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
             <input type="number" name="quantity" value="1" min="1" step="1"
                    class="w-20 border border-gray-300 px-2 py-1 rounded-l text-center">

--- a/src/Views/client/order_show.php
+++ b/src/Views/client/order_show.php
@@ -159,3 +159,23 @@ $discount = max(0, $rawSum - $order['total_amount']);
 
   </div>
 </main>
+<script>
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({
+  ecommerce: {
+    currencyCode: 'RUB',
+    purchase: {
+      actionField: { id: '<?= $order['id'] ?>' },
+      products: [
+        <?php foreach ($items as $idx => $it): ?>{
+          id: '<?= $it['product_id'] ?>',
+          name: '<?= addslashes($it['product_name'] . ($it['variety'] ? ' ' . $it['variety'] : '')) ?>',
+          price: <?= $it['unit_price'] ?>,
+          quantity: <?= $it['quantity'] ?>
+        }<?= $idx + 1 < count($items) ? ',' : '' ?>
+        <?php endforeach; ?>
+      ]
+    }
+  }
+});
+</script>

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -27,3 +27,21 @@
     </div>
   </article>
 </main>
+<script>
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({
+  ecommerce: {
+    currencyCode: 'RUB',
+    detail: {
+      products: [{
+        id: '<?= $product['id'] ?>',
+        name: '<?= addslashes($product['product'] . ($product['variety'] ? ' ' . $product['variety'] : '')) ?>',
+        price: <?= ($product['sale_price']>0?
+            ($product['sale_price']*$product['box_size']+BOX_MARKUP):
+            ($product['price']*$product['box_size']+BOX_MARKUP)) ?>,
+        quantity: 1
+      }]
+    }
+  }
+});
+</script>

--- a/src/Views/layouts/scripts.php
+++ b/src/Views/layouts/scripts.php
@@ -8,12 +8,57 @@
  k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
 (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
 
+</script>
+<script type="text/javascript">
 ym(103009404, "init", {
      clickmap:true,
      trackLinks:true,
      accurateTrackBounce:true,
-     webvisor:true
+     webvisor:true,
+     ecommerce:true
 });
+window.dataLayer = window.dataLayer || [];
 </script>
 <noscript><div><img src="https://mc.yandex.ru/watch/103009404" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
 <!-- /Yandex.Metrika counter -->
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.add-to-cart-form').forEach(function (form) {
+      form.addEventListener('submit', function () {
+        var qty = form.querySelector('input[name="quantity"]').value;
+        window.dataLayer.push({
+          ecommerce: {
+            currencyCode: 'RUB',
+            add: {
+              products: [{
+                id: form.dataset.id,
+                name: form.dataset.name,
+                price: parseFloat(form.dataset.price),
+                quantity: parseFloat(qty)
+              }]
+            }
+          }
+        });
+      });
+    });
+
+    document.querySelectorAll('.remove-from-cart-form').forEach(function (form) {
+      form.addEventListener('submit', function () {
+        window.dataLayer.push({
+          ecommerce: {
+            currencyCode: 'RUB',
+            remove: {
+              products: [{
+                id: form.dataset.id,
+                name: form.dataset.name,
+                price: parseFloat(form.dataset.price),
+                quantity: parseFloat(form.dataset.qty)
+              }]
+            }
+          }
+        });
+      });
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- enable ecommerce in the Metrica script and initialise `dataLayer`
- push product `detail` info on the product page
- send purchase information on the order page
- emit `add` and `remove` events for cart actions

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c27fd0a98832cbe672ad7835715c0