### PR TITLE
Add insert example for system page metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,15 @@ Run `bin/generate_sitemap.php` regularly to refresh `sitemap.xml`. On hosting wi
 
 The schedule assumes cron uses the Asia/Krasnoyarsk time zone. If the server works in UTC set `0 1 * * *` instead.
 
+
+### System page metadata
+
+Use the `metadata` table to customize meta tags for built-in pages. These pages have no records yet, so insert all fields explicitly:
+
+```sql
+INSERT INTO metadata (page, title, description, keywords, h1, text) VALUES
+  ('register',  'Регистрация – BerryGo', 'Создайте аккаунт для заказа свежих ягод', '', 'Регистрация', ''),
+  ('reset-pin', 'Сброс PIN – BerryGo', 'Восстановите код доступа к приложению', '', 'Сброс PIN', ''),
+  ('login',     'Вход – BerryGo', 'Авторизуйтесь для доступа к личному кабинету', '', 'Вход', '');
+```
+

--- a/src/Views/layouts/auth.php
+++ b/src/Views/layouts/auth.php
@@ -1,10 +1,36 @@
 <?php
   $pageMeta = $meta ?? [];
-  $meta = array_merge([
-    'title' => 'BerryGo',
+  global $pdo;
+  $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '/';
+  $slugMap = [
+    '/'          => 'home',
+    '/catalog'   => 'catalog',
+    '/about'     => 'about_app',
+    '/about_app' => 'about_app',
+    '/contacts'  => 'contacts',
+  ];
+  $pageSlug = $slugMap[$path] ?? trim($path, '/');
+
+  $meta = [
+    'title'       => 'BerryGo',
     'description' => '',
-    'keywords' => '',
-  ], array_filter($pageMeta, static fn($v) => $v !== null && $v !== ''));
+    'keywords'    => '',
+    'h1'          => '',
+    'text'        => '',
+  ];
+
+  if (isset($pdo)) {
+      $stmt = $pdo->prepare('SELECT title, description, keywords, h1, text FROM metadata WHERE page = ? LIMIT 1');
+      if ($stmt->execute([$pageSlug])) {
+          $row = $stmt->fetch(PDO::FETCH_ASSOC);
+          if ($row) {
+              $meta = $row;
+          }
+      }
+  }
+  if (!empty($pageMeta)) {
+      $meta = array_merge($meta, array_filter($pageMeta, static fn($v) => $v !== null && $v !== ''));
+  }
 ?>
 <!DOCTYPE html>
 <html lang="ru">


### PR DESCRIPTION
## Summary
- show how to insert metadata records for built-in pages
- load metadata from DB in auth layout so /register, /reset-pin and /login use values from metadata table

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_687a2ed04af8832ca9fcc9740f9d7bfe