### PR TITLE
Add admin date update on product card

### DIFF
--- a/index.php
+++ b/index.php
@@ -428,6 +428,10 @@ switch ("$method $uri") {
         requireAdmin();
         (new App\Controllers\ProductsController($pdo))->toggle();
         break;
+    case 'POST /admin/products/update-date':
+        requireAdmin();
+        (new App\Controllers\ProductsController($pdo))->updateDeliveryDate();
+        break;
     case 'POST /admin/products/delete':
         requireAdmin();
         (new App\Controllers\ProductsController($pdo))->delete();
@@ -639,6 +643,10 @@ switch ("$method $uri") {
     case 'POST /manager/products/toggle':
         requireManager();
         (new App\Controllers\ProductsController($pdo))->toggle();
+        break;
+    case 'POST /manager/products/update-date':
+        requireManager();
+        (new App\Controllers\ProductsController($pdo))->updateDeliveryDate();
         break;
     case 'POST /manager/products/delete':
         requireManager();

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -280,4 +280,19 @@ class ProductsController
         header('Location: /admin/products');
         exit;
     }
+
+    // Обновление даты поставки товара
+    public function updateDeliveryDate(): void
+    {
+        $id = (int)($_POST['id'] ?? 0);
+        $raw = trim($_POST['delivery_date'] ?? '');
+        $date = $raw !== '' ? $raw : null;
+        if ($id) {
+            $stmt = $this->pdo->prepare("UPDATE products SET delivery_date = ? WHERE id = ?");
+            $stmt->execute([$date, $id]);
+        }
+        $base = ($_SESSION['role'] ?? '') === 'manager' ? '/manager/products' : '/admin/products';
+        header('Location: ' . $base);
+        exit;
+    }
 }

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -38,6 +38,9 @@
     $priceBox   = $effectiveKg * $boxSize;
     $pricePerKg = round($effectiveKg, 2);
     $regularBox = $price * $boxSize;
+    $role     = $_SESSION['role'] ?? '';
+    $isStaff  = in_array($role, ['admin','manager'], true);
+    $basePath = $role === 'manager' ? '/manager' : '/admin';
     $regularKg  = round($price, 2);
   ?>
   <div class="relative">
@@ -62,17 +65,27 @@
     <?php else: ?>
       <!-- Бейджик даты / наличия -->
       <?php if ($showDate && $d <= $today): ?>
-        <span class="absolute top-3 left-3 bg-green-100 text-green-800 text-xs font-semibold px-2 py-1 rounded-full">
+        <span class="absolute top-3 left-3 bg-green-100 text-green-800 text-xs font-semibold px-2 py-1 rounded-full <?= $isStaff ? 'cursor-pointer' : '' ?>" <?= $isStaff ? 'data-edit-date="' . $p['id'] . '"' : '' ?>>
           В наличии
         </span>
       <?php elseif ($showDate): ?>
-        <span class="absolute top-3 left-3 bg-orange-100 text-orange-800 text-xs font-semibold px-2 py-1 rounded-full">
+        <span class="absolute top-3 left-3 bg-orange-100 text-orange-800 text-xs font-semibold px-2 py-1 rounded-full <?= $isStaff ? 'cursor-pointer' : '' ?>" <?= $isStaff ? 'data-edit-date="' . $p['id'] . '"' : '' ?>>
           <?= date('d.m.Y', strtotime($d)) ?>
         </span>
       <?php else: ?>
-        <span class="absolute top-3 left-3 bg-blue-100 text-blue-800 text-xs font-semibold px-2 py-1 rounded-full">
+        <span class="absolute top-3 left-3 bg-blue-100 text-blue-800 text-xs font-semibold px-2 py-1 rounded-full <?= $isStaff ? 'cursor-pointer' : '' ?>" <?= $isStaff ? 'data-edit-date="' . $p['id'] . '"' : '' ?>>
           Ближайшая возможная дата
         </span>
+      <?php endif; ?>
+
+      <?php if ($isStaff): ?>
+        <div class="absolute top-10 left-3 bg-white border rounded shadow p-2 z-10 hidden" data-date-form="<?= $p['id'] ?>">
+          <form action="<?= $basePath ?>/products/update-date" method="post" class="flex items-center space-x-2">
+            <input type="hidden" name="id" value="<?= $p['id'] ?>">
+            <input type="date" name="delivery_date" value="<?= htmlspecialchars($d ?? '') ?>" class="border px-1 py-1 rounded text-sm">
+            <button type="submit" class="bg-blue-500 text-white rounded px-2 py-1 text-xs">Обновить</button>
+          </form>
+        </div>
       <?php endif; ?>
 
       <!-- Бейджик скидки (если есть) -->

--- a/src/Views/layouts/scripts.php
+++ b/src/Views/layouts/scripts.php
@@ -60,5 +60,15 @@ window.dataLayer = window.dataLayer || [];
         });
       });
     });
+
+    document.querySelectorAll('[data-edit-date]').forEach(function (badge) {
+      badge.addEventListener('click', function () {
+        var id = badge.getAttribute('data-edit-date');
+        var form = document.querySelector('[data-date-form="' + id + '"]');
+        if (form) {
+          form.classList.toggle('hidden');
+        }
+      });
+    });
   });
 </script>


### PR DESCRIPTION
## Summary
- allow managers and admins to update product delivery date
- wire new POST routes for updating delivery date
- show editable delivery badge with popup date picker on product cards

## Testing
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_687bd03289dc832c9bf0563f41af7315