### PR TITLE
Update news slider to fade with dot nav

### DIFF
--- a/src/Views/client/_material_card.php
+++ b/src/Views/client/_material_card.php
@@ -3,7 +3,7 @@
 ?>
 <a href="/content/<?= urlencode($material['cat_alias']) ?>/<?= urlencode($material['mat_alias']) ?>" class="block bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-shadow duration-200 h-full overflow-hidden">
   <?php if (!empty($material['image_path'])): ?>
-    <img src="<?= htmlspecialchars($material['image_path']) ?>" alt="<?= htmlspecialchars($material['title']) ?>" class="w-full h-40 object-cover">
+    <img src="<?= htmlspecialchars($material['image_path']) ?>" alt="<?= htmlspecialchars($material['title']) ?>" class="w-full h-40 object-cover rounded-t-2xl">
   <?php endif; ?>
   <div class="p-3 sm:p-4">
     <h3 class="text-base sm:text-lg font-semibold text-gray-800 mb-2">

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -186,6 +186,20 @@
       background: #374151;
     }
 
+    .embla-news {
+      position: relative;
+    }
+    .embla-news .embla__controls {
+      position: absolute;
+      right: 0.5rem;
+      bottom: 0.5rem;
+      margin-top: 0;
+      justify-content: flex-end;
+    }
+    .embla-news .embla__dots {
+      justify-content: flex-end;
+    }
+
   </style>
 
   
@@ -755,8 +769,9 @@
   });
 </script>
 
-<script src="https://cdn.jsdelivr.net/npm/embla-carousel@8/embla-carousel.umd.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/embla-carousel-autoplay@6/embla-carousel-autoplay.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/embla-carousel@8/embla-carousel.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/embla-carousel-autoplay@6/embla-carousel-autoplay.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/embla-carousel-fade@8/embla-carousel-fade.umd.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     // Drag free carousels
@@ -776,7 +791,10 @@
     if (news) {
       const viewport = news.querySelector('.embla__viewport');
       const dotsContainer = news.querySelector('.embla__dots');
-      const embla = EmblaCarousel(viewport, { loop: true }, [EmblaCarouselAutoplay({ delay: 4000, stopOnInteraction: false })]);
+      const embla = EmblaCarousel(viewport, { loop: true }, [
+        EmblaCarouselAutoplay({ delay: 4000, stopOnInteraction: false }),
+        EmblaCarouselFade()
+      ]);
       const slides = embla.slideNodes();
       const dots = slides.map((_, i) => {
         const b = document.createElement('button');


### PR DESCRIPTION
## Summary
- use Embla fade plugin for news slider
- position navigation dots in the bottom right corner
- round news images

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68603a19a39c832cbd5bc1a5b85eb80d