### PR TITLE
Fix breadcrumbs

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -1120,10 +1120,10 @@ public function showOrder(int $orderId): void
             'breadcrumbs' => [
                 ['label' => 'Каталог', 'url' => '/catalog'],
                 [
-                    'label' => $product['type_alias'],
+                    'label' => $product['product'],
                     'url'   => '/catalog/' . $product['type_alias']
                 ],
-                ['label' => $product['alias']]
+                ['label' => $product['variety']]
             ],
         ]);
     }
@@ -1155,7 +1155,7 @@ public function showOrder(int $orderId): void
             'meta'        => ['h1' => $type['h1'] ?? $type['name'], 'text' => $type['text'] ?? ''],
             'breadcrumbs' => [
                 ['label' => 'Каталог', 'url' => '/catalog'],
-                ['label' => $type['alias']]
+                ['label' => $type['name']]
             ],
         ]);
     }


### PR DESCRIPTION
## Summary
- use names for catalog breadcrumbs

## Testing
- `composer install` *(fails: ext-dom missing)*
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_685d5cba44e4832c9fa48358b251543a