### PR TITLE
Fix pageTitle extraction

### DIFF
--- a/index.php
+++ b/index.php
@@ -86,11 +86,11 @@ if (file_exists($vendorAutoload)) {
 // Функция для рендеринга админских шаблонов
 function viewAdmin(string $template, array $data = []): void
 {
+    $pageTitle = $data['pageTitle'] ?? '';
     extract($data, EXTR_SKIP);
     ob_start();
     require __DIR__ . "/src/Views/admin/{$template}.php";
     $content = ob_get_clean();
-    $pageTitle = $data['pageTitle'] ?? '';
     require __DIR__ . '/src/Views/layouts/admin_main.php';
 }
 


### PR DESCRIPTION
## Summary
- fix `viewAdmin` helper so `$pageTitle` persists after extracting variables

## Testing
- `composer install`
- `./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_685f98ff6c1c832c9dde30b73eec0bd0