### PR TITLE
Add partner role and ruble balance

### DIFF
--- a/database/2025_16_partner_balance.sql
+++ b/database/2025_16_partner_balance.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users
+  MODIFY role enum('client','admin','courier','manager','partner') NOT NULL DEFAULT 'client';
+
+ALTER TABLE users
+  ADD COLUMN rub_balance int NOT NULL DEFAULT 0 AFTER points_balance;

--- a/index.php
+++ b/index.php
@@ -31,11 +31,11 @@ try {
 }
 
 if (!empty($_SESSION['user_id'])) {
-    $stmtBalance = $pdo->prepare("SELECT points_balance FROM users WHERE id = ?");
+    $stmtBalance = $pdo->prepare("SELECT points_balance, rub_balance FROM users WHERE id = ?");
     $stmtBalance->execute([ $_SESSION['user_id'] ]);
-    // Если пользователь найден, сохраняем баланс в сессию
-    $bal = $stmtBalance->fetchColumn();
-    $_SESSION['points_balance'] = $bal !== false ? (int)$bal : 0;
+    $bal = $stmtBalance->fetch(PDO::FETCH_ASSOC);
+    $_SESSION['points_balance'] = $bal !== false ? (int)$bal['points_balance'] : 0;
+    $_SESSION['rub_balance'] = $bal !== false ? (int)$bal['rub_balance'] : 0;
 }
 
 // -------------------------------------------------------
@@ -128,7 +128,7 @@ $method = $_SERVER['REQUEST_METHOD'];
 function requireClient(): void
 {
     $role = $_SESSION['role'] ?? '';
-    if (!in_array($role, ['client','admin'], true)) {
+    if (!in_array($role, ['client','partner','admin'], true)) {
         header('Location: /login');
         exit;
     }

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -102,9 +102,9 @@ public function register(): void
         // 1) Вставляем нового пользователя
         $stmt = $this->pdo->prepare("
             INSERT INTO users 
-                (role, name, phone, password_hash, referral_code, referred_by, has_used_referral_coupon, points_balance, created_at)
+                (role, name, phone, password_hash, referral_code, referred_by, has_used_referral_coupon, points_balance, rub_balance, created_at)
             VALUES 
-                ('client', ?, ?, ?, ?, ?, 0, 0, NOW())
+                ('client', ?, ?, ?, ?, ?, 0, 0, 0, NOW())
         ");
         $stmt->execute([$name, $phone, $pinHash, $newCode, $referredBy]);
         $userId = (int)$this->pdo->lastInsertId();
@@ -140,6 +140,7 @@ public function register(): void
     // Новый пользователь получает баланс 0 при регистрации
     $_SESSION['points_balance'] = 0;
 
+    $_SESSION['rub_balance'] = 0;
     unset($_SESSION['reg_verified'], $_SESSION['reg_phone'], $_SESSION['reg_code']);
     unset($_SESSION['invite_code']);
 
@@ -174,7 +175,7 @@ public function register(): void
         }
 
         $stmt = $this->pdo->prepare(
-            "SELECT id, role, password_hash, name, referral_code, points_balance
+            "SELECT id, role, password_hash, name, referral_code, points_balance, rub_balance
              FROM users
              WHERE phone = ?"
         );
@@ -185,6 +186,7 @@ public function register(): void
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['role']    = $user['role'];
             $_SESSION['name']    = $user['name'];
+            $_SESSION['rub_balance'] = (int)$user['rub_balance'];
             $_SESSION['points_balance'] = (int)$user['points_balance'];
             $_SESSION['referral_code']  = $user['referral_code'];
             

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -9,7 +9,7 @@ class User extends Model
 
     protected $fillable = [
         'name', 'phone', 'password_hash',
-        'referral_code', 'referred_by', 'points_balance'
+        'referral_code', 'referred_by', 'points_balance', 'rub_balance'
     ];
 
     protected $hidden = [

--- a/src/Views/admin/users/edit.php
+++ b/src/Views/admin/users/edit.php
@@ -50,6 +50,7 @@
         <option value="courier" <?= $user['role']==='courier'?'selected':'' ?>>Курьер</option>
         <option value="admin" <?= $user['role']==='admin'?'selected':'' ?>>Админ</option>
         <option value="manager" <?= $user['role']==='manager'?'selected':'' ?>>Менеджер</option>
+        <option value="partner" <?= $user['role']==='partner'?'selected':'' ?>>Партнёр</option>
       </select>
     </div>
     <div class="flex items-center space-x-2">

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -135,7 +135,7 @@
       <?php endif; ?>
 
       <!-- Кнопка «В корзину» или «Войдите» -->
-      <?php if ((string)($_SESSION['role'] ?? '') === 'client' && $active): ?>
+      <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner']) && $active): ?>
         <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $p['id'] ?>" data-name="<?= htmlspecialchars($p['product'] . ($p['variety'] ? ' ' . $p['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
           <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
           <div class="flex items-center space-x-2">

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -75,7 +75,7 @@
             </div>
           <?php endif; ?>
 
-          <?php if ((string)($_SESSION['role'] ?? '') === 'client' && $active): ?>
+          <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner']) && $active): ?>
             <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $product['id'] ?>" data-name="<?= htmlspecialchars($product['product'] . ($product['variety'] ? ' ' . $product['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
               <input type="hidden" name="product_id" value="<?= $product['id'] ?>">
               <div class="flex items-center space-x-2">

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -423,7 +423,7 @@
       </li>
       
       <!-- Мои заказы -->
-      <?php if ($role === 'client'): ?>
+      <?php if (in_array($role, ['client','partner'])): ?>
         <li class="flex-1 mx-1">
           <a href="/orders" class="nav-item flex flex-col items-center py-3 px-2 rounded-2xl transition-all <?= isActive('/orders') ?>">
             <span class="material-icons-round text-xl mb-1">receipt_long</span>
@@ -440,7 +440,7 @@
       <?php endif; ?>
 
       <!-- Профиль -->
-      <?php if ($role === 'client'): ?>
+      <?php if (in_array($role, ['client','partner'])): ?>
         <li class="flex-1">
           <a href="/profile" class="nav-item flex flex-col items-center py-3 px-2 rounded-2xl transition-all <?= isActive('/profile') ?>">
             <span class="material-icons-round text-xl mb-1">person</span>


### PR DESCRIPTION
## Summary
- introduce a new DB migration to add partner role and ruble balance field
- refresh session with the new column and allow partners as clients
- extend AuthController to work with rub_balance
- adjust User model and admin UI
- update client views so partners behave like clients

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68638830884c832c8fb71e8125bfc101