### PR TITLE
Add substring search for phone autocomplete

### DIFF
--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -461,7 +461,7 @@ class UsersController
         $stmt = $this->pdo->prepare(
             "SELECT id, name, phone, points_balance FROM users WHERE phone LIKE ? ORDER BY phone LIMIT 5"
         );
-        $stmt->execute([ $term . '%' ]);
+        $stmt->execute([ '%' . $term . '%' ]);
         $res = $stmt->fetchAll(PDO::FETCH_ASSOC);
         header('Content-Type: application/json');
         echo json_encode($res);

--- a/src/Views/admin/orders/create.php
+++ b/src/Views/admin/orders/create.php
@@ -141,7 +141,7 @@
   const itemsList = document.getElementById('itemsList');
   search.addEventListener('input', ()=>{
     const term = search.value.replace(/\D/g,'');
-    if (term.length < 3) { sugg.classList.add('hidden'); return; }
+    if (term.length < 2) { sugg.classList.add('hidden'); return; }
     fetch('<?= $base ?>/users/search?term='+term)
       .then(r=>r.json()).then(data=>{
         sugg.innerHTML='';


### PR DESCRIPTION
## Summary
- allow phone search by any digits
- show suggestions after typing 2 digits

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_687f760f7e48832cb9df2f37a816654f