### PR TITLE
Improve catalog breadcrumbs

### DIFF
--- a/index.php
+++ b/index.php
@@ -282,6 +282,14 @@ switch ("$method $uri") {
     case (bool) preg_match('#^GET /content/([^/]+)/([^/]+)$#', "$method $uri", $m):
         (new App\Controllers\ClientController($pdo))->showMaterial($m[1], $m[2]);
         break;
+    case (bool) preg_match('#^GET /catalog/([^/]+)/([^/]+)$#', "$method $uri", $m):
+        requireClient();
+        (new App\Controllers\ClientController($pdo))->showProduct($m[2], $m[1]);
+        break;
+    case (bool) preg_match('#^GET /catalog/([^/]+)$#', "$method $uri", $m):
+        requireClient();
+        (new App\Controllers\ClientController($pdo))->showProductType($m[1]);
+        break;
     case (bool) preg_match('#^GET /product/([^/]+)$#', "$method $uri", $m):
         (new App\Controllers\ClientController($pdo))->showProduct($m[1]);
         break;

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -37,7 +37,7 @@
   ?>
   <div class="relative">
     <?php if ($hasImage): ?>
-      <a href="/product/<?= urlencode($p['alias']) ?>">
+      <a href="/catalog/<?= urlencode($p['type_alias']) ?>/<?= urlencode($p['alias']) ?>">
         <img src="<?= htmlspecialchars($img) ?>"
              alt="<?= htmlspecialchars($p['product'] ?? '') ?>"
              class="w-full object-cover h-40 sm:h-48">
@@ -86,7 +86,7 @@
     <div class="mb-2">
       <?php $boxLabel = htmlspecialchars($boxSize . ' ' . $boxUnit); ?>
       <h3 class="text-base sm:text-lg font-semibold text-gray-800">
-        <a href="/product/<?= urlencode($p['alias']) ?>" class="hover:underline">
+        <a href="/catalog/<?= urlencode($p['type_alias']) ?>/<?= urlencode($p['alias']) ?>" class="hover:underline">
           <?= htmlspecialchars($p['product']      ?? '') ?>
           <?php if (!empty($p['variety'])): ?>
             <?= ' ' . htmlspecialchars($p['variety']) ?>

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -108,7 +108,7 @@
     <div class="flex justify-center space-x-4 pt-4">
       <a href="/" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">На главную</a>
       <a href="/catalog" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">В каталог</a>
-      <a href="/type/<?= urlencode($product['type_alias']) ?>" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">В раздел <?= htmlspecialchars($product['product']) ?></a>
+      <a href="/catalog/<?= urlencode($product['type_alias']) ?>" class="bg-gradient-to-r from-red-500 to-pink-500 text-white px-6 py-3 rounded-xl hover:from-pink-500 hover:to-red-500 transition">В раздел <?= htmlspecialchars($product['product']) ?></a>
     </div>
   </article>
 </main>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -256,7 +256,7 @@
         }
       ?>
       <nav class="px-4 pb-2 text-sm text-gray-500 mt-4" aria-label="Breadcrumb">
-        <a href="/" class="text-red-500 hover:underline">BerryGO</a>
+        <a href="/" class="text-red-500 hover:underline">Главная</a>
         <?php foreach ($crumbs as $bc): ?>
           <span class="mx-1">/</span>
           <?php if (!empty($bc['url'])): ?>


### PR DESCRIPTION
## Summary
- show `Главная` as the root crumb
- pass breadcrumbs from catalog and product pages
- build product URLs under `/catalog/<type_alias>/<product_alias>`
- route new catalog URLs in index router
- update links in catalog card and product pages

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_685ccd5b17e8832c90858d3fc1d0e0b3