### PR TITLE
Use meta tags from materials

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -1082,6 +1082,11 @@ public function showOrder(int $orderId): void
         view('client/material', [
             'material'    => $material,
             'products'    => $products,
+            'meta'        => [
+                'title'       => $material['meta_title']       ?? '',
+                'description' => $material['meta_description'] ?? '',
+                'keywords'    => $material['meta_keywords']    ?? '',
+            ],
             'breadcrumbs' => [
                 [
                     'label' => $material['category_name'],


### PR DESCRIPTION
## Summary
- include meta tags when showing materials

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687a34122148832c9458cc65ef264575