### PR TITLE
Add SEO management app

### DIFF
--- a/database/2025_15_content_categories_meta.sql
+++ b/database/2025_15_content_categories_meta.sql
@@ -1,0 +1,4 @@
+ALTER TABLE content_categories
+  ADD COLUMN meta_title VARCHAR(255) DEFAULT NULL,
+  ADD COLUMN meta_description VARCHAR(255) DEFAULT NULL,
+  ADD COLUMN meta_keywords VARCHAR(255) DEFAULT NULL;

--- a/index.php
+++ b/index.php
@@ -534,6 +534,19 @@ switch ("$method $uri") {
         (new App\Controllers\AppsController($pdo))->toggleItem();
         break;
 
+    case 'GET /admin/apps/seo':
+        requireAdmin();
+        (new App\Controllers\SeoController($pdo))->index();
+        break;
+    case 'GET /admin/apps/seo/edit':
+        requireAdmin();
+        (new App\Controllers\SeoController($pdo))->edit();
+        break;
+    case 'POST /admin/apps/seo/save':
+        requireAdmin();
+        (new App\Controllers\SeoController($pdo))->save();
+        break;
+
     case 'GET /admin/settings':
         requireAdmin();
         (new App\Controllers\SettingsController($pdo))->index();

--- a/src/Controllers/SeoController.php
+++ b/src/Controllers/SeoController.php
@@ -1,0 +1,187 @@
+<?php
+namespace App\Controllers;
+
+use PDO;
+
+class SeoController
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    // Список всех страниц с метаданными
+    public function index(): void
+    {
+        $productTypes = $this->pdo->query(
+            "SELECT id, name, alias, meta_title, meta_description, meta_keywords FROM product_types ORDER BY id DESC"
+        )->fetchAll(PDO::FETCH_ASSOC);
+
+        $products = $this->pdo->query(
+            "SELECT p.id, p.variety, p.alias, t.alias AS type_alias, p.meta_title, p.meta_description, p.meta_keywords
+             FROM products p
+             JOIN product_types t ON t.id = p.product_type_id
+             ORDER BY p.id DESC"
+        )->fetchAll(PDO::FETCH_ASSOC);
+
+        $categories = $this->pdo->query(
+            "SELECT id, name, alias, meta_title, meta_description, meta_keywords
+             FROM content_categories ORDER BY id DESC"
+        )->fetchAll(PDO::FETCH_ASSOC);
+
+        $materials = $this->pdo->query(
+            "SELECT m.id, m.title, m.alias, c.alias AS cat_alias, m.meta_title, m.meta_description, m.meta_keywords
+             FROM materials m
+             JOIN content_categories c ON c.id = m.category_id
+             ORDER BY m.id DESC"
+        )->fetchAll(PDO::FETCH_ASSOC);
+
+        $pages = $this->pdo->query(
+            "SELECT page, title, description, keywords FROM metadata ORDER BY page"
+        )->fetchAll(PDO::FETCH_ASSOC);
+
+        viewAdmin('seo/index', [
+            'pageTitle'    => 'SEO',
+            'productTypes' => $productTypes,
+            'products'     => $products,
+            'categories'   => $categories,
+            'materials'    => $materials,
+            'pages'        => $pages,
+        ]);
+    }
+
+    // Форма редактирования
+    public function edit(): void
+    {
+        $type = $_GET['type'] ?? '';
+        $id   = (int)($_GET['id'] ?? 0);
+        $page = $_GET['page'] ?? '';
+        $data = null;
+
+        switch ($type) {
+            case 'product':
+                $stmt = $this->pdo->prepare(
+                    "SELECT id, meta_title, meta_description, meta_keywords,
+                            CONCAT(t.alias,'/',p.alias) AS path
+                     FROM products p
+                     JOIN product_types t ON t.id = p.product_type_id
+                     WHERE p.id = ?"
+                );
+                $stmt->execute([$id]);
+                $data = $stmt->fetch(PDO::FETCH_ASSOC);
+                break;
+            case 'product_type':
+                $stmt = $this->pdo->prepare(
+                    "SELECT id, meta_title, meta_description, meta_keywords,
+                            alias AS path FROM product_types WHERE id = ?"
+                );
+                $stmt->execute([$id]);
+                $data = $stmt->fetch(PDO::FETCH_ASSOC);
+                break;
+            case 'material':
+                $stmt = $this->pdo->prepare(
+                    "SELECT m.id, m.meta_title, m.meta_description, m.meta_keywords,
+                            CONCAT(c.alias,'/',m.alias) AS path
+                     FROM materials m
+                     JOIN content_categories c ON c.id = m.category_id
+                     WHERE m.id = ?"
+                );
+                $stmt->execute([$id]);
+                $data = $stmt->fetch(PDO::FETCH_ASSOC);
+                break;
+            case 'category':
+                $stmt = $this->pdo->prepare(
+                    "SELECT id, meta_title, meta_description, meta_keywords,
+                            alias AS path FROM content_categories WHERE id = ?"
+                );
+                $stmt->execute([$id]);
+                $data = $stmt->fetch(PDO::FETCH_ASSOC);
+                break;
+            case 'page':
+                $stmt = $this->pdo->prepare(
+                    "SELECT page, title, description, keywords FROM metadata WHERE page = ? LIMIT 1"
+                );
+                $stmt->execute([$page]);
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($row) { $data = $row; }
+                break;
+        }
+
+        viewAdmin('seo/edit', [
+            'pageTitle' => 'Редактировать SEO',
+            'type'      => $type,
+            'data'      => $data,
+        ]);
+    }
+
+    // Сохранение
+    public function save(): void
+    {
+        $type  = $_POST['type'] ?? '';
+        $id    = (int)($_POST['id'] ?? 0);
+        $page  = $_POST['page'] ?? '';
+
+        switch ($type) {
+            case 'product':
+                $stmt = $this->pdo->prepare(
+                    "UPDATE products SET meta_title=?, meta_description=?, meta_keywords=? WHERE id=?"
+                );
+                $stmt->execute([
+                    trim($_POST['meta_title'] ?? ''),
+                    trim($_POST['meta_description'] ?? ''),
+                    trim($_POST['meta_keywords'] ?? ''),
+                    $id,
+                ]);
+                break;
+            case 'product_type':
+                $stmt = $this->pdo->prepare(
+                    "UPDATE product_types SET meta_title=?, meta_description=?, meta_keywords=? WHERE id=?"
+                );
+                $stmt->execute([
+                    trim($_POST['meta_title'] ?? ''),
+                    trim($_POST['meta_description'] ?? ''),
+                    trim($_POST['meta_keywords'] ?? ''),
+                    $id,
+                ]);
+                break;
+            case 'material':
+                $stmt = $this->pdo->prepare(
+                    "UPDATE materials SET meta_title=?, meta_description=?, meta_keywords=? WHERE id=?"
+                );
+                $stmt->execute([
+                    trim($_POST['meta_title'] ?? ''),
+                    trim($_POST['meta_description'] ?? ''),
+                    trim($_POST['meta_keywords'] ?? ''),
+                    $id,
+                ]);
+                break;
+            case 'category':
+                $stmt = $this->pdo->prepare(
+                    "UPDATE content_categories SET meta_title=?, meta_description=?, meta_keywords=? WHERE id=?"
+                );
+                $stmt->execute([
+                    trim($_POST['meta_title'] ?? ''),
+                    trim($_POST['meta_description'] ?? ''),
+                    trim($_POST['meta_keywords'] ?? ''),
+                    $id,
+                ]);
+                break;
+            case 'page':
+                $stmt = $this->pdo->prepare(
+                    "REPLACE INTO metadata (page, title, description, keywords) VALUES (?,?,?,?)"
+                );
+                $stmt->execute([
+                    $page,
+                    trim($_POST['title'] ?? ''),
+                    trim($_POST['description'] ?? ''),
+                    trim($_POST['keywords'] ?? ''),
+                ]);
+                break;
+        }
+
+        header('Location: /admin/apps/seo');
+        exit;
+    }
+}

