### PR TITLE
Add manager profile stats

### DIFF
--- a/index.php
+++ b/index.php
@@ -630,6 +630,10 @@ switch ("$method $uri") {
         requireManager();
         (new App\Controllers\AdminController($pdo))->dashboard();
         break;
+    case 'GET /manager/profile':
+        requireManager();
+        (new App\Controllers\UsersController($pdo))->managerProfile();
+        break;
     case 'GET /manager/orders':
         requireManager();
         (new App\Controllers\OrdersController($pdo))->index();

--- a/src/Views/admin/manager_profile.php
+++ b/src/Views/admin/manager_profile.php
@@ -1,0 +1,54 @@
+<?php
+/** @var int $directClients */
+/** @var int $secondClients */
+/** @var int $ordersCount */
+/** @var array $partnerStats */
+?>
+<div class="space-y-6">
+  <div class="bg-white rounded shadow p-4">
+    <h2 class="text-lg font-semibold mb-2">Общая статистика</h2>
+    <div class="grid grid-cols-3 gap-4 text-center">
+      <div>
+        <div class="text-2xl font-bold text-[#C86052]"><?= $ordersCount ?></div>
+        <div class="text-sm text-gray-600">продаж</div>
+      </div>
+      <div>
+        <div class="text-2xl font-bold text-[#C86052]"><?= $directClients ?></div>
+        <div class="text-sm text-gray-600">прямых клиентов</div>
+      </div>
+      <div>
+        <div class="text-2xl font-bold text-[#C86052]"><?= $secondClients ?></div>
+        <div class="text-sm text-gray-600">клиентов второго уровня</div>
+      </div>
+    </div>
+  </div>
+  <div class="bg-white rounded shadow p-4">
+    <h2 class="text-lg font-semibold mb-4">Партнёры</h2>
+    <?php if (empty($partnerStats)): ?>
+      <p class="text-gray-600">Партнёров нет</p>
+    <?php else: ?>
+    <table class="min-w-full text-left">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="p-2">Имя</th>
+          <th class="p-2">Телефон</th>
+          <th class="p-2 text-center">Клиенты</th>
+          <th class="p-2 text-center">Заказы</th>
+          <th class="p-2 text-center">Сумма</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($partnerStats as $ps): ?>
+        <tr class="border-b">
+          <td class="p-2"><?= htmlspecialchars($ps['name']) ?></td>
+          <td class="p-2"><?= htmlspecialchars($ps['phone']) ?></td>
+          <td class="p-2 text-center"><?= $ps['clients'] ?></td>
+          <td class="p-2 text-center"><?= $ps['orders'] ?></td>
+          <td class="p-2 text-center"><?= $ps['revenue'] ?></td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+    <?php endif; ?>
+  </div>
+</div>

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -342,6 +342,10 @@
         <span class="material-icons-round mr-3 text-teal-500 group-hover:scale-110 transition-transform">people</span>
         <span class="font-medium">Пользователи</span>
       </a>
+      <a href="/manager/profile" class="flex items-center p-4 hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 rounded-2xl transition-all group">
+        <span class="material-icons-round mr-3 text-red-500 group-hover:scale-110 transition-transform">account_circle</span>
+        <span class="font-medium">Профиль</span>
+      </a>
     </nav>
   </aside>
   <?php endif; ?>

--- a/src/Views/layouts/manager_main.php
+++ b/src/Views/layouts/manager_main.php
@@ -242,6 +242,7 @@
         <a href="/manager/orders" class="hover:underline">Заказы</a>
         <a href="/manager/products" class="hover:underline">Товары</a>
         <a href="/manager/users" class="hover:underline">Пользователи</a>
+        <a href="/manager/profile" class="hover:underline">Профиль</a>
       </nav>
       <button id="burgerBtn" class="md:hidden p-2 text-gray-600">
         <span class="material-icons-round">menu</span>
@@ -268,6 +269,10 @@
       <a href="/manager/users" class="flex items-center p-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2">people</span>
         <span class="menu-text">Пользователи</span>
+      </a>
+      <a href="/manager/profile" class="flex items-center p-2 mt-2 rounded hover:bg-gray-200">
+        <span class="material-icons-round mr-2">account_circle</span>
+        <span class="menu-text">Профиль</span>
       </a>
     </nav>
   </aside>


### PR DESCRIPTION
## Summary
- implement managerProfile in `UsersController`
- render `/manager/profile` with new manager profile view
- link profile in manager layout and site sidebar
- register route `/manager/profile`

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_687fa87cd2fc832cb3458ea67ee4ff0d