### PR TITLE
Redirect to notifications after registration

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -144,7 +144,7 @@ public function register(): void
     unset($_SESSION['reg_verified'], $_SESSION['reg_phone'], $_SESSION['reg_code']);
     unset($_SESSION['invite_code']);
 
-    header('Location: /');
+    header('Location: /notifications');
     exit;
 }
 


### PR DESCRIPTION
## Summary
- redirect newly registered users to `/notifications` instead of home page

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_687befb86d84832c977e2e455830a841