### PR TITLE
Add Telegram bot instructions

### DIFF
--- a/src/Views/client/notifications.php
+++ b/src/Views/client/notifications.php
@@ -5,6 +5,9 @@
       <span class="material-icons-round">telegram</span>
       <span class="font-semibold">Подключить уведомления</span>
     </a>
+    <p class="text-center text-gray-600 text-sm">
+      После перехода нажмите <strong>Start</strong> в Telegram и поделитесь своим номером телефона.
+    </p>
 
     <div class="bg-white rounded-3xl shadow divide-y divide-gray-100">
       <?php

--- a/src/Views/client/register.php
+++ b/src/Views/client/register.php
@@ -155,11 +155,12 @@
       </a>
     </div>
 
-    <div class="text-center mt-3 sm:mt-4">
+    <div class="text-center mt-3 sm:mt-4 space-y-1">
       <a href="https://t.me/YagodgoBot" class="inline-flex items-center px-4 sm:px-6 py-2 sm:py-3 bg-blue-500 text-white rounded-2xl font-medium hover:bg-blue-600 transition-all shadow-lg hover:shadow-xl space-x-1 sm:space-x-2 text-xs sm:text-sm">
         <span class="material-icons-round text-lg sm:text-xl">telegram</span>
         <span>Получать уведомления</span>
       </a>
+      <p class="text-gray-600 text-xs sm:text-sm">После перехода нажмите <strong>Start</strong> и отправьте свой номер телефона.</p>
     </div>
 
   </div>


### PR DESCRIPTION
## Summary
- clarify that users need to press Start and share phone number when opening the Telegram bot

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687bf539c878832ca482683adee70248