### PR TITLE
Fix orders query handling

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -65,6 +65,9 @@ class OrdersController
         $stmt = $this->pdo->prepare($sql);
         $stmt->execute($params);
         $orders = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        if (!$orders) {
+            $orders = [];
+        }
 
         // Load items for all orders (for manager view)
         $orderIds = array_column($orders, 'id');


### PR DESCRIPTION
## Summary
- guard `$orders` in OrdersController against null result

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6883c2e9caac832cadf561fb518a13c9