### PR TITLE
Fix deleted order page

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -46,6 +46,12 @@ class OrdersController
         $stmt->execute([$id]);
         $order = $stmt->fetch(PDO::FETCH_ASSOC);
 
+        if (!$order) {
+            $msg = urlencode("Заказ {$id} удалён");
+            header("Location: /admin/orders?msg={$msg}");
+            exit;
+        }
+
         $stmt = $this->pdo->prepare(
             "SELECT oi.product_id, oi.quantity, oi.boxes, oi.unit_price, t.name AS product_name, p.unit, p.variety, p.box_size, p.box_unit\n" .
             "FROM order_items oi\n" .

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -1,4 +1,9 @@
 <?php /** @var array $orders */ ?>
+<?php if (!empty($_GET['msg'])): ?>
+  <div class="mb-4 p-3 rounded bg-green-50 text-green-800 border border-green-200">
+    <?= htmlspecialchars($_GET['msg']) ?>
+  </div>
+<?php endif; ?>
 <div class="mb-4 flex flex-col md:flex-row md:items-end md:justify-between gap-2">
   <select id="statusFilter" class="border rounded px-3 py-2 text-sm">
     <option value="">Все статусы</option>


### PR DESCRIPTION
## Summary
- redirect to orders page when a deleted order is requested
- show info message on orders list when redirected

## Testing
- `php -l src/Controllers/OrdersController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f56e3dd84832c8f6a578bb6ea788d