### PR TITLE
Enhance manual order creation

### DIFF
--- a/index.php
+++ b/index.php
@@ -557,6 +557,10 @@ switch ("$method $uri") {
         requireAdmin();
         (new App\Controllers\UsersController($pdo))->searchPhone();
         break;
+    case 'GET /admin/users/addresses':
+        requireAdmin();
+        (new App\Controllers\UsersController($pdo))->addresses();
+        break;
     case (bool)preg_match('#^GET /admin/users/(\d+)$#', "$method $uri", $m):
         requireAdmin();
         (new App\Controllers\UsersController($pdo))->show((int)$m[1]);

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -123,7 +123,11 @@ class OrdersController
     public function create(): void
     {
         $stmt = $this->pdo->query(
-            "SELECT p.id, t.name AS product, p.variety, p.price, p.image_path FROM products p JOIN product_types t ON t.id = p.product_type_id WHERE p.is_active = 1 ORDER BY t.name"
+            "SELECT p.id, t.name AS product, p.variety, p.price, p.image_path, p.box_size, p.box_unit
+             FROM products p
+             JOIN product_types t ON t.id = p.product_type_id
+             WHERE p.is_active = 1
+             ORDER BY t.name"
         );
         $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
 

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -466,4 +466,21 @@ class UsersController
         header('Content-Type: application/json');
         echo json_encode($res);
     }
+
+    // Список адресов пользователя (JSON)
+    public function addresses(): void
+    {
+        $uid = (int)($_GET['user_id'] ?? 0);
+        if ($uid <= 0) {
+            echo json_encode([]);
+            return;
+        }
+        $stmt = $this->pdo->prepare(
+            "SELECT id, street FROM addresses WHERE user_id = ? ORDER BY is_primary DESC, created_at ASC"
+        );
+        $stmt->execute([$uid]);
+        $res = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        header('Content-Type: application/json');
+        echo json_encode($res);
+    }
 }

--- a/src/Views/admin/orders/create.php
+++ b/src/Views/admin/orders/create.php
@@ -19,6 +19,10 @@
       <input type="text" id="searchPhone" placeholder="Телефон" class="border px-2 py-1 rounded w-56">
       <input type="hidden" name="user_id" id="userId">
       <ul id="suggestions" class="border bg-white rounded shadow absolute hidden"></ul>
+      <div id="addressWrapper" class="space-y-1 hidden">
+        <select name="address_id" id="addressSelect" class="border px-2 py-1 rounded w-full"></select>
+        <input type="text" name="address_new" id="addressNew" placeholder="Новый адрес" class="border px-2 py-1 rounded w-full hidden">
+      </div>
     </div>
     <div id="newBlock" class="space-y-2 hidden">
       <input type="text" name="new_name" placeholder="Имя" class="border px-2 py-1 rounded w-56">
@@ -47,16 +51,20 @@
   <!-- Шаг 2 -->
   <div id="step2" class="bg-white p-4 rounded shadow space-y-2 hidden">
     <h2 class="font-semibold mb-2">Шаг 2. Товары</h2>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
       <?php foreach ($products as $p): ?>
-        <div class="border rounded p-2 flex flex-col items-center">
+        <div class="border rounded p-2 flex flex-col items-center text-sm min-w-24 max-w-30">
           <?php if (!empty($p['image_path'])): ?>
-            <img src="<?= htmlspecialchars($p['image_path']) ?>" class="w-24 h-24 object-cover mb-2" />
+            <img src="<?= htmlspecialchars($p['image_path']) ?>" class="w-24 h-24 object-cover mb-1" />
           <?php endif; ?>
           <div class="font-medium text-center mb-1">
-            <?= htmlspecialchars($p['product']) ?><?php if ($p['variety']) echo ' '.htmlspecialchars($p['variety']); ?>
+            <?= htmlspecialchars($p['product']) ?><?php if ($p['variety']) echo ' '.htmlspecialchars($p['variety']); ?><?php if (!empty($p['box_size']) && !empty($p['box_unit'])) echo ' '.$p['box_size'].' '.htmlspecialchars($p['box_unit']); ?>
           </div>
-          <input type="number" step="0.01" name="items[<?= $p['id'] ?>]" placeholder="Кол-во" class="border px-2 py-1 rounded w-24">
+          <div class="flex items-center space-x-1">
+            <button type="button" class="dec px-2 bg-gray-200 rounded" data-target="item<?= $p['id'] ?>">-</button>
+            <input id="item<?= $p['id'] ?>" data-price="<?= $p['price'] ?>" type="number" step="0.01" name="items[<?= $p['id'] ?>]" value="0" class="qty border px-1 py-0.5 rounded w-16 text-center">
+            <button type="button" class="inc px-2 bg-gray-200 rounded" data-target="item<?= $p['id'] ?>">+</button>
+          </div>
         </div>
       <?php endforeach; ?>
     </div>
@@ -66,13 +74,19 @@
   <!-- Шаг 3 -->
   <div id="step3" class="bg-white p-4 rounded shadow space-y-2 hidden">
     <h2 class="font-semibold mb-2">Шаг 3. Подтверждение</h2>
+    <div id="summary" class="space-y-1 text-sm">
+      <div class="flex justify-between"><span>Стоимость товаров:</span> <span id="sumSubtotal">0</span></div>
+      <div id="rowPickup" class="flex justify-between hidden"><span>Самовывоз -10%</span> <span id="sumPickup">0</span></div>
+      <div id="rowReferral" class="flex justify-between hidden"><span>Скидка -10%</span> <span id="sumReferral">0</span></div>
+      <div class="flex justify-between font-semibold border-t pt-1"><span>Итого:</span> <span id="sumTotal">0</span></div>
+    </div>
     <div>
       <label>Купон:</label>
       <input type="text" name="coupon_code" class="border px-2 py-1 rounded">
     </div>
     <div>
       <label>Списать баллы:</label>
