### PR TITLE
Fix SEO edit data handling

### DIFF
--- a/src/Controllers/SeoController.php
+++ b/src/Controllers/SeoController.php
@@ -70,7 +70,10 @@ class SeoController
                      WHERE p.id = ?"
                 );
                 $stmt->execute([$id]);
-                $data = $stmt->fetch(PDO::FETCH_ASSOC);
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($row !== false) {
+                    $data = $row;
+                }
                 break;
             case 'product_type':
                 $stmt = $this->pdo->prepare(
@@ -78,7 +81,10 @@ class SeoController
                             alias AS path FROM product_types WHERE id = ?"
                 );
                 $stmt->execute([$id]);
-                $data = $stmt->fetch(PDO::FETCH_ASSOC);
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($row !== false) {
+                    $data = $row;
+                }
                 break;
             case 'material':
                 $stmt = $this->pdo->prepare(
@@ -89,7 +95,10 @@ class SeoController
                      WHERE m.id = ?"
                 );
                 $stmt->execute([$id]);
-                $data = $stmt->fetch(PDO::FETCH_ASSOC);
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($row !== false) {
+                    $data = $row;
+                }
                 break;
             case 'category':
                 $stmt = $this->pdo->prepare(
@@ -97,7 +106,10 @@ class SeoController
                             alias AS path FROM content_categories WHERE id = ?"
                 );
                 $stmt->execute([$id]);
-                $data = $stmt->fetch(PDO::FETCH_ASSOC);
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($row !== false) {
+                    $data = $row;
+                }
                 break;
             case 'page':
                 $stmt = $this->pdo->prepare(
@@ -105,7 +117,9 @@ class SeoController
                 );
                 $stmt->execute([$page]);
                 $row = $stmt->fetch(PDO::FETCH_ASSOC);
-                if ($row) { $data = $row; }
+                if ($row !== false) {
+                    $data = $row;
+                }
                 break;
         }
 


### PR DESCRIPTION
## Summary
- avoid errors when SEO entry is missing

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685fd3760db8832c8fb1e8f924f5a9c2