### PR TITLE
Adjust order card header for manager

### DIFF
--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -77,15 +77,15 @@
       ?>
       <div class="order-card block bg-white p-2 sm:p-4 rounded shadow hover:bg-gray-50 <?= $bg ?>" data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" data-created="<?= $createdAttr ?>" data-id="<?= $o['id'] ?>" data-delivery="<?= $deliveryAttr ?>" data-slot="<?= $slotAttr ?>">
         <div class="flex justify-between items-center">
-          <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col font-bold underline">
-            <span class="text-green-600">#<?= $o['id'] ?></span><?php if ($o['delivery_date']): ?>, <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?>
+          <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col font-bold underline<?php if($isManager): ?> text-white decoration-white<?php endif; ?>">
+            <span class="<?= $isManager ? 'text-white' : 'text-green-600' ?>">#<?= $o['id'] ?></span><?php if ($o['delivery_date']): ?>, <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?>
           </a>
           <span class="inline-flex items-center px-2 py-0.5 rounded-full text-sm font-medium <?= order_status_info($o['status'])['badge'] ?>">
             <?= order_status_info($o['status'])['label'] ?>
           </span>
         </div>
         <div class="text-sm text-gray-600 mt-1">
-          <?= htmlspecialchars($o['client_name']) ?>, <a href="https://wa.me/<?= $wa ?>" class="hover:underline" target="_blank"><?= htmlspecialchars($o['phone']) ?></a>, <?= htmlspecialchars($o['address']) ?>
+          <?= htmlspecialchars($o['client_name']) ?>, <a href="https://wa.me/<?= $wa ?>" class="<?php if($isManager): ?>text-green-600 underline hover:text-green-700<?php else: ?>hover:underline<?php endif; ?>" target="_blank"><?= htmlspecialchars($o['phone']) ?></a>, <?= htmlspecialchars($o['address']) ?>
         </div>
         <div class="font-semibold mt-2">Состав:</div>
         <?php foreach ($o['items'] as $it): ?>


### PR DESCRIPTION
## Summary
- tweak `/manager/orders` card styles to display order header link in white and WhatsApp link in green

## Testing
- `composer install`
- `vendor/bin/phpunit --testsuite unit`

------
https://chatgpt.com/codex/tasks/task_e_6883dadc2da4832c8abac0d50daa3fbf