### PR TITLE
feat: show manager quick links on main page

### DIFF
--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -244,6 +244,15 @@
     <?php if (($_SESSION['role'] ?? '') === 'admin'): ?>
       <button id="adminToggle" class="material-icons-round text-2xl text-gray-600 hover:text-emerald-500 transition-colors p-2 hover:bg-emerald-50 rounded-xl">settings</button>
     <?php elseif (($_SESSION['role'] ?? '') === 'manager'): ?>
+      <a href="/manager/users/edit" class="p-2 text-gray-600 hover:text-[#C86052]" title="Добавить пользователя">
+        <span class="material-icons-round">person_add</span>
+      </a>
+      <a href="/manager/orders/create" class="p-2 text-gray-600 hover:text-[#C86052]" title="Создать заказ">
+        <span class="material-icons-round">add_shopping_cart</span>
+      </a>
+      <a href="/manager/profile" class="p-2 text-gray-600 hover:text-[#C86052]" title="Дашборд">
+        <span class="material-icons-round">dashboard</span>
+      </a>
       <button id="managerToggle" class="material-icons-round text-2xl text-gray-600 hover:text-emerald-500 transition-colors p-2 hover:bg-emerald-50 rounded-xl">manage_accounts</button>
     <?php endif; ?>
 

--- a/src/Views/layouts/manager_main.php
+++ b/src/Views/layouts/manager_main.php
@@ -248,17 +248,6 @@
         <a href="/manager/users" class="hover:underline">Пользователи</a>
         <a href="/manager/profile" class="hover:underline">Профиль</a>
       </nav>
-      <div class="flex space-x-1 md:space-x-2">
-        <a href="/manager/users/edit" class="p-2 text-gray-600 hover:text-[#C86052]" title="Добавить пользователя">
-          <span class="material-icons-round">person_add</span>
-        </a>
-        <a href="/manager/orders/create" class="p-2 text-gray-600 hover:text-[#C86052]" title="Создать заказ">
-          <span class="material-icons-round">add_shopping_cart</span>
-        </a>
-        <a href="/manager/profile" class="p-2 text-gray-600 hover:text-[#C86052]" title="Дашборд">
-          <span class="material-icons-round">dashboard</span>
-        </a>
-      </div>
       <button id="burgerBtn" class="md:hidden p-2 text-gray-600">
         <span class="material-icons-round">menu</span>
       </button>


### PR DESCRIPTION
## Summary
- show manager quick links in main layout header
- remove duplicate icons from manager-specific layout

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688f241862b8832cbfcdb07bbdc0bc31