### PR TITLE
Improve manager layout for mobile

### DIFF
--- a/src/Views/admin/manager_profile.php
+++ b/src/Views/admin/manager_profile.php
@@ -5,29 +5,29 @@
 /** @var array $partnerStats */
 ?>
 <div class="space-y-6">
-  <div class="bg-white rounded shadow p-4">
-    <h2 class="text-lg font-semibold mb-2">Общая статистика</h2>
-    <div class="grid grid-cols-3 gap-4 text-center">
+  <div class="bg-white rounded shadow p-2 md:p-4">
+    <h2 class="text-base md:text-lg font-semibold mb-2">Общая статистика</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 md:gap-4 text-center">
       <div>
-        <div class="text-2xl font-bold text-[#C86052]"><?= $ordersCount ?></div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $ordersCount ?></div>
         <div class="text-sm text-gray-600">продаж</div>
       </div>
       <div>
-        <div class="text-2xl font-bold text-[#C86052]"><?= $directClients ?></div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $directClients ?></div>
         <div class="text-sm text-gray-600">прямых клиентов</div>
       </div>
       <div>
-        <div class="text-2xl font-bold text-[#C86052]"><?= $secondClients ?></div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $secondClients ?></div>
         <div class="text-sm text-gray-600">клиентов второго уровня</div>
       </div>
     </div>
   </div>
-  <div class="bg-white rounded shadow p-4">
-    <h2 class="text-lg font-semibold mb-4">Партнёры</h2>
+  <div class="bg-white rounded shadow p-2 md:p-4">
+    <h2 class="text-base md:text-lg font-semibold mb-4">Партнёры</h2>
     <?php if (empty($partnerStats)): ?>
       <p class="text-gray-600">Партнёров нет</p>
     <?php else: ?>
-    <table class="min-w-full text-left">
+    <table class="min-w-full text-left text-sm">
       <thead class="bg-gray-100">
         <tr>
           <th class="p-2">Имя</th>

--- a/src/Views/layouts/manager_main.php
+++ b/src/Views/layouts/manager_main.php
@@ -230,15 +230,19 @@
     [data-theme='dark'] .status-btn:hover {
       background: #475569;
     }
+
+    @media (max-width: 768px) {
+      body { font-size: 14px; }
+    }
   </style>
 </head>
 <body class="flex flex-col min-h-screen bg-gray-100 font-sans">
 
   <!-- Header -->
-  <header class="flex items-center justify-between bg-white p-4 shadow">
-    <div class="flex items-center space-x-4">
-      <div class="font-bold text-xl text-[#C86052]">BerryGo Manager</div>
-      <nav class="hidden md:flex space-x-4">
+  <header class="flex items-center justify-between bg-white p-2 md:p-4 shadow">
+    <div class="flex items-center space-x-2 md:space-x-4">
+      <div class="font-bold text-lg md:text-xl text-[#C86052]">BerryGo Manager</div>
+      <nav class="hidden md:flex space-x-2 md:space-x-4">
         <a href="/manager/orders" class="hover:underline">Заказы</a>
         <a href="/manager/products" class="hover:underline">Товары</a>
         <a href="/manager/users" class="hover:underline">Пользователи</a>
@@ -256,32 +260,32 @@
   </header>
 
   <!-- Sidebar for small screens -->
-  <aside id="sidebar" class="md:hidden fixed top-16 left-0 w-64 bg-white shadow-md transform -translate-x-full transition-transform duration-300 z-40">
-    <nav class="p-4">
+  <aside id="sidebar" class="md:hidden fixed top-16 left-0 w-52 md:w-64 bg-white shadow-md transform -translate-x-full transition-transform duration-300 z-40">
+    <nav class="p-2 md:p-4">
       <a href="/manager/orders" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
-        <span class="material-icons-round mr-2">receipt_long</span>
-        <span class="menu-text">Заказы</span>
+        <span class="material-icons-round mr-2 text-base md:text-lg">receipt_long</span>
+        <span class="menu-text text-sm md:text-base">Заказы</span>
       </a>
       <a href="/manager/products" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
-        <span class="material-icons-round mr-2">inventory_2</span>
-        <span class="menu-text">Товары</span>
+        <span class="material-icons-round mr-2 text-base md:text-lg">inventory_2</span>
+        <span class="menu-text text-sm md:text-base">Товары</span>
       </a>
       <a href="/manager/users" class="flex items-center p-2 rounded hover:bg-gray-200">
-        <span class="material-icons-round mr-2">people</span>
-        <span class="menu-text">Пользователи</span>
+        <span class="material-icons-round mr-2 text-base md:text-lg">people</span>
+        <span class="menu-text text-sm md:text-base">Пользователи</span>
       </a>
       <a href="/manager/profile" class="flex items-center p-2 mt-2 rounded hover:bg-gray-200">
-        <span class="material-icons-round mr-2">account_circle</span>
-        <span class="menu-text">Профиль</span>
+        <span class="material-icons-round mr-2 text-base md:text-lg">account_circle</span>
+        <span class="menu-text text-sm md:text-base">Профиль</span>
       </a>
     </nav>
   </aside>
 
   <!-- Контент -->
   <div class="flex-1 flex flex-col">
-    <h1 class="text-2xl font-semibold text-gray-700 p-4"><?= htmlspecialchars($pageTitle) ?></h1>
+    <h1 class="text-xl md:text-2xl font-semibold text-gray-700 p-2 md:p-4"><?= htmlspecialchars($pageTitle) ?></h1>
     <!-- Main -->
-    <main class="p-6 overflow-auto bg-gray-50 flex-1">
+    <main class="p-3 md:p-6 overflow-auto bg-gray-50 flex-1">
       <?= $content ?>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- tweak manager layout paddings and fonts for mobile
- add mobile-friendly sizes to manager profile stats

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6883b75988e0832ca14e6b2c3c5aa37e