### PR TITLE
Input product price per unit

### DIFF
--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -82,10 +82,7 @@ class ProductsController
             $product = $stmt->fetch(PDO::FETCH_ASSOC);
         }
 
-        $priceBox = null;
-        if ($product && !empty($product['box_size'])) {
-            $priceBox = ($product['price'] * $product['box_size'] + BOX_MARKUP) * DISCOUNT_FACTOR;
-        }
+        $priceKg = $product['price'] ?? null;
 
         // Список типов
         $types = $this->pdo
@@ -99,7 +96,7 @@ class ProductsController
             'box_size'      => $product['box_size']      ?? 0,
             'box_unit'      => $product['box_unit']      ?? 'кг',
             'delivery_date' => $product['delivery_date'] ?? null,
-            'price_box'     => $priceBox,
+            'price_kg'      => $priceKg,
         ]);
     }
 
@@ -126,12 +123,7 @@ class ProductsController
         $boxUnit       = ($boxUnitRaw === 'л' ? 'л' : 'кг');
         $unitRaw       = $_POST['unit'] ?? 'кг';
         $unit          = ($unitRaw === 'л' ? 'л' : 'кг');
-        $priceBoxInput = (float)$_POST['price']; // desired box price with discount
-        if ($boxSize > 0) {
-            $price = ($priceBoxInput / DISCOUNT_FACTOR - BOX_MARKUP) / $boxSize;
-        } else {
-            $price = 0.0;
-        }
+        $price        = (float)$_POST['price']; // price per kg/l
         $salePrice     = (float)($_POST['sale_price'] ?? 0);
         $stockBoxes    = (float)$_POST['stock_boxes'];
         $isActive      = isset($_POST['is_active']) ? 1 : 0;

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -164,11 +164,11 @@
       <?php endif; ?>
     </div>
 
-    <!-- Цена за ящик с учётом скидки -->
+    <!-- Цена за кг/л -->
     <div>
-      <label class="block mb-1">Цена за ящик (₽)</label>
+      <label class="block mb-1">Цена за кг или л (₽)</label>
       <input name="price" type="number" step="0.01"
-             value="<?= htmlspecialchars($price_box ?? '') ?>"
+             value="<?= htmlspecialchars($price_kg ?? '') ?>"
              class="w-full border px-2 py-1 rounded" required>
     </div>
 

--- a/src/Views/admin/products/index.php
+++ b/src/Views/admin/products/index.php
@@ -14,7 +14,7 @@
       <?php endif; ?>
       <th class="p-3 text-left font-semibold">Сорт</th>
       <th class="p-3 text-left font-semibold">Вес ящика</th>
-      <th class="p-3 text-left font-semibold">Цена</th>
+      <th class="p-3 text-left font-semibold">Цена за кг/л</th>
       <?php if (!$isManager): ?>
       <th class="p-3 text-left font-semibold">Остаток (ящиков)</th>
       <?php endif; ?>
@@ -41,11 +41,8 @@
         <td class="p-3 text-gray-600">
           <?= $p['box_size'] ?> <?= htmlspecialchars($p['box_unit']) ?>
         </td>
-        <?php
-          $displayPrice = ($p['price'] * $p['box_size'] + BOX_MARKUP) * DISCOUNT_FACTOR;
-        ?>
         <td class="p-3 text-gray-600">
-          <?= number_format($displayPrice, 2, '.', ' ') ?> ₽/ящик
+          <?= number_format($p['price'], 2, '.', ' ') ?> ₽/<?= htmlspecialchars($p['unit']) ?>
         </td>
         <?php if (!$isManager): ?>
         <td class="p-3 text-gray-600"><?= $p['stock_boxes'] ?></td>


### PR DESCRIPTION
## Summary
- change product price editing to use cost per kilogram or liter
- store per-unit price in the database
- show per-unit price in admin product list

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_687df6fcee48832c92358413995cf027