### PR TITLE
Drop orders.delivery_slot column

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,11 @@ INSERT INTO delivery_slots (time_from, time_to) VALUES
   ('18:00', '22:00');
 ```
 
+
+### Orders table update
+
+Remove the obsolete `delivery_slot` column from the `orders` table. Slots are now referenced via `slot_id`.
+
+```sql
+ALTER TABLE orders DROP COLUMN delivery_slot;
+```

--- a/database/2025_20_orders_drop_delivery_slot.sql
+++ b/database/2025_20_orders_drop_delivery_slot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders DROP COLUMN delivery_slot;

--- a/index.php
+++ b/index.php
@@ -217,6 +217,15 @@ function format_slot(?string $slot): string
     return $slot;
 }
 
+// Formats delivery slot from time range
+function format_time_range(?string $from, ?string $to): string
+{
+    if (!$from || !$to) {
+        return '';
+    }
+    return substr($from, 0, 5) . ' - ' . substr($to, 0, 5);
+}
+
 switch ("$method $uri") {
 
 

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -71,10 +71,10 @@
         <td class="p-3 text-gray-600"><?= date('d.m H:i', strtotime($o['created_at'])) ?></td>
         <td class="p-3 text-gray-600">
           <?php if ($o['delivery_date']): ?>
-            <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_slot($o['delivery_slot'])) ?>
+            <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?>
           <?php endif; ?>
         </td>
-        <td class="p-3 text-gray-600"><?= htmlspecialchars(format_slot($o['delivery_slot'])) ?></td>
+        <td class="p-3 text-gray-600"><?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?></td>
         <td class="p-3 text-gray-600"><?= htmlspecialchars($o['client_name']) ?></td>
         <td class="p-3 text-gray-600"><?= htmlspecialchars($o['phone']) ?></td>
         <td class="p-3 text-gray-600"><?= htmlspecialchars($o['address']) ?></td>

--- a/src/Views/client/checkout.php
+++ b/src/Views/client/checkout.php
@@ -100,8 +100,7 @@ $slots           = $slots           ?? [];
                           required
                           class="w-full border-2 border-gray-200 rounded-2xl px-4 py-3 pr-10 focus:ring-2 focus:ring-red-500 focus:border-red-500 outline-none transition-all bg-white">
                     <?php foreach ($slots as $slot): ?>
-                      <?php $value = sprintf('%02d-%02d', (int)substr($slot['time_from'], 0, 2), (int)substr($slot['time_to'], 0, 2)); ?>
-                      <option value="<?= $value ?>">
+                      <option value="<?= $slot['id'] ?>">
                         <?= htmlspecialchars($slot['time_from'] . ' - ' . $slot['time_to']) ?>
                       </option>
                     <?php endforeach; ?>

--- a/src/Views/client/order_show.php
+++ b/src/Views/client/order_show.php
@@ -60,7 +60,7 @@ $discount = max(0, $rawSum - $order['total_amount']);
         <?php if ($order['delivery_date'] === $placeholder): ?>
           Ближайшая возможная дата
         <?php else: ?>
-          <?= date('d.m.Y', strtotime($order['delivery_date'])) ?> <?= htmlspecialchars(format_slot($order['delivery_slot'])) ?>
+          <?= date('d.m.Y', strtotime($order['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($order['slot_from'], $order['slot_to'])) ?>
         <?php endif; ?>
       </p>
       <p class="text-gray-700 mb-2 flex items-center">

--- a/src/Views/client/orders.php
+++ b/src/Views/client/orders.php
@@ -44,7 +44,7 @@ function status_classes(string $status): string {
                 <span class="font-semibold">#<?= $order['id'] ?>:</span>
                 <span>
                   <?php if (!empty($order['delivery_date'])): ?>
-                    <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['delivery_slot'])): ?> <?= htmlspecialchars(format_slot($order['delivery_slot'])) ?><?php endif; ?>
+                    <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['slot_from'])): ?> <?= htmlspecialchars(format_time_range($order['slot_from'], $order['slot_to'])) ?><?php endif; ?>
                   <?php endif; ?>
                 </span>
                 <span class="order-date hidden"><?= date('d.m.Y H:i', strtotime($order['created_at'])) ?></span>
@@ -92,7 +92,7 @@ function status_classes(string $status): string {
                 <span class="font-semibold">#<?= $order['id'] ?>:</span>
                 <span>
                   <?php if (!empty($order['delivery_date'])): ?>
-                    <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['delivery_slot'])): ?> <?= htmlspecialchars(format_slot($order['delivery_slot'])) ?><?php endif; ?>
+                    <?= date('d.m', strtotime($order['delivery_date'])) ?><?php if(!empty($order['slot_from'])): ?> <?= htmlspecialchars(format_time_range($order['slot_from'], $order['slot_to'])) ?><?php endif; ?>
                   <?php endif; ?>
                 </span>
                 <span class="order-date hidden"><?= date('d.m.Y H:i', strtotime($order['created_at'])) ?></span>


### PR DESCRIPTION
## Summary
- remove obsolete `orders.delivery_slot` column
- update queries and forms to use `slot_id`
- display delivery slots via `slot_from`/`slot_to`
- add migration and README note

## Testing
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_688360591884832c8f3e1ce0f6da74c3