### PR TITLE
Remove self-pickup discount

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -710,7 +710,6 @@ public function cart(): void
     $recipientPhone  = $this->normalizePhone($_POST['recipient_phone'] ?? '');
 
     $addressIds   = [];
-    $pickupByDate = [];
     foreach ($itemsByDate as $dateKey => $_) {
         $addrInput = $postedAddresses[$dateKey] ?? $defaultAddress;
         $streetVal = '';
@@ -734,7 +733,7 @@ public function cart(): void
             $addressIds[$dateKey] = $this->ensureAddress($userId, $addrInput, $recipientName, $recipientPhone);
             $streetVal = $addrInput;
         }
-        $pickupByDate[$dateKey] = ($addrInput === 'pickup') || stripos($streetVal, 'самовывоз') !== false;
+        // сохраняем адрес как обычный, скидка за самовывоз не применяется
     }
 
     // 9) СОЗДАЁМ ЗАКАЗЫ ПО КАЖДОЙ ДАТЕ, учитываем дату и слот
@@ -745,11 +744,7 @@ public function cart(): void
         foreach ($block as $data) {
             $blockSum += $data['quantity'] * $data['unit_price'];
         }
-        $pickupDiscount = 0;
-        if (!empty($pickupByDate[$dateKey])) {
-            $pickupDiscount = (int) floor($blockSum * 0.20);
-        }
-        $subAfterPickup = $blockSum - $pickupDiscount;
+        $subAfterPickup = $blockSum;
         $pointsDiscount = $discountsByDate[$dateKey] ?? 0;
         $couponDiscount = 0;
         if ($discountPercent > 0) {
@@ -773,7 +768,7 @@ public function cart(): void
             $addressIds[$dateKey],
             $slotId,
             $finalSum,
-            $couponDiscount + $pickupDiscount, // discount_applied = скидка по купону и самовывозу
+            $couponDiscount, // discount_applied = скидка по купону
             $pointsDiscount,  // points_used = списанные баллы
             $pointsAccrued,   // points_accrued = пока 0
             $couponCode,

--- a/src/Views/admin/orders/create.php
+++ b/src/Views/admin/orders/create.php
@@ -26,9 +26,6 @@
       <input type="text" name="new_address" placeholder="Адрес" class="border px-2 py-1 rounded w-full">
     </div>
     <div>
-      <label><input type="checkbox" name="pickup" id="pickupChk"> Самовывоз</label>
-    </div>
-    <div>
       <label>Дата доставки:</label>
       <input type="date" name="delivery_date" value="<?= $today ?>" class="border px-2 py-1 rounded">
       <select name="slot_id" class="border px-2 py-1 rounded">
@@ -76,7 +73,6 @@
     <div id="itemsList" class="space-y-1 text-sm"></div>
     <div id="summary" class="space-y-1 text-sm">
       <div class="flex justify-between"><span>Стоимость товаров:</span> <span id="sumSubtotal">0</span></div>
-      <div id="rowPickup" class="flex justify-between hidden"><span>Самовывоз -20%</span> <span id="sumPickup">0</span></div>
       <div id="rowReferral" class="flex justify-between hidden"><span>Скидка -10%</span> <span id="sumReferral">0</span></div>
       <div class="flex justify-between font-semibold border-t pt-1"><span>Итого:</span> <span id="sumTotal">0</span></div>
     </div>
@@ -115,11 +111,8 @@
   const addressWrapper = document.getElementById('addressWrapper');
   const addressSelect = document.getElementById('addressSelect');
   const addressNew = document.getElementById('addressNew');
-  const pickupChk = document.getElementById('pickupChk');
   const qtyInputs = document.querySelectorAll('.qty');
   const subtotalEl = document.getElementById('sumSubtotal');
-  const pickupRow = document.getElementById('rowPickup');
-  const pickupEl = document.getElementById('sumPickup');
   const refRow = document.getElementById('rowReferral');
   const refEl = document.getElementById('sumReferral');
   const totalEl = document.getElementById('sumTotal');
@@ -188,7 +181,6 @@
     });
   });
   qtyInputs.forEach(i=>i.addEventListener('input', updateSummary));
