### PR TITLE
Add phone-based Telegram linking

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -1045,8 +1045,14 @@ public function showOrder(int $orderId): void
     public function notifications(): void
     {
         requireClient();
+        $userId = $_SESSION['user_id'];
+        $stmt = $this->pdo->prepare("SELECT phone FROM users WHERE id = ?");
+        $stmt->execute([$userId]);
+        $phone = $stmt->fetchColumn();
+        $tgStart = $phone ? $phone : null;
         view('client/notifications', [
             'userName' => $_SESSION['name'] ?? null,
+            'tgStart'  => $tgStart,
         ]);
     }
 

--- a/src/Views/client/notifications.php
+++ b/src/Views/client/notifications.php
@@ -1,12 +1,13 @@
 <?php /** @var string|null $userName */ ?>
+<?php /** @var string|null $tgStart */ ?>
 <main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 min-h-screen pb-24">
   <div class="px-4 pt-6 space-y-6">
-    <a href="https://t.me/YagodgoBot" class="flex items-center justify-center space-x-2 bg-blue-500 text-white rounded-2xl py-3 shadow-lg hover:bg-blue-600 transition">
+    <a href="https://t.me/YagodgoBot<?= $tgStart ? '?start=' . $tgStart : '' ?>" class="flex items-center justify-center space-x-2 bg-blue-500 text-white rounded-2xl py-3 shadow-lg hover:bg-blue-600 transition">
       <span class="material-icons-round">telegram</span>
       <span class="font-semibold">Подключить уведомления</span>
     </a>
     <p class="text-center text-gray-600 text-sm">
-      После перехода нажмите <strong>Start</strong> в Telegram и поделитесь своим номером телефона.
+      После перехода нажмите <strong>Start</strong> в Telegram.
     </p>
 
     <div class="bg-white rounded-3xl shadow divide-y divide-gray-100">

--- a/src/Views/client/register.php
+++ b/src/Views/client/register.php
@@ -156,11 +156,11 @@
     </div>
 
     <div class="text-center mt-3 sm:mt-4 space-y-1">
-      <a href="https://t.me/YagodgoBot" class="inline-flex items-center px-4 sm:px-6 py-2 sm:py-3 bg-blue-500 text-white rounded-2xl font-medium hover:bg-blue-600 transition-all shadow-lg hover:shadow-xl space-x-1 sm:space-x-2 text-xs sm:text-sm">
+      <a id="tgLink" href="https://t.me/YagodgoBot" class="inline-flex items-center px-4 sm:px-6 py-2 sm:py-3 bg-blue-500 text-white rounded-2xl font-medium hover:bg-blue-600 transition-all shadow-lg hover:shadow-xl space-x-1 sm:space-x-2 text-xs sm:text-sm">
         <span class="material-icons-round text-lg sm:text-xl">telegram</span>
         <span>Получать уведомления</span>
       </a>
-      <p class="text-gray-600 text-xs sm:text-sm">После перехода нажмите <strong>Start</strong> и отправьте свой номер телефона.</p>
+      <p class="text-gray-600 text-xs sm:text-sm">После перехода нажмите <strong>Start</strong> в Telegram.</p>
     </div>
 
   </div>
@@ -226,6 +226,7 @@ const sendRegBtn = document.getElementById('sendRegCode');
 const codeRegBlock = document.getElementById('codeRegBlock');
 const regCodeInputs = document.querySelectorAll('input[data-reg-code]');
 const extraFields = document.getElementById('extraFields');
+const tgLink = document.getElementById('tgLink');
 
 sendRegBtn.addEventListener('click', () => {
   const phone = phoneInput.value.replace(/\D/g, '');
@@ -266,6 +267,7 @@ function verifyRegCode() {
         extraFields.disabled = false;
         extraFields.classList.remove('opacity-50');
         document.getElementById('phoneBlock').classList.add('hidden');
+        tgLink.href = 'https://t.me/YagodgoBot?start=7' + phone;
       } else {
         alert('Неверный код');
         regCodeInputs.forEach(i => i.value = '');


### PR DESCRIPTION
## Summary
- pre-fill Telegram bot start param with user's phone
- link Telegram chat from notifications page using start param
- update registration page to insert phone into bot link after SMS verification
- link phone from /start so the bot saves chat_id automatically

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687bfbd2efd4832c9a97250cd44f6cb3