--- a/src/Views/admin/apps/index.php
+++ b/src/Views/admin/apps/index.php
@@ -16,3 +16,8 @@
   </div>
   <a href="/admin/apps/sitemap" class="text-[#C86052] hover:underline mt-4 inline-block">Настройки</a>
 </div>
+
+<div class="bg-white p-4 rounded shadow mt-6">
+  <h2 class="text-lg font-semibold mb-2">SEO</h2>
+  <a href="/admin/apps/seo" class="text-[#C86052] hover:underline">Открыть</a>
+</div>

--- a/src/Views/admin/seo/edit.php
+++ b/src/Views/admin/seo/edit.php
@@ -1,0 +1,43 @@
+<?php /** @var string $type */ ?>
+<?php /** @var array|null $data */ ?>
+<form action="/admin/apps/seo/save" method="post" class="space-y-4 bg-white p-6 rounded shadow max-w-lg mx-auto">
+  <input type="hidden" name="type" value="<?= htmlspecialchars($type) ?>">
+  <?php if ($type !== 'page'): ?>
+    <input type="hidden" name="id" value="<?= (int)($data['id'] ?? 0) ?>">
+    <div>
+      <label class="block mb-1">Страница</label>
+      <input type="text" value="<?= htmlspecialchars('/'.($data['path'] ?? '')) ?>" class="w-full border px-2 py-1 rounded bg-gray-100" disabled>
+    </div>
+    <div>
+      <label class="block mb-1">Meta title</label>
+      <input name="meta_title" type="text" value="<?= htmlspecialchars($data['meta_title'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+    </div>
+    <div>
+      <label class="block mb-1">Meta description</label>
+      <input name="meta_description" type="text" value="<?= htmlspecialchars($data['meta_description'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+    </div>
+    <div>
+      <label class="block mb-1">Meta keywords</label>
+      <input name="meta_keywords" type="text" value="<?= htmlspecialchars($data['meta_keywords'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+    </div>
+  <?php else: ?>
+    <input type="hidden" name="page" value="<?= htmlspecialchars($data['page'] ?? '') ?>">
+    <div>
+      <label class="block mb-1">Страница</label>
+      <input type="text" value="<?= htmlspecialchars('/'.($data['page'] ?? '')) ?>" class="w-full border px-2 py-1 rounded bg-gray-100" disabled>
+    </div>
+    <div>
+      <label class="block mb-1">Title</label>
+      <input name="title" type="text" value="<?= htmlspecialchars($data['title'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+    </div>
+    <div>
+      <label class="block mb-1">Description</label>
+      <input name="description" type="text" value="<?= htmlspecialchars($data['description'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+    </div>
+    <div>
+      <label class="block mb-1">Keywords</label>
+      <input name="keywords" type="text" value="<?= htmlspecialchars($data['keywords'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+    </div>
+  <?php endif; ?>
+  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+</form>