-  pickupChk.addEventListener('change', updateSummary);
   if (pointsInput) pointsInput.addEventListener('input', updateSummary);
 
   function updateSummary() {
@@ -207,15 +199,6 @@
     });
     subtotalEl.textContent = subtotal.toFixed(2) + ' ₽';
     let total = subtotal;
-    const pickup = pickupChk.checked;
-    if (pickup) {
-      const d = subtotal * 0.2;
-      pickupEl.textContent = '-' + d.toFixed(2);
-      pickupRow.classList.remove('hidden');
-      total -= d;
-    } else {
-      pickupRow.classList.add('hidden');
-    }
     const referral = document.getElementById('userId').value === '';
     if (referral) {
       const d = subtotal * 0.1;
@@ -262,7 +245,6 @@
       } else {
         addressNew.classList.add('hidden');
       }
-      pickupChk.checked = addressSelect.value === 'pickup';
     });
   }
 </script>

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -100,12 +100,6 @@
             <span>-<?= number_format($o['coupon_discount'], 0, '.', ' ') ?> ₽</span>
           </div>
         <?php endif; ?>
-        <?php if (($o['pickup_discount'] ?? 0) > 0): ?>
-          <div class="flex justify-between text-sm">
-            <span>Скидка за самовывоз:</span>
-            <span>-<?= number_format($o['pickup_discount'], 0, '.', ' ') ?> ₽</span>
-          </div>
-        <?php endif; ?>
         <div class="flex justify-between font-semibold border-t pt-1 mt-1">
           <span>Стоимость заказа:</span>
           <span><?= number_format($o['total_amount'], 0, '.', ' ') ?> ₽</span>

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -126,14 +126,7 @@ $regularKg  = round($price, 2);
   <div class="flex-1"></div>
 <?php endif; ?>
 
-    <!-- Самовывоз toggle -->
-    <div class="flex items-center justify-between mb-3 bg-gray-50 rounded px-2 py-1">
-      <span class="text-sm text-gray-600 font-semibold">Самовывоз -20%</span>
-      <label class="inline-flex relative items-center cursor-pointer">
-        <input type="checkbox" class="sr-only peer pickup-toggle">
-        <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-pink-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-pink-500"></div>
-      </label>
-    </div>
+
 
     <!-- Блок цены -->
     <div class="mt-auto">

--- a/src/Views/client/cart.php
+++ b/src/Views/client/cart.php
@@ -150,7 +150,6 @@
             </button>
           </form>
         </div>
-        <p class="text-xs text-gray-500 mt-3 text-center">Скидка за самовывоз будет рассчитана при подтверждении заказа.</p>
       </div>
     </div>
 

--- a/src/Views/client/checkout.php
+++ b/src/Views/client/checkout.php
@@ -242,10 +242,6 @@ $slots           = $slots           ?? [];
             <div class="bg-gradient-to-r from-emerald-50 to-teal-50 rounded-2xl p-4">
               <div class="flex justify-between items-center">
                 <div>
-                  <div id="pickupRow" class="flex justify-between text-sm text-gray-600 mb-1 hidden">
-                    <span>Самовывоз -20%</span>
-                    <span id="pickupAmount">-0 ₽</span>
-                  </div>
                   <div class="text-sm text-gray-600 mb-1">К оплате</div>
                   <div id="finalTotal" class="text-2xl font-bold text-gray-800"
                        data-subtotal="<?= (int)$subtotal ?>"
@@ -280,24 +276,6 @@ $slots           = $slots           ?? [];
 <script>
   const select = document.getElementById('addressSelect');
   const block = document.getElementById('newAddressBlock');
