### PR TITLE
Improve order creation flow

### DIFF
--- a/index.php
+++ b/index.php
@@ -692,6 +692,14 @@ switch ("$method $uri") {
         requireManager();
         (new App\Controllers\UsersController($pdo))->index();
         break;
+    case 'GET /manager/users/search':
+        requireManager();
+        (new App\Controllers\UsersController($pdo))->searchPhone();
+        break;
+    case 'GET /manager/users/addresses':
+        requireManager();
+        (new App\Controllers\UsersController($pdo))->addresses();
+        break;
     case (bool)preg_match('#^GET /manager/users/(\d+)$#', "$method $uri", $m):
         requireManager();
         (new App\Controllers\UsersController($pdo))->show((int)$m[1]);

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -459,7 +459,7 @@ class UsersController
         }
 
         $stmt = $this->pdo->prepare(
-            "SELECT id, name, phone FROM users WHERE phone LIKE ? ORDER BY phone LIMIT 5"
+            "SELECT id, name, phone, points_balance FROM users WHERE phone LIKE ? ORDER BY phone LIMIT 5"
         );
         $stmt->execute([ $term . '%' ]);
         $res = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- add missing manager routes for user lookup
- allow listing user points during phone search
- update admin order form with item summary and auto points usage
- handle coupon and point deduction in manual order controller
- make quantity fields integer inputs

## Testing
- `composer install`
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687f73100008832c8b65a5ff1523a44e