### PR TITLE
Add manager pages with filtering

### DIFF
--- a/index.php
+++ b/index.php
@@ -91,7 +91,12 @@ function viewAdmin(string $template, array $data = []): void
     ob_start();
     require __DIR__ . "/src/Views/admin/{$template}.php";
     $content = ob_get_clean();
-    require __DIR__ . '/src/Views/layouts/admin_main.php';
+    $role = $_SESSION['role'] ?? '';
+    if ($role === 'manager') {
+        require __DIR__ . '/src/Views/layouts/manager_main.php';
+    } else {
+        require __DIR__ . '/src/Views/layouts/admin_main.php';
+    }
 }
 
 // Render manager templates (reuse admin views with manager layout)

--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -1,4 +1,5 @@
 <?php /** @var array $order @var array $items */ ?>
+<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
 <div class="space-y-4">
   <div class="flex justify-between items-center bg-white p-4 rounded shadow">
     <div class="flex flex-wrap items-center gap-2">
@@ -25,7 +26,7 @@
             <?= ' ' . $it['box_size'] . ' ' . htmlspecialchars($it['box_unit']) ?>
           <?php endif; ?>
         </span>
-        <form action="/admin/orders/update-item" method="post" class="flex items-center space-x-2">
+        <form action="<?= $base ?>/orders/update-item" method="post" class="flex items-center space-x-2">
           <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
           <input type="hidden" name="product_id" value="<?= $it['product_id'] ?>">
           <input type="number" name="quantity" value="<?= $it['quantity'] ?>" step="0.01" class="w-20 border px-1 py-0.5 rounded"> кг
@@ -74,19 +75,19 @@
         'delivered'  => 'Выполнен',
         'cancelled'  => 'Отменен'
       ] as $st => $label): ?>
-      <form action="/admin/orders/status" method="post">
+      <form action="<?= $base ?>/orders/status" method="post">
         <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
         <input type="hidden" name="status" value="<?= $st ?>">
         <button class="px-3 py-1 rounded text-white <?= $btnClasses[$st] ?>" type="submit"><?= $label ?></button>
       </form>
     <?php endforeach; ?>
-    <form class="ml-auto" action="/admin/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
+    <form class="ml-auto" action="<?= $base ?>/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
       <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
       <button class="px-3 py-1 rounded text-white bg-red-700 hover:bg-red-800" type="submit">Удалить</button>
     </form>
   </div>
 
   <div>
-    <a href="/admin/orders" class="inline-block px-4 py-2 rounded text-white bg-purple-700 hover:bg-purple-800">Вернуться к заказам</a>
+    <a href="<?= $base ?>/orders" class="inline-block px-4 py-2 rounded text-white bg-purple-700 hover:bg-purple-800">Вернуться к заказам</a>
   </div>
 </div>

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -6,7 +6,8 @@
  * @var string     $box_unit
  */
 ?>
-<form action="/admin/products/save" method="post" enctype="multipart/form-data"
+<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
+<form action="<?= $base ?>/products/save" method="post" enctype="multipart/form-data"
       class="bg-white p-6 rounded shadow max-w-lg mx-auto">
 
   <?php if (!empty($product['id'])): ?>
@@ -32,7 +33,7 @@
           </option>
         <?php endforeach; ?>
       </select>
-      <a href="/admin/product-types/edit" class="ml-2 text-[#C86052] hover:underline">
+      <a href="<?= $base ?>/product-types/edit" class="ml-2 text-[#C86052] hover:underline">
         Добавить
       </a>
     </div>

--- a/src/Views/admin/products/index.php
+++ b/src/Views/admin/products/index.php
@@ -1,40 +1,52 @@
 <?php /** @var array $products */ ?>
+<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; ?>
+<?php $base = $isManager ? '/manager' : '/admin'; ?>
 
-<a href="/admin/products/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
+<a href="<?= $base ?>/products/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
   <span class="material-icons-round text-base mr-1">add</span> Добавить товар</a>
 
 <table class="min-w-full bg-white rounded shadow overflow-hidden">
   <thead class="bg-gray-200 text-gray-700">
     <tr>
       <th class="p-3 text-left font-semibold">Продукт</th>
+      <?php if (!$isManager): ?>
       <th class="p-3 text-left font-semibold">Алиас</th>
+      <?php endif; ?>
       <th class="p-3 text-left font-semibold">Сорт</th>
       <th class="p-3 text-left font-semibold">Вес ящика</th>
       <th class="p-3 text-left font-semibold">Цена</th>
+      <?php if (!$isManager): ?>
       <th class="p-3 text-left font-semibold">Остаток (ящиков)</th>
+      <?php endif; ?>
       <th class="p-3 text-center font-semibold">Активен</th>
+      <?php if (!$isManager): ?>
       <th class="p-3 text-center font-semibold">Удалить</th>
+      <?php endif; ?>
     </tr>
   </thead>
   <tbody>
     <?php foreach ($products as $p): ?>
       <tr class="border-b hover:bg-gray-50 transition-all duration-200">
         <td class="p-3 font-medium text-gray-600">
-          <a href="/admin/products/edit?id=<?= $p['id'] ?>" class="text-[#C86052] hover:underline">
+          <a href="<?= $base ?>/products/edit?id=<?= $p['id'] ?>" class="text-[#C86052] hover:underline">
             <?= htmlspecialchars($p['product']) ?>
           </a>
         </td>
+        <?php if (!$isManager): ?>
         <td class="p-3 text-gray-600">
           <?= htmlspecialchars($p['alias']) ?>
         </td>