-      <input type="number" name="points" class="border px-2 py-1 rounded w-24">
+      <input type="number" name="points" id="pointsInput" class="border px-2 py-1 rounded w-24" value="0">
     </div>
     <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Создать заказ</button>
   </div>
@@ -97,10 +111,23 @@
   document.getElementById('toStep3').addEventListener('click', ()=>{
     document.getElementById('step2').classList.add('hidden');
     document.getElementById('step3').classList.remove('hidden');
+    updateSummary();
   });
 
   const search = document.getElementById('searchPhone');
   const sugg = document.getElementById('suggestions');
+  const addressWrapper = document.getElementById('addressWrapper');
+  const addressSelect = document.getElementById('addressSelect');
+  const addressNew = document.getElementById('addressNew');
+  const pickupChk = document.getElementById('pickupChk');
+  const qtyInputs = document.querySelectorAll('.qty');
+  const subtotalEl = document.getElementById('sumSubtotal');
+  const pickupRow = document.getElementById('rowPickup');
+  const pickupEl = document.getElementById('sumPickup');
+  const refRow = document.getElementById('rowReferral');
+  const refEl = document.getElementById('sumReferral');
+  const totalEl = document.getElementById('sumTotal');
+  const pointsInput = document.getElementById('pointsInput');
   search.addEventListener('input', ()=>{
     const term = search.value.replace(/\D/g,'');
     if (term.length < 3) { sugg.classList.add('hidden'); return; }
@@ -115,10 +142,98 @@
             search.value=u.phone;
             document.getElementById('userId').value=u.id;
             sugg.classList.add('hidden');
+            loadAddresses(u.id);
           });
           sugg.appendChild(li);
         });
-        sugg.classList.remove('hidden');
+      sugg.classList.remove('hidden');
       });
   });
+
+  document.querySelectorAll('.dec').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const inp = document.getElementById(btn.dataset.target);
+      if (!inp) return;
+      inp.stepDown();
+      updateSummary();
+    });
+  });
+  document.querySelectorAll('.inc').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const inp = document.getElementById(btn.dataset.target);
+      if (!inp) return;
+      inp.stepUp();
+      updateSummary();
+    });
+  });
+  qtyInputs.forEach(i=>i.addEventListener('input', updateSummary));
+  pickupChk.addEventListener('change', updateSummary);
+  document.getElementById('modeNew').addEventListener('change', updateSummary);
+  document.getElementById('modeExist').addEventListener('change', updateSummary);
+  if (pointsInput) pointsInput.addEventListener('input', updateSummary);
+
+  function updateSummary() {
+    let subtotal = 0;
+    qtyInputs.forEach(i => {
+      const q = parseFloat(i.value) || 0;
+      const price = parseFloat(i.dataset.price);
+      subtotal += q * price;
+    });
+    subtotalEl.textContent = subtotal.toFixed(2) + ' ₽';
+    let total = subtotal;
+    const pickup = pickupChk.checked;
+    if (pickup) {
+      const d = subtotal * 0.1;
+      pickupEl.textContent = '-' + d.toFixed(2);
+      pickupRow.classList.remove('hidden');
+      total -= d;
+    } else {
+      pickupRow.classList.add('hidden');
+    }
+    const referral = document.getElementById('modeNew').checked;
+    if (referral) {
+      const d = subtotal * 0.1;
+      refEl.textContent = '-' + d.toFixed(2);
+      refRow.classList.remove('hidden');
+      total -= d;
+    } else {
+      refRow.classList.add('hidden');
+    }
+    const points = parseFloat(pointsInput ? pointsInput.value : 0) || 0;
+    total -= points;
+    totalEl.textContent = total.toFixed(2) + ' ₽';
+  }
+
+  function loadAddresses(uid) {
+    fetch('<?= $base ?>/users/addresses?user_id='+uid)
+      .then(r=>r.json()).then(list=>{
+        addressSelect.innerHTML='';
+        list.forEach(a=>{
+          const opt=document.createElement('option');
+          opt.value=a.id;
+          opt.textContent=a.street;
+          addressSelect.appendChild(opt);
+        });
+        const optNew=document.createElement('option');
+        optNew.value='new';
+        optNew.textContent='Добавить новый адрес';
+        addressSelect.appendChild(optNew);
+        const optPickup=document.createElement('option');
+        optPickup.value='pickup';
+        optPickup.textContent='Самовывоз 9 мая 73';
+        addressSelect.appendChild(optPickup);
+        addressWrapper.classList.remove('hidden');
+      });
+  }
+
+  if (addressSelect) {
+    addressSelect.addEventListener('change', () => {
+      if (addressSelect.value === 'new') {
+        addressNew.classList.remove('hidden');
+      } else {
+        addressNew.classList.add('hidden');
+      }
+      pickupChk.checked = addressSelect.value === 'pickup';
+    });
+  }
 </script>


### PR DESCRIPTION
## Summary
- select address when choosing a customer in admin order form
- show product box weight and allow adjusting quantity with +/-
- add summary calculation before confirming order
- expose user addresses via a new controller endpoint
- route new endpoint in `index.php`
- include box size in order creation products query

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687f6eff62dc832cb4dc829977453dd7