### PR TITLE
Adjust pickup discount and points usage

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -250,7 +250,7 @@ class OrdersController
         }
 
         if (isset($_POST['pickup'])) {
-            $total = (int)floor($total * 0.9);
+            $total = (int)floor($total * 0.8);
         }
 
         if ($referralDiscount) {

--- a/src/Views/admin/orders/create.php
+++ b/src/Views/admin/orders/create.php
@@ -85,7 +85,7 @@
     <div id="itemsList" class="space-y-1 text-sm"></div>
     <div id="summary" class="space-y-1 text-sm">
       <div class="flex justify-between"><span>Стоимость товаров:</span> <span id="sumSubtotal">0</span></div>
-      <div id="rowPickup" class="flex justify-between hidden"><span>Самовывоз -10%</span> <span id="sumPickup">0</span></div>
+      <div id="rowPickup" class="flex justify-between hidden"><span>Самовывоз -20%</span> <span id="sumPickup">0</span></div>
       <div id="rowReferral" class="flex justify-between hidden"><span>Скидка -10%</span> <span id="sumReferral">0</span></div>
       <div class="flex justify-between font-semibold border-t pt-1"><span>Итого:</span> <span id="sumTotal">0</span></div>
     </div>
@@ -212,7 +212,7 @@
     let total = subtotal;
     const pickup = pickupChk.checked;
     if (pickup) {
-      const d = subtotal * 0.1;
+      const d = subtotal * 0.2;
       pickupEl.textContent = '-' + d.toFixed(2);
       pickupRow.classList.remove('hidden');
       total -= d;
@@ -228,8 +228,11 @@
     } else {
       refRow.classList.add('hidden');
     }
-    const points = parseFloat(pointsInput ? pointsInput.value : 0) || 0;
-    total -= points;
+    let points = parseFloat(pointsInput ? pointsInput.value : 0) || 0;
+    const maxUse = Math.min(points, total);
+    if (pointsInput) pointsInput.value = maxUse;
+    pointsAmount.textContent = maxUse;
+    total -= maxUse;
     totalEl.textContent = total.toFixed(2) + ' ₽';
   }
 


### PR DESCRIPTION
## Summary
- update manual order logic to give 20% pickup discount
- adjust admin order creation page to show 20% pickup discount
- prevent entering more bonus points than the order total

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_687fe2dd4f40832cb0692f9ee3d947b0