### PR TITLE
Restrict nav notifications link to admin

### DIFF
--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -446,7 +446,7 @@
       <?php endif; ?>
 
       <!-- Уведомления -->
-      <?php if (in_array($role, ['client','partner'])): ?>
+      <?php if ($role === 'admin'): ?>
         <li class="flex-1 mx-1">
           <a href="/notifications" class="nav-item flex flex-col items-center py-3 px-2 rounded-2xl transition-all <?= isActive('/notifications') ?>">
             <span class="material-icons-round text-xl mb-1">notifications</span>


### PR DESCRIPTION
## Summary
- limit notifications navigation link to admin users only

## Testing
- `composer install`
- `./vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_687c6b802598832caf1eac086a4fb033