### PR TITLE
Use product type metadata on category pages

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -1150,18 +1150,22 @@ public function showOrder(int $orderId): void
         $pStmt->execute([$type['id']]);
         $products = $pStmt->fetchAll(PDO::FETCH_ASSOC);
 
-        $types = $this->pdo->query(
-            "SELECT id, name, alias FROM product_types ORDER BY name"
-        )->fetchAll(PDO::FETCH_ASSOC);
-
         view('client/catalog', [
-            'products'    => $products,
-            'types'       => $types,
-            'meta'        => ['h1' => $type['h1'] ?? $type['name'], 'text' => $type['text'] ?? ''],
+            'products'          => $products,
+            'meta'             => [
+                'title'       => $type['meta_title']       ?? '',
+                'description' => $type['meta_description'] ?? '',
+                'keywords'    => $type['meta_keywords']    ?? '',
+                'h1'          => $type['h1']              ?? $type['name'],
+                'text'        => $type['text']            ?? '',
+            ],
+            'short_description' => $type['short_description'] ?? '',
             'breadcrumbs' => [
                 ['label' => 'Каталог', 'url' => '/catalog'],
                 ['label' => $type['name']]
             ],
+            'hideFilters'  => true,
+            'showMetaText' => false,
         ]);
     }
 }

--- a/src/Views/client/catalog.php
+++ b/src/Views/client/catalog.php
@@ -1,9 +1,28 @@
-<?php /** @var array $products @var string|null $userName */ ?>
+<?php
+/** @var array $products */
+/** @var array $meta */
+/** @var string $short_description */
+/** @var bool $hideFilters */
+?>
 
 <main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 min-h-screen pb-24">
 
+  <?php if (!empty($meta['h1']) || !empty($short_description)): ?>
+    <div class="max-w-screen-lg mx-auto px-4 pt-6 pb-4 text-gray-700 space-y-2">
+      <?php if (!empty($meta['h1'])): ?>
+        <h1 class="text-2xl font-bold">
+          <?= htmlspecialchars($meta['h1']) ?>
+        </h1>
+      <?php endif; ?>
+      <?php if (!empty($short_description)): ?>
+        <p class="text-sm">
+          <?= nl2br(htmlspecialchars($short_description)) ?>
+        </p>
+      <?php endif; ?>
+    </div>
+  <?php endif; ?>
 
-
+  <?php if (empty($hideFilters)): ?>
   <!-- Поле поиска и фильтры -->
   <div class="px-4 mb-6">
     <div class="bg-white rounded-2xl shadow-lg p-4 space-y-4">
@@ -24,6 +43,7 @@
       </div>
     </div>
   </div>
+  <?php endif; ?>
 
   <!-- Сетка товаров -->
   <div class="px-4">
@@ -48,6 +68,13 @@
     <?php endif; ?>
   </div>
 
+  <?php if (!empty($meta['text'])): ?>
+    <div class="max-w-screen-lg mx-auto px-4 py-6 text-gray-700 text-sm">
+      <p><?= nl2br(htmlspecialchars($meta['text'])) ?></p>
+    </div>
+  <?php endif; ?>
+
+  <?php if (empty($hideFilters)): ?>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const search = document.getElementById('catalogSearch');
@@ -82,5 +109,6 @@
       }));
     });
   </script>
+  <?php endif; ?>
 
 </main>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -321,8 +321,10 @@
       </nav>
     <?php endif; ?>
     <?= $content ?>
-    <?php if (!empty($meta['text'])): ?>
-      <div class="hidden lg:block max-w-screen-lg mx-auto px-4 pb-24 text-gray-700 text-sm">
+    <?php
+      $showMetaText = $showMetaText ?? true;
+      if (!empty($meta['text']) && $showMetaText): ?>
+      <div class="max-w-screen-lg mx-auto px-4 pb-24 text-gray-700 text-sm">
         <?php if (!empty($meta['h1'])): ?>
           <h1 class="text-2xl font-bold mb-4"><?= htmlspecialchars($meta['h1']) ?></h1>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- load meta info for product type pages
- display category h1 and short description at the top
- hide filters on category pages
- render category description below product list
- allow layout text block to be disabled

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686023e04700832cac3ab0cee16b4e0d