### PR TITLE
Enable managers access to client area

### DIFF
--- a/index.php
+++ b/index.php
@@ -141,7 +141,7 @@ $method = $_SERVER['REQUEST_METHOD'];
 function requireClient(): void
 {
     $role = $_SESSION['role'] ?? '';
-    if (!in_array($role, ['client','partner','admin'], true)) {
+    if (!in_array($role, ['client','partner','admin','manager'], true)) {
         header('Location: /login');
         exit;
     }

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -433,7 +433,7 @@
       </li>
       
       <!-- Мои заказы -->
-      <?php if (in_array($role, ['client','partner'])): ?>
+      <?php if (in_array($role, ['client','partner','manager','admin'])): ?>
         <li class="flex-1 mx-1">
           <a href="/orders" class="nav-item flex flex-col items-center py-3 px-2 rounded-2xl transition-all <?= isActive('/orders') ?>">
             <span class="material-icons-round text-xl mb-1">receipt_long</span>
@@ -467,7 +467,7 @@
       <?php endif; ?>
 
       <!-- Профиль -->
-      <?php if (in_array($role, ['client','partner'])): ?>
+      <?php if (in_array($role, ['client','partner','manager','admin'])): ?>
         <li class="flex-1">
           <a href="/profile" class="nav-item flex flex-col items-center py-3 px-2 rounded-2xl transition-all <?= isActive('/profile') ?>">
             <span class="material-icons-round text-xl mb-1">person</span>


### PR DESCRIPTION
## Summary
- allow the `manager` role to pass client route protection
- show client Orders and Profile links for admins and managers

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6880cad4fc30832cbd70d32d60723d96