### PR TITLE
Add SEO meta fields to products

### DIFF
--- a/database/2025_14_product_meta.sql
+++ b/database/2025_14_product_meta.sql
@@ -1,0 +1,4 @@
+ALTER TABLE products
+  ADD COLUMN meta_title VARCHAR(255) DEFAULT NULL AFTER composition,
+  ADD COLUMN meta_description VARCHAR(255) DEFAULT NULL AFTER meta_title,
+  ADD COLUMN meta_keywords VARCHAR(255) DEFAULT NULL AFTER meta_description;

--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -1125,6 +1125,11 @@ public function showOrder(int $orderId): void
                 ],
                 ['label' => $product['variety']]
             ],
+            'meta' => [
+                'title'       => $product['meta_title'] ?? '',
+                'description' => $product['meta_description'] ?? '',
+                'keywords'    => $product['meta_keywords'] ?? ''
+            ]
         ]);
     }
 

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -110,6 +110,9 @@ class ProductsController
         $fullDesc      = trim($_POST['full_description'] ?? '');
         $compositionArr = array_filter(array_map('trim', $_POST['composition'] ?? []));
         $compositionJson = $compositionArr ? json_encode(array_values($compositionArr), JSON_UNESCAPED_UNICODE) : null;
+        $metaTitle      = trim($_POST['meta_title'] ?? '');
+        $metaDesc       = trim($_POST['meta_description'] ?? '');
+        $metaKeys       = trim($_POST['meta_keywords'] ?? '');
         $manufacturer  = trim($_POST['manufacturer'] ?? '');
         $originCountry = trim($_POST['origin_country'] ?? '');
         $boxSize       = (float)($_POST['box_size'] ?? 0);
@@ -183,6 +186,9 @@ class ProductsController
                         description     = ?,
                         full_description= ?,
                         composition     = ?,
+                        meta_title      = ?,
+                        meta_description= ?,
+                        meta_keywords   = ?,
                         manufacturer    = ?,
                         origin_country  = ?,
                         box_size        = ?,
@@ -194,8 +200,9 @@ class ProductsController
                         delivery_date   = ?,
                         is_active       = ?";
             $params = [
-                $typeId, $alias, $variety, $description, $fullDesc, $compositionJson, $manufacturer,
-                $originCountry, $boxSize, $boxUnit,
+                $typeId, $alias, $variety, $description, $fullDesc, $compositionJson,
+                $metaTitle, $metaDesc, $metaKeys,
+                $manufacturer, $originCountry, $boxSize, $boxUnit,
                 $unit, $price, $salePrice, $stockBoxes,
                 $deliveryDate, $isActive
             ];
@@ -213,12 +220,13 @@ class ProductsController
 
         } else {
             // INSERT
-            $columns      = "product_type_id,alias,variety,description,full_description,composition,manufacturer,origin_country,box_size,box_unit,unit,price,sale_price,stock_boxes,delivery_date,is_active";
-            // 16 placeholders corresponding to the columns above
-            $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
+            $columns      = "product_type_id,alias,variety,description,full_description,composition,meta_title,meta_description,meta_keywords,manufacturer,origin_country,box_size,box_unit,unit,price,sale_price,stock_boxes,delivery_date,is_active";
+            // 19 placeholders corresponding to the columns above
+            $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
             $params       = [
-                $typeId, $alias, $variety, $description, $fullDesc, $compositionJson, $manufacturer,
-                $originCountry, $boxSize, $boxUnit,
+                $typeId, $alias, $variety, $description, $fullDesc, $compositionJson,
+                $metaTitle, $metaDesc, $metaKeys,
+                $manufacturer, $originCountry, $boxSize, $boxUnit,
                 $unit, $price, $salePrice, $stockBoxes,
                 $deliveryDate, $isActive
             ];

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -42,6 +42,24 @@
            value="<?= htmlspecialchars($product['alias'] ?? '') ?>"
            class="w-full border px-2 py-1 rounded" required>
   </div>
+  <div>
+    <label class="block mb-1">Meta title</label>
+    <input name="meta_title" type="text"
+           value="<?= htmlspecialchars($product['meta_title'] ?? '') ?>"
+           class="w-full border px-2 py-1 rounded">
+  </div>
+  <div>
+    <label class="block mb-1">Meta description</label>
+    <input name="meta_description" type="text"
+           value="<?= htmlspecialchars($product['meta_description'] ?? '') ?>"
+           class="w-full border px-2 py-1 rounded">
+  </div>
+  <div>
+    <label class="block mb-1">Meta keywords</label>
+    <input name="meta_keywords" type="text"
+           value="<?= htmlspecialchars($product['meta_keywords'] ?? '') ?>"
+           class="w-full border px-2 py-1 rounded">
+  </div>
 
   <!-- Описание -->
   <div>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -2,6 +2,7 @@
   $points = (int)($_SESSION['points_balance'] ?? 0);
 
   /** Метаданные страницы */
+  $pageMeta = $meta ?? [];
   global $pdo;
   $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '/';
   $slugMap = [
@@ -29,6 +30,9 @@
               $meta = $row;
           }
       }
+  }
+  if (!empty($pageMeta)) {
+      $meta = array_merge($meta, array_filter($pageMeta, static fn($v) => $v !== null && $v !== ''));
   }
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- extend products table with meta title, description and keywords
- capture and store meta fields when creating or editing products
- allow overriding page meta data from views
- expose meta fields in product admin form
- pass meta data when showing a product

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685f69ec1688832cbd4364407e9aee05