### PR TITLE
Add aliases for products and product types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ ALTER TABLE materials
   ADD COLUMN alias VARCHAR(255) NOT NULL AFTER category_id,
   ADD UNIQUE KEY alias (alias);
 ```
+
+To make pretty URLs for products and categories, add alias columns:
+
+```sql
+ALTER TABLE product_types
+  ADD COLUMN alias VARCHAR(255) NOT NULL AFTER name,
+  ADD UNIQUE KEY alias (alias);
+
+ALTER TABLE products
+  ADD COLUMN alias VARCHAR(255) NOT NULL AFTER product_type_id,
+  ADD UNIQUE KEY alias (alias);
+```

--- a/database/2025_12_product_alias.sql
+++ b/database/2025_12_product_alias.sql
@@ -1,0 +1,7 @@
+ALTER TABLE product_types
+  ADD COLUMN alias VARCHAR(255) NOT NULL AFTER name,
+  ADD UNIQUE KEY alias (alias);
+
+ALTER TABLE products
+  ADD COLUMN alias VARCHAR(255) NOT NULL AFTER product_type_id,
+  ADD UNIQUE KEY alias (alias);

--- a/index.php
+++ b/index.php
@@ -282,11 +282,11 @@ switch ("$method $uri") {
     case (bool) preg_match('#^GET /content/([^/]+)/([^/]+)$#', "$method $uri", $m):
         (new App\Controllers\ClientController($pdo))->showMaterial($m[1], $m[2]);
         break;
-    case (bool) preg_match('#^GET /product/(\d+)$#', "$method $uri", $m):
-        (new App\Controllers\ClientController($pdo))->showProduct((int)$m[1]);
+    case (bool) preg_match('#^GET /product/([^/]+)$#', "$method $uri", $m):
+        (new App\Controllers\ClientController($pdo))->showProduct($m[1]);
         break;
-    case (bool) preg_match('#^GET /type/(\d+)$#', "$method $uri", $m):
-        (new App\Controllers\ClientController($pdo))->showProductType((int)$m[1]);
+    case (bool) preg_match('#^GET /type/([^/]+)$#', "$method $uri", $m):
+        (new App\Controllers\ClientController($pdo))->showProductType($m[1]);
         break;
 
     case 'GET /favorites':

--- a/src/Controllers/ProductTypesController.php
+++ b/src/Controllers/ProductTypesController.php
@@ -43,6 +43,7 @@ class ProductTypesController
     {
         $id      = $_POST['id'] ?? null;
         $name    = trim($_POST['name'] ?? '');
+        $alias   = trim($_POST['alias'] ?? '');
         $metaT   = trim($_POST['meta_title'] ?? '');
         $metaD   = trim($_POST['meta_description'] ?? '');
         $metaK   = trim($_POST['meta_keywords'] ?? '');
@@ -52,14 +53,14 @@ class ProductTypesController
 
         if ($id) {
             $stmt = $this->pdo->prepare(
-                "UPDATE product_types SET name=?, meta_title=?, meta_description=?, meta_keywords=?, h1=?, short_description=?, text=? WHERE id=?"
+                "UPDATE product_types SET name=?, alias=?, meta_title=?, meta_description=?, meta_keywords=?, h1=?, short_description=?, text=? WHERE id=?"
             );
-            $stmt->execute([$name, $metaT, $metaD, $metaK, $h1, $short, $text, (int)$id]);
+            $stmt->execute([$name, $alias, $metaT, $metaD, $metaK, $h1, $short, $text, (int)$id]);
         } else {
             $stmt = $this->pdo->prepare(
-                "INSERT INTO product_types (name, meta_title, meta_description, meta_keywords, h1, short_description, text) VALUES (?,?,?,?,?,?,?)"
+                "INSERT INTO product_types (name, alias, meta_title, meta_description, meta_keywords, h1, short_description, text) VALUES (?,?,?,?,?,?,?,?)"
             );
-            $stmt->execute([$name, $metaT, $metaD, $metaK, $h1, $short, $text]);
+            $stmt->execute([$name, $alias, $metaT, $metaD, $metaK, $h1, $short, $text]);
         }
         header('Location: /admin/product-types');
         exit;

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -41,7 +41,9 @@ class ProductsController
         $stmt = $this->pdo->query(
             "SELECT
                 p.id,
+                p.alias,
                 t.name            AS product,
+                t.alias           AS type_alias,
                 p.variety,
                 p.description,
                 p.manufacturer,
@@ -103,6 +105,7 @@ class ProductsController
         $id            = $_POST['id'] ?? null;
         $typeId        = (int)($_POST['product_type_id'] ?? 0);
         $variety       = trim($_POST['variety'] ?? '');
+        $alias         = trim($_POST['alias'] ?? '');
         $description   = trim($_POST['description'] ?? '');
         $fullDesc      = trim($_POST['full_description'] ?? '');
         $compositionArr = array_filter(array_map('trim', $_POST['composition'] ?? []));
@@ -175,6 +178,7 @@ class ProductsController
             // UPDATE
             $sql = "UPDATE products SET
                         product_type_id = ?,
+                        alias           = ?,
                         variety         = ?,
                         description     = ?,
                         full_description= ?,
@@ -190,7 +194,7 @@ class ProductsController
                         delivery_date   = ?,
                         is_active       = ?";
             $params = [
-                $typeId, $variety, $description, $fullDesc, $compositionJson, $manufacturer,
+                $typeId, $alias, $variety, $description, $fullDesc, $compositionJson, $manufacturer,
                 $originCountry, $boxSize, $boxUnit,
                 $unit, $price, $salePrice, $stockBoxes,
                 $deliveryDate, $isActive
@@ -209,11 +213,11 @@ class ProductsController
 
         } else {
             // INSERT
-            $columns      = "product_type_id,variety,description,full_description,composition,manufacturer,origin_country,box_size,box_unit,unit,price,sale_price,stock_boxes,delivery_date,is_active";
-            // 15 placeholders corresponding to the columns above
-            $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
+            $columns      = "product_type_id,alias,variety,description,full_description,composition,manufacturer,origin_country,box_size,box_unit,unit,price,sale_price,stock_boxes,delivery_date,is_active";
+            // 16 placeholders corresponding to the columns above
+            $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
             $params       = [
-                $typeId, $variety, $description, $fullDesc, $compositionJson, $manufacturer,
+                $typeId, $alias, $variety, $description, $fullDesc, $compositionJson, $manufacturer,
                 $originCountry, $boxSize, $boxUnit,
                 $unit, $price, $salePrice, $stockBoxes,
                 $deliveryDate, $isActive

--- a/src/Views/admin/product_types/edit.php
+++ b/src/Views/admin/product_types/edit.php
@@ -8,6 +8,10 @@
     <input name="name" type="text" value="<?= htmlspecialchars($type['name'] ?? '') ?>" class="w-full border px-2 py-1 rounded" required>
   </div>
   <div>
+    <label class="block mb-1">Алиас</label>
+    <input name="alias" type="text" value="<?= htmlspecialchars($type['alias'] ?? '') ?>" class="w-full border px-2 py-1 rounded" required>
+  </div>
+  <div>
     <label class="block mb-1">Meta title</label>
     <input name="meta_title" type="text" value="<?= htmlspecialchars($type['meta_title'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
   </div>

--- a/src/Views/admin/product_types/index.php
+++ b/src/Views/admin/product_types/index.php
@@ -6,6 +6,7 @@
   <thead class="bg-gray-200 text-gray-700">
     <tr>
       <th class="p-3 text-left font-semibold">Название</th>
+      <th class="p-3 text-left font-semibold">Алиас</th>
       <th class="p-3 text-center font-semibold">Редактировать</th>
     </tr>
   </thead>
@@ -13,6 +14,7 @@
     <?php foreach ($types as $t): ?>
     <tr class="border-b hover:bg-gray-50 transition-all duration-200">
       <td class="p-3 text-gray-600"><?= htmlspecialchars($t['name']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($t['alias']) ?></td>
       <td class="p-3 text-center">
         <a href="/admin/product-types/edit?id=<?= $t['id'] ?>" class="text-[#C86052] hover:underline">Редактировать</a>
       </td>

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -36,6 +36,12 @@
            value="<?= htmlspecialchars($product['variety'] ?? '') ?>"
            class="w-full border px-2 py-1 rounded">
   </div>
+  <div>
+    <label class="block mb-1">Алиас</label>
+    <input name="alias" type="text"
+           value="<?= htmlspecialchars($product['alias'] ?? '') ?>"
+           class="w-full border px-2 py-1 rounded" required>
+  </div>
 
   <!-- Описание -->
   <div>

--- a/src/Views/admin/products/index.php
+++ b/src/Views/admin/products/index.php
@@ -7,6 +7,7 @@
   <thead class="bg-gray-200 text-gray-700">
     <tr>
       <th class="p-3 text-left font-semibold">Продукт</th>
+      <th class="p-3 text-left font-semibold">Алиас</th>
       <th class="p-3 text-left font-semibold">Сорт</th>
       <th class="p-3 text-left font-semibold">Вес ящика</th>
       <th class="p-3 text-left font-semibold">Цена</th>
@@ -22,6 +23,9 @@
           <a href="/admin/products/edit?id=<?= $p['id'] ?>" class="text-[#C86052] hover:underline">
             <?= htmlspecialchars($p['product']) ?>
           </a>
+        </td>
+        <td class="p-3 text-gray-600">
+          <?= htmlspecialchars($p['alias']) ?>
         </td>
         <td class="p-3 text-gray-600"><?= htmlspecialchars($p['variety']) ?></td>
         <td class="p-3 text-gray-600">

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -15,7 +15,7 @@
  */
 ?>
 <?php $search = mb_strtolower(($p['product'] ?? '') . ' ' . ($p['variety'] ?? ''), 'UTF-8'); ?>
-<div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 h-full max-w-[350px]" data-search="<?= htmlspecialchars($search) ?>">
+<div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 h-full max-w-[350px]" data-search="<?= htmlspecialchars($search) ?>" data-type="<?= htmlspecialchars($p['type_alias'] ?? '') ?>" data-sale="<?= ($p['sale_price'] ?? 0) > 0 ? '1' : '0' ?>">
   <?php 
   $img       = trim($p['image_path'] ?? '');
   $hasImage  = $img !== '';
@@ -37,7 +37,7 @@
   ?>
   <div class="relative">
     <?php if ($hasImage): ?>
-      <a href="/product/<?= $p['id'] ?>">
+      <a href="/product/<?= urlencode($p['alias']) ?>">
         <img src="<?= htmlspecialchars($img) ?>"
              alt="<?= htmlspecialchars($p['product'] ?? '') ?>"
              class="w-full object-cover h-40 sm:h-48">
@@ -86,7 +86,7 @@
     <div class="mb-2">
       <?php $boxLabel = htmlspecialchars($boxSize . ' ' . $boxUnit); ?>
       <h3 class="text-base sm:text-lg font-semibold text-gray-800">
-        <a href="/product/<?= $p['id'] ?>" class="hover:underline">
+        <a href="/product/<?= urlencode($p['alias']) ?>" class="hover:underline">
           <?= htmlspecialchars($p['product']      ?? '') ?>
           <?php if (!empty($p['variety'])): ?>
             <?= ' ' . htmlspecialchars($p['variety']) ?>

--- a/src/Views/client/catalog.php
+++ b/src/Views/client/catalog.php
@@ -13,12 +13,14 @@
                class="w-full pl-12 pr-4 py-3 border border-gray-200 rounded-2xl focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500 transition-all text-gray-700 placeholder-gray-400">
         <span class="material-icons-round absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400">search</span>
       </div>
-      <div class="flex space-x-2 overflow-x-auto pb-2">
-        <button class="flex-shrink-0 px-4 py-2 bg-red-500 text-white rounded-full text-sm font-medium hover:bg-red-600 transition-colors">Все</button>
-        <button class="flex-shrink-0 px-4 py-2 bg-gray-100 text-gray-700 rounded-full text-sm font-medium hover:bg-gray-200 transition-colors">🍓 Ягоды</button>
-        <button class="flex-shrink-0 px-4 py-2 bg-gray-100 text-gray-700 rounded-full text-sm font-medium hover:bg-gray-200 transition-colors">🍑 Фрукты</button>
-        <button class="flex-shrink-0 px-4 py-2 bg-gray-100 text-gray-700 rounded-full text-sm font-medium hover:bg-gray-200 transition-colors">🥝 Экзотика</button>
-        <button class="flex-shrink-0 px-4 py-2 bg-gray-100 text-gray-700 rounded-full text-sm font-medium hover:bg-gray-200 transition-colors">💰 Акции</button>
+      <div class="flex space-x-2 overflow-x-auto pb-2" id="quickFilters">
+        <button data-filter="all" class="flex-shrink-0 px-4 py-2 bg-red-500 text-white rounded-full text-sm font-medium hover:bg-red-600 transition-colors">Все</button>
+        <button data-filter="sale" class="flex-shrink-0 px-4 py-2 bg-gray-100 text-gray-700 rounded-full text-sm font-medium hover:bg-gray-200 transition-colors">Акции</button>
+        <?php foreach (($types ?? []) as $t): ?>
+          <button data-filter="<?= htmlspecialchars($t['alias']) ?>" class="flex-shrink-0 px-4 py-2 bg-gray-100 text-gray-700 rounded-full text-sm font-medium hover:bg-gray-200 transition-colors">
+            <?= htmlspecialchars($t['name']) ?>
+          </button>
+        <?php endforeach; ?>
       </div>
     </div>
   </div>
@@ -51,17 +53,33 @@
       const search = document.getElementById('catalogSearch');
       const container = document.getElementById('productsContainer');
       const allCards = Array.from(container.querySelectorAll('.product-card'));
+      const filterButtons = document.querySelectorAll('#quickFilters [data-filter]');
+      let currentFilter = 'all';
 
       function applyFilter() {
         const term = search.value.trim().toLowerCase();
-        const cards = allCards
-          .filter(c => c.dataset.search.includes(term))
-          .sort((a, b) => a.dataset.search.localeCompare(b.dataset.search, 'ru'));
+        const cards = allCards.filter(c => {
+          const matchesTerm = c.dataset.search.includes(term);
+          const matchesFilter = currentFilter === 'all'
+            ? true
+            : currentFilter === 'sale'
+              ? c.dataset.sale === '1'
+              : c.dataset.type === currentFilter;
+          return matchesTerm && matchesFilter;
+        }).sort((a, b) => a.dataset.search.localeCompare(b.dataset.search, 'ru'));
         container.innerHTML = '';
         cards.forEach(c => container.appendChild(c));
       }
 
       search.addEventListener('input', applyFilter);
+      filterButtons.forEach(btn => btn.addEventListener('click', () => {
+        filterButtons.forEach(b => b.classList.remove('bg-red-500', 'text-white'));
+        filterButtons.forEach(b => b.classList.add('bg-gray-100', 'text-gray-700'));
+        btn.classList.remove('bg-gray-100', 'text-gray-700');
+        btn.classList.add('bg-red-500', 'text-white');
+        currentFilter = btn.dataset.filter;
+        applyFilter();
+      }));
     });
   </script>
 

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -108,7 +108,7 @@
     <div class="flex justify-center space-x-4 pt-4">
       <a href="/" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">На главную</a>
       <a href="/catalog" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">В каталог</a>
-      <a href="/type/<?= $product['product_type_id'] ?>" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">В раздел <?= htmlspecialchars($product['product']) ?></a>
+      <a href="/type/<?= urlencode($product['type_alias']) ?>" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">В раздел <?= htmlspecialchars($product['product']) ?></a>
     </div>
   </article>
 </main>


### PR DESCRIPTION
## Summary
- add `alias` columns for product types and products
- expose alias management in admin UI
- support `/product/{alias}` and `/type/{alias}` routes
- update catalog with dynamic quick filters
- document database changes

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_685c3ac9d104832c9c0000cea1d54906