--- a/src/Views/admin/seo/index.php
+++ b/src/Views/admin/seo/index.php
@@ -1,0 +1,137 @@
+<?php
+/** @var array $productTypes */
+/** @var array $products */
+/** @var array $categories */
+/** @var array $materials */
+/** @var array $pages */
+?>
+
+<h2 class="text-xl font-semibold mb-2">Категории товаров</h2>
+<table class="min-w-full bg-white rounded shadow overflow-hidden mb-6">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">Страница</th>
+      <th class="p-3 text-left font-semibold">Title</th>
+      <th class="p-3 text-left font-semibold">Description</th>
+      <th class="p-3 text-left font-semibold">Keywords</th>
+      <th class="p-3 text-center font-semibold">Редактировать</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($productTypes as $pt): ?>
+    <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <td class="p-3 text-gray-600">/catalog/<?= htmlspecialchars($pt['alias']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($pt['meta_title']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($pt['meta_description']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($pt['meta_keywords']) ?></td>
+      <td class="p-3 text-center">
+        <a href="/admin/apps/seo/edit?type=product_type&id=<?= $pt['id'] ?>" class="text-[#C86052] hover:underline">Редактировать</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+
+<h2 class="text-xl font-semibold mb-2">Товары</h2>
+<table class="min-w-full bg-white rounded shadow overflow-hidden mb-6">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">Страница</th>
+      <th class="p-3 text-left font-semibold">Title</th>
+      <th class="p-3 text-left font-semibold">Description</th>
+      <th class="p-3 text-left font-semibold">Keywords</th>
+      <th class="p-3 text-center font-semibold">Редактировать</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($products as $p): ?>
+    <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <td class="p-3 text-gray-600">/catalog/<?= htmlspecialchars($p['type_alias'].'/'.$p['alias']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($p['meta_title']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($p['meta_description']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($p['meta_keywords']) ?></td>
+      <td class="p-3 text-center">
+        <a href="/admin/apps/seo/edit?type=product&id=<?= $p['id'] ?>" class="text-[#C86052] hover:underline">Редактировать</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+
+<h2 class="text-xl font-semibold mb-2">Категории материалов</h2>
+<table class="min-w-full bg-white rounded shadow overflow-hidden mb-6">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">Страница</th>
+      <th class="p-3 text-left font-semibold">Title</th>
+      <th class="p-3 text-left font-semibold">Description</th>
+      <th class="p-3 text-left font-semibold">Keywords</th>
+      <th class="p-3 text-center font-semibold">Редактировать</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($categories as $c): ?>
+    <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <td class="p-3 text-gray-600">/content/<?= htmlspecialchars($c['alias']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($c['meta_title']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($c['meta_description']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($c['meta_keywords']) ?></td>
+      <td class="p-3 text-center">
+        <a href="/admin/apps/seo/edit?type=category&id=<?= $c['id'] ?>" class="text-[#C86052] hover:underline">Редактировать</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+
+<h2 class="text-xl font-semibold mb-2">Материалы</h2>
+<table class="min-w-full bg-white rounded shadow overflow-hidden mb-6">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">Страница</th>
+      <th class="p-3 text-left font-semibold">Title</th>
+      <th class="p-3 text-left font-semibold">Description</th>
+      <th class="p-3 text-left font-semibold">Keywords</th>
+      <th class="p-3 text-center font-semibold">Редактировать</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($materials as $m): ?>
+    <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <td class="p-3 text-gray-600">/content/<?= htmlspecialchars($m['cat_alias'].'/'.$m['alias']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($m['meta_title']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($m['meta_description']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($m['meta_keywords']) ?></td>
+      <td class="p-3 text-center">
+        <a href="/admin/apps/seo/edit?type=material&id=<?= $m['id'] ?>" class="text-[#C86052] hover:underline">Редактировать</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+
+<h2 class="text-xl font-semibold mb-2">Системные страницы</h2>
+<table class="min-w-full bg-white rounded shadow overflow-hidden">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">Страница</th>
+      <th class="p-3 text-left font-semibold">Title</th>
+      <th class="p-3 text-left font-semibold">Description</th>
+      <th class="p-3 text-left font-semibold">Keywords</th>
+      <th class="p-3 text-center font-semibold">Редактировать</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($pages as $p): ?>
+    <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <td class="p-3 text-gray-600">/<?= htmlspecialchars($p['page']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($p['title']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($p['description']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($p['keywords']) ?></td>
+      <td class="p-3 text-center">
+        <a href="/admin/apps/seo/edit?type=page&page=<?= htmlspecialchars($p['page']) ?>" class="text-[#C86052] hover:underline">Редактировать</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- add SEO app with routes and controller
- display SEO option in admin apps
- provide SQL migration to extend `content_categories`
- create views for SEO listing and editing
- include new routes in main router

## Testing
- `composer install`
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_685f6f5c11f0832c93ac59a29bf15eae