### PR TITLE
Fix coupon coupon code query parameter indexing

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -90,7 +90,10 @@ class OrdersController
         }
 
         // Prefetch coupon info
-        $codes = array_filter(array_column($orders, 'coupon_code'), fn($c) => $c !== null && $c !== '');
+        $codes = array_values(array_filter(
+            array_column($orders, 'coupon_code'),
+            fn($c) => $c !== null && $c !== ''
+        ));
         $couponInfo = [];
         if ($codes) {
             $placeholders = implode(',', array_fill(0, count($codes), '?'));


### PR DESCRIPTION
## Summary
- prevent mismatched placeholders when querying coupon codes

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6883c4a4b20c832caf2ff85aa8164090