### PR TITLE
Adjust manager orders styling for mobile

### DIFF
--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -61,7 +61,7 @@
         $createdAttr = date('Y-m-d H:i', strtotime($o['created_at']));
         $deliveryAttr = $o['delivery_date'] ? date('Y-m-d', strtotime($o['delivery_date'])) : '';
       ?>
-      <div class="order-card bg-white p-4 rounded shadow <?= $bg ?>" data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" data-created="<?= $createdAttr ?>" data-id="<?= $o['id'] ?>" data-delivery="<?= $deliveryAttr ?>">
+      <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="order-card block bg-white p-2 sm:p-4 rounded shadow hover:bg-gray-50 <?= $bg ?>" data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" data-created="<?= $createdAttr ?>" data-id="<?= $o['id'] ?>" data-delivery="<?= $deliveryAttr ?>">
         <div class="flex justify-between items-center">
           <div class="flex flex-col">
             <span class="font-semibold">#<?= $o['id'] ?><?php if ($o['delivery_date']): ?>, <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?></span>
@@ -104,7 +104,7 @@
           <span>Стоимость заказа:</span>
           <span><?= number_format($o['total_amount'], 0, '.', ' ') ?> ₽</span>
         </div>
-      </div>
+      </a>
     <?php endforeach; ?>
   </div>
 <?php else: ?>

--- a/src/Views/layouts/manager_main.php
+++ b/src/Views/layouts/manager_main.php
@@ -285,7 +285,7 @@
   <div class="flex-1 flex flex-col">
     <h1 class="text-xl md:text-2xl font-semibold text-gray-700 p-2 md:p-4"><?= htmlspecialchars($pageTitle) ?></h1>
     <!-- Main -->
-    <main class="p-3 md:p-6 overflow-auto bg-gray-50 flex-1">
+    <main class="p-0 sm:p-3 md:p-6 overflow-auto bg-gray-50 flex-1">
       <?= $content ?>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- link entire order card in manager orders list
- tweak main padding responsively

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6883cd586b78832c8ac0a186ee16b2eb