### PR TITLE
Add manager order creation and move button

### DIFF
--- a/index.php
+++ b/index.php
@@ -634,6 +634,14 @@ switch ("$method $uri") {
         requireManager();
         (new App\Controllers\OrdersController($pdo))->index();
         break;
+    case 'GET /manager/orders/create':
+        requireManager();
+        (new App\Controllers\OrdersController($pdo))->create();
+        break;
+    case 'POST /manager/orders/create':
+        requireManager();
+        (new App\Controllers\OrdersController($pdo))->storeManual();
+        break;
     case (bool)preg_match('#^GET /manager/orders/(\d+)$#', "$method $uri", $m):
         requireManager();
         (new App\Controllers\OrdersController($pdo))->show((int)$m[1]);

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -7,6 +7,9 @@
     <?= htmlspecialchars($_GET['msg']) ?>
   </div>
 <?php endif; ?>
+<div class="mb-2">
+  <a href="<?= $base ?>/orders/create" class="px-3 py-2 bg-[#C86052] text-white rounded text-sm">Создать заказ</a>
+</div>
 <div class="mb-4 flex flex-col md:flex-row md:items-end md:justify-between gap-2">
   <select id="statusFilter" class="border rounded px-3 py-2 text-sm">
     <option value="">Все статусы</option>
@@ -31,7 +34,6 @@
     <span class="text-gray-500">-</span>
     <input type="date" id="dateTo" class="border rounded px-2 py-1 text-sm">
     <button id="clearDate" class="px-3 py-2 bg-gray-200 rounded text-sm">Без даты</button>
-    <a href="<?= $base ?>/orders/create" class="ml-4 px-3 py-2 bg-[#C86052] text-white rounded text-sm">Создать заказ</a>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- move order creation button above filters on the orders page
- allow managers to access order creation via `/manager/orders/create`

## Testing
- `vendor/bin/phpunit --verbose`

------
https://chatgpt.com/codex/tasks/task_e_687f7182a28c832c9e6c9b6c7715c4e3