-  function applyPickup() {
-    if (!select) return;
-    const enabled = localStorage.getItem('pickupEnabled') === '1';
-    let opt = select.querySelector('option[value="pickup"]');
-    if (enabled) {
-      if (!opt) {
-        opt = document.createElement('option');
-        opt.value = 'pickup';
-        opt.textContent = 'Самовывоз 9 мая 73';
-        select.prepend(opt);
-      }
-      select.value = 'pickup';
-      block.classList.add('hidden');
-    } else if (opt) {
-      if (opt.selected) select.selectedIndex = 0;
-      opt.remove();
-    }
-  }
   function toggleBlock() {
     if (select.value === 'new') {
       block.classList.remove('hidden');
@@ -311,7 +289,6 @@ $slots           = $slots           ?? [];
   }
 
   function updateTotal() {
-    applyPickup();
     toggleBlock();
     const finalEl = document.getElementById('finalTotal');
     if (!finalEl) return;
@@ -320,13 +297,7 @@ $slots           = $slots           ?? [];
     const couponPts = parseFloat(finalEl.dataset.couponpoints);
     const discountPercent = parseFloat(finalEl.dataset.discountpercent);
 
-    const pickup = select && select.value === 'pickup';
-    let pickupDiscount = 0;
-    let subAfterPickup = subtotal;
-    if (pickup) {
-      pickupDiscount = Math.floor(subtotal * 0.20);
-      subAfterPickup -= pickupDiscount;
-    }
+    const subAfterPickup = subtotal;
 
     const pointsDiscount = Math.min(points + couponPts, subAfterPickup);
     const afterPoints = subAfterPickup - pointsDiscount;
@@ -338,14 +309,7 @@ $slots           = $slots           ?? [];
     const final = afterPoints - couponDiscount;
     finalEl.textContent = format(final) + ' ₽';
 
-    const row = document.getElementById('pickupRow');
-    const amtEl = document.getElementById('pickupAmount');
-    if (pickup && row && amtEl) {
-      amtEl.textContent = '-' + format(pickupDiscount) + ' ₽';
-      row.classList.remove('hidden');
-    } else if (row) {
-      row.classList.add('hidden');
-    }
+
   }
 
   if (select) {

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -42,14 +42,7 @@
           </p>
         <?php endif; ?>
 
-        <!-- Самовывоз toggle -->
-        <div class="flex items-center justify-between mb-3 bg-gray-50 rounded px-2 py-1">
-          <span class="text-sm text-gray-600 font-semibold">Самовывоз -20%</span>
-          <label class="inline-flex relative items-center cursor-pointer">
-            <input type="checkbox" class="sr-only peer pickup-toggle">
-            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-pink-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-pink-500"></div>
-          </label>
-        </div>
+
         <?php
         $active = (int)($product['is_active'] ?? 0);
         $price  = floatval($product['price'] ?? 0);

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -957,44 +957,7 @@
       
 
   
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const toggles = document.querySelectorAll('.pickup-toggle');
-    if (toggles.length === 0) return;
-    const cards = document.querySelectorAll('.product-card');
-    let state = localStorage.getItem('pickupEnabled') === '1';
-    toggles.forEach(t => t.checked = state);
 
-    function format(num) {
-      return num.toLocaleString('ru-RU');
-    }
-
-    function update() {
-      const mul = state ? 0.8 : 1;
-      cards.forEach(c => {
-        const baseBox = parseFloat(c.dataset.baseBox);
-        const baseKg = parseFloat(c.dataset.baseKg);
-        if (!isNaN(baseBox)) {
-          const el = c.querySelector('.box-price');
-          if (el) el.textContent = format(Math.round(baseBox * mul)) + ' ₽/ящик';
-        }
-        if (!isNaN(baseKg)) {
-          const el2 = c.querySelector('.kg-price');
-          if (el2) el2.textContent = format(Math.round(baseKg * mul)) + ' ₽/кг';
-        }
-      });
-    }
-
-    update();
-
-    toggles.forEach(t => t.addEventListener('change', e => {
-      state = e.target.checked;
-      localStorage.setItem('pickupEnabled', state ? '1' : '0');
-      toggles.forEach(other => { if (other !== e.target) other.checked = state; });
-      update();
-    }));
-  });
-</script>
 
 <?php include __DIR__ . '/scripts.php'; ?>
 </body>


### PR DESCRIPTION
## Summary
- eliminate self-pickup discount logic in order and checkout flows
- drop pickup discount UI from product cards and admin pages
- simplify checkout script and related layout
- update order views to remove pickup discount fields

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688859b83b0c832c90e8d4fc45e3c8a0