### PR TITLE
Add debug overlay for manual order creation

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -134,10 +134,14 @@ class OrdersController
         $slotsStmt = $this->pdo->query("SELECT id, date, time_from, time_to FROM delivery_slots ORDER BY date, time_from");
         $slots = $slotsStmt->fetchAll(PDO::FETCH_ASSOC);
 
+        $debugData = $_SESSION['debug_order_data'] ?? [];
+        unset($_SESSION['debug_order_data']);
+
         viewAdmin('orders/create', [
             'pageTitle' => 'Создать заказ',
             'products'  => $products,
             'slots'     => $slots,
+            'debugData' => $debugData,
         ]);
     }
 
@@ -153,6 +157,13 @@ class OrdersController
             $address = trim($_POST['new_address'] ?? '');
             $pin   = trim($_POST['new_pin'] ?? '');
             if ($name === '' || !preg_match('/^7\d{10}$/', $phone) || !preg_match('/^\d{4}$/', $pin)) {
+                $_SESSION['debug_order_data'] = [
+                    'name'    => $name,
+                    'phone'   => $phone,
+                    'address' => $address,
+                    'pin'     => $pin,
+                    'raw'     => $_POST,
+                ];
                 header('Location: /admin/orders/create?error=invalid+user');
                 exit;
             }

--- a/src/Views/admin/orders/create.php
+++ b/src/Views/admin/orders/create.php
@@ -266,3 +266,65 @@
     });
   }
 </script>
+
+<?php if (!empty($debugData)): ?>
+  <div id="debugOverlay" style="
+      position: fixed;
+      bottom: 10px;
+      right: 10px;
+      width: 320px;
+      max-height: 50vh;
+      overflow-y: auto;
+      background: rgba(0,0,0,0.8);
+      color: #fff;
+      font-family: monospace;
+      font-size: 12px;
+      line-height: 1.2;
+      padding: 8px;
+      border-radius: 6px;
+      z-index: 9999;
+      display: none;
+  ">
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px;">
+      <strong>DEBUG INFO</strong>
+      <button id="debugToggle" style="
+          background: transparent;
+          border: none;
+          color: #fff;
+          font-weight: bold;
+          cursor: pointer;
+          font-size: 14px;
+      ">×</button>
+    </div>
+    <pre id="debugContent" style="white-space: pre-wrap;">
+<?= htmlspecialchars(json_encode($debugData, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT)) ?>
+    </pre>
+  </div>
+  <button id="debugOpenBtn" style="
+      position: fixed;
+      bottom: 10px;
+      right: 10px;
+      background: #e53e3e;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 6px 10px;
+      font-size: 12px;
+      cursor: pointer;
+      z-index: 9999;
+  ">Открыть DEBUG</button>
+  <script>
+    const overlay = document.getElementById('debugOverlay');
+    const content = document.getElementById('debugContent');
+    const btnOpen = document.getElementById('debugOpenBtn');
+    const btnClose = document.getElementById('debugToggle');
+    btnOpen.addEventListener('click', () => {
+      overlay.style.display = 'block';
+      btnOpen.style.display = 'none';
+    });
+    btnClose.addEventListener('click', () => {
+      overlay.style.display = 'none';
+      btnOpen.style.display = 'block';
+    });
+  </script>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- show debug info when manual order creation fails
- persist debug info via session

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_687fd4c40818832c81d354b5723c6c64