### PR TITLE
Fix duplicate phone errors on admin order creation

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -195,6 +195,21 @@ class OrdersController
                 exit;
             }
 
+            // Check for duplicate phone number to avoid unique constraint errors
+            $stmt = $this->pdo->prepare('SELECT id FROM users WHERE phone = ?');
+            $stmt->execute([$phone]);
+            if ($stmt->fetchColumn()) {
+                $_SESSION['debug_order_data'] = [
+                    'name'    => $name,
+                    'phone'   => $phone,
+                    'address' => $address,
+                    'pin'     => $pin,
+                    'raw'     => $_POST,
+                ];
+                header('Location: ' . $this->basePath() . '/create?error=phone_exists');
+                exit;
+            }
+
             $refCode = ReferralHelper::generateUniqueCode($this->pdo, 8);
             $managerId = $_SESSION['user_id'] ?? null;
             $pinHash = password_hash($pin, PASSWORD_DEFAULT);


### PR DESCRIPTION
## Summary
- handle duplicate phone numbers when creating new users via admin

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6880929866e4832c93357bd656b807fa