### PR TITLE
Fix manager order creation redirect

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -317,7 +317,7 @@ class OrdersController
             )->execute([$userId, $orderId, -$pointsUsed, $desc]);
         }
 
-        header('Location: ' . $this->basePath() . '/' . $orderId);
+        header('Location: ' . $this->basePath());
         exit;
     }
 


### PR DESCRIPTION
## Summary
- adjust redirect after manual order creation so managers return to the order list

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68809e6ce840832cbe58e99ca4194486