### PR TITLE
Add mouse-drag carousels

### DIFF
--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -39,9 +39,9 @@
   <?php if (!empty($materials)): ?>
   <section class="px-4 mb-8 hidden md:block">
     <div class="scroll-wrapper relative dots-carousel">
-      <div class="scroll-row flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory">
+      <div class="scroll-row flex space-x-4 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory eq-row">
         <?php foreach ($materials as $m): ?>
-          <div class="flex-none w-[60vw] snap-start h-full">
+          <div class="flex-none w-[40vw] max-w-[415px] snap-start h-full">
             <?php $material = $m; include __DIR__ . '/_material_card.php'; ?>
           </div>
         <?php endforeach; ?>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -431,7 +431,41 @@
       });
     });
   </script>
-  
+
+<script>
+  // Enable mouse drag scrolling for carousels
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.scroll-row').forEach(row => {
+      let isDown = false;
+      let startX;
+      let scrollLeft;
+
+      const start = x => {
+        isDown = true;
+        startX = x;
+        scrollLeft = row.scrollLeft;
+      };
+
+      const move = x => {
+        if (!isDown) return;
+        row.scrollLeft = scrollLeft - (x - startX);
+      };
+
+      row.addEventListener('mousedown', e => start(e.pageX));
+      row.addEventListener('mousemove', e => {
+        if (!isDown) return;
+        e.preventDefault();
+        move(e.pageX);
+      });
+      window.addEventListener('mouseup', () => { isDown = false; });
+
+      row.addEventListener('touchstart', e => start(e.touches[0].pageX));
+      row.addEventListener('touchmove', e => move(e.touches[0].pageX));
+      window.addEventListener('touchend', () => { isDown = false; });
+    });
+  });
+</script>
+
   
   
       


### PR DESCRIPTION
## Summary
- keep news carousel cards equal height and narrower
- make all carousels draggable with the mouse

## Testing
- `./vendor/bin/phpunit tests` *(fails: PDOException could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_685d8044e464832c889137d31772c9db