### PR TITLE
Simplify registration flow

### DIFF
--- a/src/Views/client/register.php
+++ b/src/Views/client/register.php
@@ -47,16 +47,8 @@
             </div>
             <input id="phone" name="phone" type="tel" maxlength="10" inputmode="numeric" pattern="\d{10}" placeholder="902 923 7794" required class="w-full pl-16 sm:pl-20 pr-3 sm:pr-4 py-2.5 sm:py-3 md:py-4 text-sm sm:text-base md:text-lg border-2 border-gray-100 rounded-2xl focus:border-red-500 focus:ring-2 focus:ring-red-100 outline-none transition-all text-gray-800 placeholder-gray-400">
           </div>
-          <div class="relative">
-            <div class="absolute left-3 sm:left-4 top-1/2 transform -translate-y-1/2 flex items-center">
-              <span class="material-icons-round text-red-500 mr-1 sm:mr-2 text-lg sm:text-xl">mail</span>
-            </div>
-            <input id="email" type="email" placeholder="you@example.com" class="w-full pl-12 sm:pl-16 pr-3 sm:pr-4 py-2.5 sm:py-3 md:py-4 text-sm sm:text-base md:text-lg border-2 border-gray-100 rounded-2xl focus:border-red-500 focus:ring-2 focus:ring-red-100 outline-none transition-all text-gray-800 placeholder-gray-400">
-          </div>
-          <div class="flex space-x-2">
-            <button type="button" id="sendRegCode" class="flex-1 bg-red-500 text-white py-2 rounded-2xl">по SMS</button>
-            <button type="button" id="sendRegCodeTg" class="flex-1 bg-blue-500 text-white py-2 rounded-2xl">Telegram</button>
-            <button type="button" id="sendRegCodeEmail" class="flex-1 bg-gray-500 text-white py-2 rounded-2xl">e-mail</button>
+          <div class="flex">
+            <button type="button" id="sendRegCode" class="w-full bg-red-500 text-white py-2 rounded-2xl">Подтвердить номер</button>
           </div>
           <div id="codeRegBlock" class="hidden space-y-2">
             <div class="flex space-x-1.5 sm:space-x-2 justify-center">
@@ -165,13 +157,7 @@
       </a>
     </div>
 
-    <div class="text-center mt-3 sm:mt-4 space-y-1">
-      <a id="tgLink" href="https://t.me/YagodgoBot" class="inline-flex items-center px-4 sm:px-6 py-2 sm:py-3 bg-blue-500 text-white rounded-2xl font-medium hover:bg-blue-600 transition-all shadow-lg hover:shadow-xl space-x-1 sm:space-x-2 text-xs sm:text-sm">
-        <span class="material-icons-round text-lg sm:text-xl">telegram</span>
-        <span>Получать уведомления</span>
-      </a>
-      <p class="text-gray-600 text-xs sm:text-sm">После перехода нажмите <strong>Start</strong> в Telegram.</p>
-    </div>
+
 
   </div>
 
@@ -233,27 +219,16 @@ phoneInput.addEventListener('input', function() {
 });
 
 const sendRegBtn = document.getElementById('sendRegCode');
-const sendRegBtnTg = document.getElementById('sendRegCodeTg');
-const sendRegBtnEmail = document.getElementById('sendRegCodeEmail');
-const emailInput = document.getElementById('email');
 const codeRegBlock = document.getElementById('codeRegBlock');
 const regCodeInputs = document.querySelectorAll('input[data-reg-code]');
 const extraFields = document.getElementById('extraFields');
-const tgLink = document.getElementById('tgLink');
 
 sendRegBtn.addEventListener('click', () => sendCode('sms'));
-sendRegBtnTg.addEventListener('click', () => sendCode('telegram'));
-sendRegBtnEmail.addEventListener('click', () => sendCode('email'));
 
 function sendCode(method) {
   const phone = phoneInput.value.replace(/\D/g, '');
   if (phone.length !== 10) { alert('Введите номер'); return; }
   let payload = 'phone=' + phone + '&method=' + method;
-  if (method === 'email') {
-    const email = emailInput.value.trim();
-    if (!email) { alert('Введите email'); return; }
-    payload += '&email=' + encodeURIComponent(email);
-  }
   fetch('/api/send-reg-code', {method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded'}, body: payload})
     .then(r => r.json())
     .then(d => {
@@ -290,7 +265,6 @@ function verifyRegCode() {
         extraFields.disabled = false;
         extraFields.classList.remove('opacity-50');
         document.getElementById('phoneBlock').classList.add('hidden');
-        tgLink.href = 'https://t.me/YagodgoBot?start=7' + phone;
       } else {
         alert('Неверный код');
         regCodeInputs.forEach(i => i.value = '');


### PR DESCRIPTION
## Summary
- streamline `/register` page
- drop Telegram and email options
- remove notification link

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_687c6a37650c832c8dc64de27ac047ff