+        <?php endif; ?>
         <td class="p-3 text-gray-600"><?= htmlspecialchars($p['variety']) ?></td>
         <td class="p-3 text-gray-600">
           <?= $p['box_size'] ?> <?= htmlspecialchars($p['box_unit']) ?>
         </td>
         <td class="p-3 text-gray-600"><?= $p['price'] ?> ₽/<?= $p['unit'] ?></td>
+        <?php if (!$isManager): ?>
         <td class="p-3 text-gray-600"><?= $p['stock_boxes'] ?></td>
+        <?php endif; ?>
         <td class="p-3 text-center">
-          <form action="/admin/products/toggle" method="post" class="inline-block">
+          <form action="<?= $base ?>/products/toggle" method="post" class="inline-block">
             <input type="hidden" name="id" value="<?= $p['id'] ?>">
             <label class="relative inline-flex items-center cursor-pointer">
               <input type="checkbox" name="active" onchange="this.form.submit()" <?= $p['is_active'] ? 'checked' : '' ?> class="sr-only peer">
@@ -42,14 +54,16 @@
             </label>
           </form>
         </td>
+        <?php if (!$isManager): ?>
         <td class="p-3 text-center">
-          <form action="/admin/products/delete" method="post" onsubmit="return confirm('Удалить товар?');">
+          <form action="<?= $base ?>/products/delete" method="post" onsubmit="return confirm('Удалить товар?');">
             <input type="hidden" name="id" value="<?= $p['id'] ?>">
             <button type="submit" class="text-red-600">
               <span class="material-icons-round">delete</span>
             </button>
           </form>
         </td>
+        <?php endif; ?>
       </tr>
     <?php endforeach; ?>
   </tbody>

--- a/src/Views/admin/users/edit.php
+++ b/src/Views/admin/users/edit.php
@@ -1,5 +1,6 @@
 <?php /** @var array|null $user */ ?>
 <?php $isNew = empty($user); ?>
+<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
 
 <?php if (!empty($_GET['error'])): ?>
   <div class="bg-red-50 border-l-4 border-red-400 p-3 mb-4 rounded">
@@ -8,7 +9,7 @@
 <?php endif; ?>
 
 <?php if ($isNew): ?>
-  <form action="/admin/users/save" method="post" class="bg-white p-6 rounded shadow max-w-md space-y-4">
+  <form action="<?= $base ?>/users/save" method="post" class="bg-white p-6 rounded shadow max-w-md space-y-4">
     <div>
       <label class="block mb-1">Имя</label>
       <input name="name" type="text" class="w-full border px-2 py-1 rounded" required>
@@ -32,7 +33,7 @@
     <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Создать</button>
   </form>
 <?php else: ?>
-  <form action="/admin/users/save" method="post" class="bg-white p-6 rounded shadow max-w-md space-y-4">
+  <form action="<?= $base ?>/users/save" method="post" class="bg-white p-6 rounded shadow max-w-md space-y-4">
     <input type="hidden" name="id" value="<?= $user['id'] ?>">
     <div>
       <label class="block mb-1">Имя</label>

--- a/src/Views/admin/users/index.php
+++ b/src/Views/admin/users/index.php
@@ -1,15 +1,19 @@
 <?php /** @var array $users */ ?>
+<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; ?>
+<?php $base = $isManager ? '/manager' : '/admin'; ?>
 <form method="get" class="mb-4 flex">
   <input type="text" name="q" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Телефон или адрес" class="border rounded px-3 py-2 mr-2 flex-grow">
   <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Поиск</button>
 </form>
-<a href="/admin/users/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
+<a href="<?= $base ?>/users/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
   <span class="material-icons-round text-base mr-1">add</span> Добавить пользователя
 </a>
 <table class="min-w-full bg-white rounded shadow overflow-hidden">
   <thead class="bg-gray-200 text-gray-700">
     <tr>
+      <?php if (!$isManager): ?>
       <th class="p-3 text-left font-semibold">ID</th>
+      <?php endif; ?>
       <th class="p-3 text-left font-semibold">Имя</th>
       <th class="p-3 text-left font-semibold">Телефон</th>
       <th class="p-3 text-left font-semibold">Адрес</th>
@@ -19,10 +23,12 @@
   <tbody>
     <?php foreach($users as $u): ?>
     <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <?php if (!$isManager): ?>
       <td class="p-3 font-medium text-gray-600"><?= $u['id'] ?></td>
+      <?php endif; ?>
       <td class="p-3">
         <div class="flex items-center">
-            <a href="/admin/users/edit?id=<?= $u['id'] ?>" class="">
+            <a href="<?= $base ?>/users/edit?id=<?= $u['id'] ?>" class="">
                 <span class="font-medium"><?= htmlspecialchars($u['name']) ?></span>
             </a>
         </div>
@@ -30,7 +36,7 @@
       <td class="p-3 text-gray-600"><?= htmlspecialchars($u['phone']) ?></td>
       <td class="p-3 text-gray-600"><?= htmlspecialchars($u['address'] ?? '') ?></td>
       <td class="p-3 text-center">
-        <form action="/admin/users/toggle-block" method="post" class="inline-block">
+        <form action="<?= $base ?>/users/toggle-block" method="post" class="inline-block">
           <input type="hidden" name="id" value="<?= $u['id'] ?>">
           <label class="relative inline-flex items-center cursor-pointer">
             <input type="checkbox" onchange="this.form.submit()" <?= $u['is_blocked'] ? 'checked' : '' ?> class="sr-only peer">


### PR DESCRIPTION
## Summary
- show manager layout for manager role
- add manager filter in orders list
- adjust views for manager-friendly users and products pages
- support manager routes in controllers and templates

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686355538800832c865b6f4917fc2314