### PR TITLE
Fix redirect after product date change

### DIFF
--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -291,7 +291,16 @@ class ProductsController
             $stmt = $this->pdo->prepare("UPDATE products SET delivery_date = ? WHERE id = ?");
             $stmt->execute([$date, $id]);
         }
-        $base = ($_SESSION['role'] ?? '') === 'manager' ? '/manager/products' : '/admin/products';
+        // Determine where to redirect after updating
+        $refererPath = parse_url($_SERVER['HTTP_REFERER'] ?? '', PHP_URL_PATH) ?? '';
+        if (preg_match('#^/(admin|manager)/#', $refererPath)) {
+            $base = ($_SESSION['role'] ?? '') === 'manager'
+                ? '/manager/products'
+                : '/admin/products';
+        } else {
+            $base = '/';
+        }
+
         header('Location: ' . $base);
         exit;
     }


### PR DESCRIPTION
## Summary
- adjust `updateDeliveryDate` so staff editing from client pages returns to `/`

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_687bd6bcad6c832c933ccfff43e28168