### PR TITLE
Add pickup toggle and update checkout labels

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -378,7 +378,7 @@ public function cart(): void
     /**
      * Форма подтверждения (checkout):
      * - группирует товары по дате
-     * - рассчитывает, сколько баллов можно списать (до 30 % от общей суммы)
+     * - рассчитывает, сколько баллов можно списать
      * - передаёт в шаблон: группы, subtotal, баланс баллов, сколько списать, сумма после списания, адрес
      */
     public function checkout(): void
@@ -512,9 +512,8 @@ public function cart(): void
             }
         }
     
-        // 6) Рассчитываем, сколько баллов можно списать (до 30% от суммы)
-        $maxAllowedByPercent = (int)floor($subtotal * 0.30);
-        $pointsToUse = min($pointsBalance, $maxAllowedByPercent);
+        // 6) Рассчитываем, сколько баллов можно списать (не более суммы заказа)
+        $pointsToUse = min($pointsBalance, (int)$subtotal);
 
         // 7) Итог после применения купона и баллов
         $pointsDiscountTotal = min($pointsToUse + $couponPoints, $subtotal);
@@ -664,9 +663,8 @@ public function cart(): void
         }
     }
 
-    // 5) Считаем, сколько баллов списать (до 30% от суммы)
-    $maxPossible  = floor($allTotal * 0.3);
-    $pointsToUse  = min($pointsBalance, $maxPossible);
+    // 5) Считаем, сколько баллов списать (не более суммы заказа)
+    $pointsToUse  = min($pointsBalance, $allTotal);
 
     $this->pdo->beginTransaction();
 

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -253,7 +253,7 @@ class OrdersController
         }
 
         $currentPoints = $user['points_balance'] ?? 0;
-        $maxPointsUse  = (int)floor($subtotal * 0.30);
+        $maxPointsUse  = (int)$subtotal;
 
         include __DIR__ . '/../../src/Views/client/checkout.php';
     }
@@ -291,7 +291,7 @@ class OrdersController
             }
 
             $pointsUsed = 0;
-            $maxPointsUse = (int)floor(($totalAmount - $discount) * 0.30);
+            $maxPointsUse = (int)($totalAmount - $discount);
             if (!empty($_POST['use_points']) && $user['points_balance'] > 0) {
                 $requested = intval($_POST['points_to_use'] ?? 0);
                 $pointsUsed = min($requested, $maxPointsUse, $user['points_balance']);

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -28,10 +28,10 @@ class Order extends Model
         return (int) floor($sum * 0.10);
     }
 
-    // Метод для подсчёта максимума списания баллов (30% от суммы после скидки)
+    // Метод для подсчёта максимума списания баллов (без ограничений)
     public static function calculateMaxPointsUsage(int $sumAfterDiscount): int
     {
-        return (int) floor($sumAfterDiscount * 0.30);
+        return (int) $sumAfterDiscount;
     }
 
     // Метод для подсчёта личного начисления (5% от суммы после списания баллов)

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -15,7 +15,12 @@
  */
 ?>
 <?php $search = mb_strtolower(($p['product'] ?? '') . ' ' . ($p['variety'] ?? ''), 'UTF-8'); ?>
-<div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 h-full max-w-[350px]" data-search="<?= htmlspecialchars($search) ?>" data-type="<?= htmlspecialchars($p['type_alias'] ?? '') ?>" data-sale="<?= ($p['sale_price'] ?? 0) > 0 ? '1' : '0' ?>">
+<div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 h-full max-w-[350px]"
+     data-search="<?= htmlspecialchars($search) ?>"
+     data-type="<?= htmlspecialchars($p['type_alias'] ?? '') ?>"
+     data-sale="<?= ($p['sale_price'] ?? 0) > 0 ? '1' : '0' ?>"
+     data-base-box="<?= $sale > 0 ? $priceBox : $regularBox ?>"
+     data-base-kg="<?= $sale > 0 ? $pricePerKg : $regularKg ?>">
   <?php 
   $img       = trim($p['image_path'] ?? '');
   $hasImage  = $img !== '';
@@ -99,13 +104,23 @@
     </div>
 
     <!-- Описание (если есть) -->
-    <?php if (!empty($p['description'])): ?>
-      <p class="text-xs sm:text-sm text-gray-600 mb-3 sm:mb-4 flex-1">
-        <?= htmlspecialchars($p['description']) ?>
-      </p>
-    <?php else: ?>
-      <div class="flex-1"></div>
-    <?php endif; ?>
+
+<?php if (!empty($p['description'])): ?>
+  <p class="text-xs sm:text-sm text-gray-600 mb-3 sm:mb-4 flex-1">
+    <?= htmlspecialchars($p['description']) ?>
+  </p>
+<?php else: ?>
+  <div class="flex-1"></div>
+<?php endif; ?>
+
+    <!-- Самовывоз toggle -->
+    <div class="flex items-center justify-between mb-3">
+      <span class="text-sm text-gray-600 font-semibold">Самовывоз -20%</span>
+      <label class="inline-flex relative items-center cursor-pointer">
+        <input type="checkbox" class="sr-only peer pickup-toggle">
+        <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-pink-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-pink-500"></div>
+      </label>
+    </div>
 
     <!-- Блок цены -->
     <div class="mt-auto">
@@ -115,20 +130,20 @@
           <div class="text-xs sm:text-sm text-gray-400 line-through">
             <?= number_format($regularBox, 0, '.', ' ') ?> ₽/ящик
           </div>
-          <div class="text-lg sm:text-xl font-bold text-red-600">
+          <div class="text-lg sm:text-xl font-bold text-red-600 box-price">
             <?= number_format($priceBox, 0, '.', ' ') ?> ₽/ящик
           </div>
         </div>
