### PR TITLE
Add delivery fee option

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -521,7 +521,8 @@ public function cart(): void
         if ($discountPercent > 0) {
             $couponPercentAmount = (int)floor(($subtotal - $pointsDiscountTotal) * ($discountPercent / 100));
         }
-        $finalTotal = $subtotal - $pointsDiscountTotal - $couponPercentAmount;
+        $shippingTotal = 300 * count($groups);
+        $finalTotal = $subtotal - $pointsDiscountTotal - $couponPercentAmount + $shippingTotal;
     
         // 8) Берём текущий адрес пользователя
         $addrStmt = $this->pdo->prepare(
@@ -750,7 +751,9 @@ public function cart(): void
         if ($discountPercent > 0) {
             $couponDiscount = (int) floor(($subAfterPickup - $pointsDiscount) * ($discountPercent / 100));
         }
-        $finalSum = $subAfterPickup - $pointsDiscount - $couponDiscount;
+        $addrInput = $postedAddresses[$dateKey] ?? $defaultAddress;
+        $shippingFee = ($addrInput === 'pickup') ? 0 : 300;
+        $finalSum = $subAfterPickup - $pointsDiscount - $couponDiscount + $shippingFee;
 
         $slotId = $_POST['slot_id'][$dateKey] ?? null; // из формы
 

--- a/src/Views/client/checkout.php
+++ b/src/Views/client/checkout.php
@@ -154,23 +154,28 @@ $slots           = $slots           ?? [];
                     <?= number_format($orderSum, 0, '.', ' ') ?> ₽
                   </span>
                 </div>
+                <div class="flex justify-between items-center pt-2" data-shipping-row>
+                  <span class="font-semibold text-gray-800">Доставка:</span>
+                  <span class="font-bold text-gray-800">300 ₽</span>
+                </div>
               </div>
             </div>
           </div>
         <?php endforeach; ?>
 
-        <!-- Адрес доставки -->
+        <!-- Способ получения -->
         <div class="bg-white rounded-3xl shadow-lg p-6">
           <h3 class="text-lg font-semibold text-gray-800 mb-4">
             <span class="material-icons-round text-lg mr-2 align-middle">location_on</span>
-            Адрес доставки
+            Способ получения
           </h3>
           <div class="space-y-2">
             <select name="address_id[default]" id="addressSelect" class="w-full border-2 border-gray-200 rounded-2xl px-4 py-3 focus:ring-2 focus:ring-red-500 focus:border-red-500 outline-none">
               <?php foreach ($addresses as $a): ?>
-                <option value="<?= $a['id'] ?>" <?= $a['is_primary'] ? 'selected' : '' ?>><?= htmlspecialchars($a['street']) ?> (<?= htmlspecialchars($a['recipient_name']) ?>)</option>
+                <option value="<?= $a['id'] ?>" <?= $a['is_primary'] ? 'selected' : '' ?>>Доставка: <?= htmlspecialchars($a['street']) ?> (<?= htmlspecialchars($a['recipient_name']) ?>)</option>
               <?php endforeach; ?>
-              <option value="new">Другой адрес</option>
+              <option value="new">Доставка: другой адрес</option>
+              <option value="pickup">Самовывоз: 9 мая 73</option>
             </select>
             <div id="newAddressBlock" class="space-y-2 hidden">
               <input type="text" name="new_address" placeholder="Адрес" class="w-full border-2 border-gray-200 rounded-2xl px-4 py-3 focus:ring-2 focus:ring-red-500 focus:border-red-500 outline-none">
@@ -247,7 +252,9 @@ $slots           = $slots           ?? [];
                        data-subtotal="<?= (int)$subtotal ?>"
                        data-pointstouse="<?= (int)$pointsToUse ?>"
                        data-couponpoints="<?= (int)$couponPoints ?>"
-                       data-discountpercent="<?= (float)$discountPercent ?>">
+                       data-discountpercent="<?= (float)$discountPercent ?>"
+                       data-groups="<?= count($groups) ?>"
+                       data-shipping="300">
                     <?= number_format($finalTotal, 0, '.', ' ') ?> ₽
                   </div>
                 </div>
@@ -296,20 +303,28 @@ $slots           = $slots           ?? [];
     const points = parseFloat(finalEl.dataset.pointstouse);
     const couponPts = parseFloat(finalEl.dataset.couponpoints);
     const discountPercent = parseFloat(finalEl.dataset.discountpercent);
+    const groups = parseInt(finalEl.dataset.groups);
+    const shipPer = parseFloat(finalEl.dataset.shipping);
 
-    const subAfterPickup = subtotal;
+    const shipping = select.value === 'pickup' ? 0 : shipPer * groups;
 
-    const pointsDiscount = Math.min(points + couponPts, subAfterPickup);
-    const afterPoints = subAfterPickup - pointsDiscount;
+    const pointsDiscount = Math.min(points + couponPts, subtotal);
+    const afterPoints = subtotal - pointsDiscount;
     let couponDiscount = 0;
     if (discountPercent > 0) {
       couponDiscount = Math.floor(afterPoints * (discountPercent / 100));
     }
 
-    const final = afterPoints - couponDiscount;
+    const final = afterPoints - couponDiscount + shipping;
     finalEl.textContent = format(final) + ' ₽';
 
-
+    document.querySelectorAll('[data-shipping-row]').forEach(row => {
+      if (select.value === 'pickup') {
+        row.classList.add('hidden');
+      } else {
+        row.classList.remove('hidden');
+      }
+    });
   }
 
   if (select) {

--- a/src/Views/client/order_show.php
+++ b/src/Views/client/order_show.php
@@ -19,7 +19,8 @@ foreach ($items as $it) {
     $rawSum += ($it['quantity'] * $it['unit_price']);
 }
 // Сумма скидки в рублях
-$discount = max(0, $rawSum - $order['total_amount']);
+$shippingCost = (stripos($order['address'] ?? '', 'Самовывоз') === false) ? 300 : 0;
+$discount = max(0, $rawSum - $order['total_amount'] + $shippingCost);
 ?>
 
 <main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 min-h-screen pb-24">
@@ -134,8 +135,12 @@ $discount = max(0, $rawSum - $order['total_amount']);
         <?php endif; ?>
       </div>
 
-      <!-- Окончательная сумма -->
       <div class="flex justify-between items-center pt-4 border-t border-gray-200 mt-4">
+        <span class="font-semibold text-gray-800">Доставка:</span>
+        <span class="font-semibold text-gray-800"><?= $shippingCost > 0 ? '300 ₽' : '0 ₽' ?></span>
+      </div>
+      <!-- Окончательная сумма -->
+      <div class="flex justify-between items-center pt-2">
         <span class="font-semibold text-gray-800 text-lg">Стоимость заказа:</span>
         <span class="font-bold text-2xl text-gray-800">
           <?= number_format($order['total_amount'], 0, '.', ' ') ?> ₽


### PR DESCRIPTION
## Summary
- rename the delivery address block to pick-up method and add pickup option
- show delivery cost per order in checkout page
- calculate delivery fee in totals and order processing
- display delivery price in order details

## Testing
- `composer install`
- `php -d variables_order=EGPCS vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68889c1978dc832cbf129a9ace26c754