### PR TITLE
Fix phone prefix in manual order creation

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -14,6 +14,23 @@ class OrdersController
         $this->pdo = $pdo;
     }
 
+    /**
+     * Normalize phone number to 7XXXXXXXXXX format
+     */
+    private function normalizePhone(string $raw): string
+    {
+        $digits = preg_replace('/\D+/', '', $raw);
+        if (strlen($digits) === 10) {
+            return '7' . $digits;
+        }
+        if (strlen($digits) === 11) {
+            $first = $digits[0];
+            $rest  = substr($digits, 1);
+            return ($first === '8' ? '7' : $first) . $rest;
+        }
+        return $digits;
+    }
+
     // Список заказов (админ/менеджер)
     public function index(): void
     {
@@ -153,7 +170,7 @@ class OrdersController
 
         if ($isNew) {
             $name  = trim($_POST['new_name'] ?? '');
-            $phone = preg_replace('/\D+/', '', $_POST['new_phone'] ?? '');
+            $phone = $this->normalizePhone($_POST['new_phone'] ?? '');
             $address = trim($_POST['new_address'] ?? '');
             $pin   = trim($_POST['new_pin'] ?? '');
             if ($name === '' || !preg_match('/^7\d{10}$/', $phone) || !preg_match('/^\d{4}$/', $pin)) {

--- a/tests/OrdersControllerTest.php
+++ b/tests/OrdersControllerTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\OrdersController;
+use PDO;
+use ReflectionClass;
+
+class OrdersControllerTest extends TestCase
+{
+    public function testNormalizePhoneAddsPrefix(): void
+    {
+        if (!class_exists('App\\Controllers\\OrdersController')) {
+            require_once __DIR__ . '/../src/Controllers/OrdersController.php';
+        }
+        $controller = new OrdersController(new PDO('sqlite::memory:'));
+        $ref = new ReflectionClass($controller);
+        $method = $ref->getMethod('normalizePhone');
+        $method->setAccessible(true);
+        $result = $method->invoke($controller, '2222222222');
+        $this->assertSame('72222222222', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize phone numbers when managers create users manually
- test OrdersController phone normalization

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687fe14d0e68832ca91fe5e191669652