-        <div class="text-xs sm:text-sm text-gray-400 mb-3">
+        <div class="text-xs sm:text-sm text-gray-400 mb-3 kg-price">
           <?= htmlspecialchars($pricePerKg) ?> ₽/кг
         </div>
       <?php else: ?>
         <!-- Обычная цена -->
         <div class="flex justify-between items-center mb-3">
-          <div class="text-xl sm:text-2xl font-bold text-gray-800">
+          <div class="text-xl sm:text-2xl font-bold text-gray-800 box-price">
             <?= number_format($regularBox, 0, '.', ' ') ?> ₽/ящик
           </div>
-          <div class="text-xs sm:text-sm text-gray-400">
+          <div class="text-xs sm:text-sm text-gray-400 kg-price">
             <?= htmlspecialchars($regularKg) ?> ₽/кг
           </div>
         </div>

--- a/src/Views/client/cart.php
+++ b/src/Views/client/cart.php
@@ -111,7 +111,7 @@
         </div>
 
         <div>
-          <label class="block text-sm text-gray-600 font-bold mb-1">Выберите дату доставки</label>
+          <label class="block text-sm text-gray-600 font-bold mb-1">Выберите дату получения</label>
           <select name="delivery_date[<?= $it['product_id'] ?>]"
                   form="checkoutForm"
                   <?= empty($options) ? 'disabled' : 'required' ?>

--- a/src/Views/client/checkout.php
+++ b/src/Views/client/checkout.php
@@ -3,7 +3,7 @@
  * @var array        $groups           // сгруппированные по дате доставки товары
  * @var float        $subtotal         // исходная сумма без учёта баллов
  * @var int          $pointsBalance    // сколько баллов (клубничек) есть у пользователя
- * @var int          $pointsToUse      // сколько баллов автоматически списывается (до 30% от суммы)
+ * @var int          $pointsToUse      // сколько баллов автоматически списывается
  * @var string|null  $couponCode       // введённый промокод
  * @var array|null   $couponInfo       // информация о применённом купоне
  * @var float        $finalTotal       // итоговая сумма после всех скидок
@@ -89,7 +89,7 @@ $couponError     = $couponError     ?? null;
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-3">
                   <span class="material-icons-round text-sm mr-1 align-middle">schedule</span>
-                  Время доставки (<?= $label ?>)
+                  Время получения (<?= $label ?>)
                 </label>
                 <div class="relative">
                   <select name="slot_id[<?= htmlspecialchars($dateKey) ?>]"
@@ -274,6 +274,24 @@ $couponError     = $couponError     ?? null;
 <script>
   const select = document.getElementById('addressSelect');
   const block = document.getElementById('newAddressBlock');
+  function applyPickup() {
+    if (!select) return;
+    const enabled = localStorage.getItem('pickupEnabled') === '1';
+    let opt = select.querySelector('option[value="pickup"]');
+    if (enabled) {
+      if (!opt) {
+        opt = document.createElement('option');
+        opt.value = 'pickup';
+        opt.textContent = 'Самовывоз 9 мая 73';
+        select.prepend(opt);
+      }
+      select.value = 'pickup';
+      block.classList.add('hidden');
+    } else if (opt) {
+      if (opt.selected) select.selectedIndex = 0;
+      opt.remove();
+    }
+  }
   function toggleBlock() {
     if (select.value === 'new') {
       block.classList.remove('hidden');
@@ -283,6 +301,7 @@ $couponError     = $couponError     ?? null;
   }
   if (select) {
     select.addEventListener('change', toggleBlock);
+    applyPickup();
     toggleBlock();
   }
 </script>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -944,6 +944,45 @@
       
 
   
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggles = document.querySelectorAll('.pickup-toggle');
+    if (toggles.length === 0) return;
+    const cards = document.querySelectorAll('.product-card');
+    let state = localStorage.getItem('pickupEnabled') === '1';
+    toggles.forEach(t => t.checked = state);
+
+    function format(num) {
+      return num.toLocaleString('ru-RU');
+    }
+
+    function update() {
+      const mul = state ? 0.8 : 1;
+      cards.forEach(c => {
+        const baseBox = parseFloat(c.dataset.baseBox);
+        const baseKg = parseFloat(c.dataset.baseKg);
+        if (!isNaN(baseBox)) {
+          const el = c.querySelector('.box-price');
+          if (el) el.textContent = format(Math.round(baseBox * mul)) + ' ₽/ящик';
+        }
+        if (!isNaN(baseKg)) {
+          const el2 = c.querySelector('.kg-price');
+          if (el2) el2.textContent = format(Math.round(baseKg * mul)) + ' ₽/кг';
+        }
+      });
+    }
+
+    update();
+
+    toggles.forEach(t => t.addEventListener('change', e => {
+      state = e.target.checked;
+      localStorage.setItem('pickupEnabled', state ? '1' : '0');
+      toggles.forEach(other => { if (other !== e.target) other.checked = state; });
+      update();
+    }));
+  });
+</script>
+
 <?php include __DIR__ . '/scripts.php'; ?>
 </body>
 </html>

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -21,7 +21,7 @@ class OrderTest extends TestCase
 
     public function testCalculateMaxPointsUsage(): void
     {
-        $this->assertSame(30, \App\Models\Order::calculateMaxPointsUsage(100));
+        $this->assertSame(100, \App\Models\Order::calculateMaxPointsUsage(100));
     }
 
     public function testCalculatePersonalBonus(): void


### PR DESCRIPTION
## Summary
- add samovivoz toggle to product cards with dataset pricing
- sync toggles across cards and recalc price via JS
- rename delivery labels to получение and update pickup address logic
- remove 30% cap on loyalty points
- adjust Order model and tests

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_687bce79ada0832cabf90d2c008f9f12