### PR TITLE
Fix pickup option in order creation

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -199,6 +199,11 @@ class OrdersController
         } else {
             $userId = (int)($_POST['user_id'] ?? 0);
             $addressId = $_POST['address_id'] ?? null;
+            if ($addressId === 'pickup') {
+                $addressId = null;
+            } elseif ($addressId !== null) {
+                $addressId = is_numeric($addressId) ? (int)$addressId : null;
+            }
             $referralDiscount = false;
         }
 


### PR DESCRIPTION
## Summary
- handle `pickup` as `null` for `address_id` in `OrdersController::storeManual`

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_687fdfd7a038832c8b0bec2f22749706