### PR TITLE
Improve mobile view for manager orders

### DIFF
--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -2,15 +2,30 @@
 <?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; ?>
 <?php $base = $isManager ? '/manager' : '/admin'; ?>
 <?php $managers = $managers ?? []; $selectedManager = $selectedManager ?? 0; ?>
+<style>
+  @media (max-width: 640px) {
+    .orders-filter select,
+    .orders-filter button,
+    .orders-filter input {
+      padding: 0.25rem 0.5rem;
+      font-size: 0.75rem;
+    }
+    .orders-table th,
+    .orders-table td {
+      padding: 0.25rem;
+      font-size: 0.75rem;
+    }
+  }
+</style>
 <?php if (!empty($_GET['msg'])): ?>
   <div class="mb-4 p-3 rounded bg-green-50 text-green-800 border border-green-200">
     <?= htmlspecialchars($_GET['msg']) ?>
   </div>
 <?php endif; ?>
 <div class="mb-2">
-  <a href="<?= $base ?>/orders/create" class="px-3 py-2 bg-[#C86052] text-white rounded text-sm">Создать заказ</a>
+  <a href="<?= $base ?>/orders/create" class="px-2 py-1 md:px-3 md:py-2 bg-[#C86052] text-white rounded text-xs md:text-sm">Создать заказ</a>
 </div>
-<div class="mb-4 flex flex-col md:flex-row md:items-end md:justify-between gap-2">
+<div class="orders-filter mb-4 flex flex-col md:flex-row md:items-end md:justify-between gap-2">
   <select id="statusFilter" class="border rounded px-3 py-2 text-sm">
     <option value="">Все статусы</option>
     <option value="new">Новые</option>
@@ -37,7 +52,8 @@
   </div>
 </div>
 
-<table class="min-w-full bg-white rounded shadow overflow-hidden">
+<div class="overflow-x-auto">
+<table class="orders-table min-w-full bg-white rounded shadow overflow-hidden">
   <thead class="bg-gray-200 text-gray-700">
     <tr>
       <th class="p-3 text-left font-semibold cursor-pointer sortable" data-sort="id">№</th>
@@ -83,6 +99,7 @@
     <?php endforeach; ?>
   </tbody>
 </table>
+</div>
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {

--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -1,6 +1,12 @@
 <?php /** @var array $order @var array $items */ ?>
 <?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
-<div class="space-y-4">
+<style>
+  @media (max-width: 640px) {
+    .order-details button { padding: 0.25rem 0.5rem; font-size: 0.75rem; }
+    .order-details span { font-size: 0.75rem; }
+  }
+</style>
+<div class="order-details space-y-4">
   <div class="flex justify-between items-center bg-white p-4 rounded shadow">
     <div class="flex flex-wrap items-center gap-2">
       <span class="font-semibold">Заказ #<?= $order['id'] ?></span>


### PR DESCRIPTION
## Summary
- tweak styles in orders index for smaller screens
- add responsive styles to orders details page

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6883bb26df18832c83a5d46897e9ba54