### PR TITLE
Add partner management interface

### DIFF
--- a/index.php
+++ b/index.php
@@ -97,7 +97,7 @@ function viewAdmin(string $template, array $data = []): void
     require __DIR__ . "/src/Views/admin/{$template}.php";
     $content = ob_get_clean();
     $role = $_SESSION['role'] ?? '';
-    if ($role === 'manager') {
+    if (in_array($role, ['manager','partner'], true)) {
         require __DIR__ . '/src/Views/layouts/manager_main.php';
     } else {
         require __DIR__ . '/src/Views/layouts/admin_main.php';
@@ -163,6 +163,16 @@ function requireManager(): void
 {
     $role = $_SESSION['role'] ?? '';
     if (!in_array($role, ['manager', 'admin'], true)) {
+        header('Location: /login');
+        exit;
+    }
+}
+
+// Partner access (partner, manager or admin)
+function requirePartner(): void
+{
+    $role = $_SESSION['role'] ?? '';
+    if (!in_array($role, ['partner', 'manager', 'admin'], true)) {
         header('Location: /login');
         exit;
     }
@@ -714,6 +724,106 @@ switch ("$method $uri") {
         break;
     case 'POST /manager/users/toggle-block':
         requireManager();
+        (new App\Controllers\UsersController($pdo))->toggleBlock();
+        break;
+
+    // === ROUTES FOR PARTNERS ===
+    case 'GET /partner/dashboard':
+        requirePartner();
+        (new App\Controllers\AdminController($pdo))->dashboard();
+        break;
+    case 'GET /partner/profile':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->partnerProfile();
+        break;
+    case 'GET /partner/orders':
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->index();
+        break;
+    case 'GET /partner/orders/create':
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->create();
+        break;
+    case 'POST /partner/orders/create':
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->storeManual();
+        break;
+    case (bool)preg_match('#^GET /partner/orders/(\d+)$#', "$method $uri", $m):
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->show((int)$m[1]);
+        break;
+    case 'POST /partner/orders/assign':
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->assign();
+        break;
+    case 'POST /partner/orders/status':
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->updateStatus();
+        break;
+    case 'POST /partner/orders/update-item':
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->updateItemQuantity();
+        break;
+    case 'POST /partner/orders/update-delivery':
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->updateDelivery();
+        break;
+    case 'POST /partner/orders/delete':
+        requirePartner();
+        (new App\Controllers\OrdersController($pdo))->delete();
+        break;
+
+    case 'GET /partner/products':
+        requirePartner();
+        (new App\Controllers\ProductsController($pdo))->index();
+        break;
+    case 'GET /partner/products/edit':
+        requirePartner();
+        (new App\Controllers\ProductsController($pdo))->edit();
+        break;
+    case 'POST /partner/products/save':
+        requirePartner();
+        (new App\Controllers\ProductsController($pdo))->save();
+        break;
+    case 'POST /partner/products/toggle':
+        requirePartner();
+        (new App\Controllers\ProductsController($pdo))->toggle();
+        break;
+    case 'POST /partner/products/update-date':
+        requirePartner();
+        (new App\Controllers\ProductsController($pdo))->updateDeliveryDate();
+        break;
+    case 'POST /partner/products/delete':
+        requirePartner();
+        (new App\Controllers\ProductsController($pdo))->delete();
+        break;
+
+    case 'GET /partner/users':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->index();
+        break;
+    case 'GET /partner/users/search':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->searchPhone();
+        break;
+    case 'GET /partner/users/addresses':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->addresses();
+        break;
+    case (bool)preg_match('#^GET /partner/users/(\d+)$#', "$method $uri", $m):
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->show((int)$m[1]);
+        break;
+    case 'GET /partner/users/edit':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->edit();
+        break;
+    case 'POST /partner/users/save':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->save();
+        break;
+    case 'POST /partner/users/toggle-block':
+        requirePartner();
         (new App\Controllers\UsersController($pdo))->toggleBlock();
         break;
 

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -19,9 +19,12 @@ class OrdersController
      */
     private function basePath(): string
     {
-        return ($_SESSION['role'] ?? '') === 'manager'
-            ? '/manager/orders'
-            : '/admin/orders';
+        $role = $_SESSION['role'] ?? '';
+        return match ($role) {
+            'manager' => '/manager/orders',
+            'partner' => '/partner/orders',
+            default   => '/admin/orders',
+        };
     }
 
     /**

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -17,9 +17,12 @@ class ProductsController
      */
     private function basePath(): string
     {
-        return ($_SESSION['role'] ?? '') === 'manager'
-            ? '/manager/products'
-            : '/admin/products';
+        $role = $_SESSION['role'] ?? '';
+        return match ($role) {
+            'manager' => '/manager/products',
+            'partner' => '/partner/products',
+            default   => '/admin/products',
+        };
     }
 
 
@@ -295,10 +298,13 @@ class ProductsController
         }
         // Determine where to redirect after updating
         $refererPath = parse_url($_SERVER['HTTP_REFERER'] ?? '', PHP_URL_PATH) ?? '';
-        if (preg_match('#^/(admin|manager)/#', $refererPath)) {
-            $base = ($_SESSION['role'] ?? '') === 'manager'
-                ? '/manager/products'
-                : '/admin/products';
+        if (preg_match('#^/(admin|manager|partner)/#', $refererPath)) {
+            $role = $_SESSION['role'] ?? '';
+            $base = match ($role) {
+                'manager' => '/manager/products',
+                'partner' => '/partner/products',
+                default   => '/admin/products',
+            };
         } else {
             $base = '/';
         }

--- a/src/Views/admin/orders/create.php
+++ b/src/Views/admin/orders/create.php
@@ -1,5 +1,5 @@
 <?php /** @var array $products @var array $slots */ ?>
-<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
+<?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 
 <?php if (!empty($_GET['error'])): ?>
   <div class="mb-4 p-3 bg-red-50 text-red-700 rounded"><?= htmlspecialchars($_GET['error']) ?></div>

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -1,6 +1,5 @@
 <?php /** @var array $orders */ ?>
-<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; ?>
-<?php $base = $isManager ? '/manager' : '/admin'; ?>
+<?php $role = $_SESSION['role'] ?? ''; $isManager = ($role === 'manager'); $isStaff = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 <?php $managers = $managers ?? []; $selectedManager = $selectedManager ?? 0; $slots = $slots ?? []; ?>
 <style>
   @media (max-width: 640px) {
@@ -33,7 +32,7 @@
     <option value="delivered">Выполненные</option>
     <option value="cancelled">Отмененные</option>
   </select>
-  <?php if ($isManager || !empty($managers)): ?>
+  <?php if ($role === 'manager' || !empty($managers)): ?>
     <select id="managerFilter" class="border rounded px-3 py-2 text-sm">
       <option value="">Все менеджеры</option>
       <?php foreach ($managers as $m): ?>
@@ -68,7 +67,7 @@
       ?>
       <div class="order-card block bg-white p-2 sm:p-4 rounded shadow hover:bg-gray-50 <?= $bg ?>" data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" data-created="<?= $createdAttr ?>" data-id="<?= $o['id'] ?>" data-delivery="<?= $deliveryAttr ?>" data-slot="<?= $slotAttr ?>">
         <div class="flex justify-between items-center">
-          <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col font-bold<?php if($isManager): ?> text-white decoration-white<?php endif; ?>">
+          <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col font-bold<?php if($isStaff): ?> text-white decoration-white<?php endif; ?>">
             #<?= $o['id'] ?> <?php if ($o['delivery_date']): ?> | <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?>
           </a>
           <span class="inline-flex items-center px-2 py-0.5 rounded-full text-sm font-medium <?= order_status_info($o['status'])['badge'] ?>">
@@ -77,7 +76,7 @@
         </div>
         <div class="text-sm text-gray-600 mt-1">
           <?= htmlspecialchars($o['client_name']) ?>,
-          <a href="https://wa.me/<?= $wa ?>" class="<?php if($isManager): ?>text-green-600 underline hover:text-green-700<?php else: ?>hover:underline<?php endif; ?>" target="_blank"><?= htmlspecialchars($o['phone']) ?></a>,
+          <a href="https://wa.me/<?= $wa ?>" class="<?php if($isStaff): ?>text-green-600 underline hover:text-green-700<?php else: ?>hover:underline<?php endif; ?>" target="_blank"><?= htmlspecialchars($o['phone']) ?></a>,
           <a href="#" class="copy-address hover:underline" data-address="<?= htmlspecialchars($o['address'], ENT_QUOTES) ?>"><?= htmlspecialchars($o['address']) ?></a>
         </div>
         <div class="font-semibold mt-2">Состав:</div>
@@ -115,7 +114,7 @@
     const dateButtons = document.querySelectorAll('.date-btn');
     let dateFilter = '';
     const managerFilter = document.getElementById('managerFilter');
-    const isManager = <?= $isManager ? 'true' : 'false' ?>;
+    const isManager = <?= $isStaff ? 'true' : 'false' ?>;
     let rows = document.querySelectorAll('#ordersCards .order-card');
 
     function applyFilters() {

--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -1,5 +1,5 @@
 <?php /** @var array $order @var array $items @var array $addresses @var array $slots */ ?>
-<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
+<?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 <style>
   @media (max-width: 640px) {
     .order-details button { padding: 0.25rem 0.5rem; font-size: 0.75rem; }

--- a/src/Views/admin/partner_profile.php
+++ b/src/Views/admin/partner_profile.php
@@ -1,0 +1,20 @@
+<?php /** @var int $clientCount @var int $ordersCount @var int $revenue */ ?>
+<div class="space-y-6">
+  <div class="bg-white rounded shadow p-2 md:p-4">
+    <h2 class="text-base md:text-lg font-semibold mb-2">Общая статистика</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 md:gap-4 text-center">
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $ordersCount ?></div>
+        <div class="text-sm text-gray-600">продаж</div>
+      </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $clientCount ?></div>
+        <div class="text-sm text-gray-600">клиентов</div>
+      </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $revenue ?></div>
+        <div class="text-sm text-gray-600">оборот, ₽</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -6,7 +6,7 @@
  * @var string     $box_unit
  */
 ?>
-<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
+<?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 <form action="<?= $base ?>/products/save" method="post" enctype="multipart/form-data"
       class="bg-white p-6 rounded shadow max-w-lg mx-auto">
 

--- a/src/Views/admin/products/index.php
+++ b/src/Views/admin/products/index.php
@@ -1,6 +1,5 @@
 <?php /** @var array $products */ ?>
-<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; ?>
-<?php $base = $isManager ? '/manager' : '/admin'; ?>
+<?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 
 <a href="<?= $base ?>/products/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
   <span class="material-icons-round text-base mr-1">add</span> Добавить товар</a>

--- a/src/Views/admin/users/edit.php
+++ b/src/Views/admin/users/edit.php
@@ -1,6 +1,6 @@
 <?php /** @var array|null $user */ ?>
 <?php $isNew = empty($user); ?>
-<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
+<?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 
 <?php if (!empty($_GET['error'])): ?>
   <div class="bg-red-50 border-l-4 border-red-400 p-3 mb-4 rounded">

--- a/src/Views/admin/users/index.php
+++ b/src/Views/admin/users/index.php
@@ -1,6 +1,5 @@
 <?php /** @var array $users */ ?>
-<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; ?>
-<?php $base = $isManager ? '/manager' : '/admin'; ?>
+<?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 <form method="get" class="mb-4 flex">
   <input type="text" name="q" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Телефон или адрес" class="border rounded px-3 py-2 mr-2 flex-grow">
   <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Поиск</button>

--- a/src/Views/admin/users/show.php
+++ b/src/Views/admin/users/show.php
@@ -1,5 +1,5 @@
 <?php /** @var array $user @var array $transactions */ ?>
-<?php $isManager = ($_SESSION['role'] ?? '') === 'manager'; $base = $isManager ? '/manager' : '/admin'; ?>
+<?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 <h1 class="text-xl font-semibold mb-4">Пользователь #<?= $user['id'] ?></h1>
 <div class="bg-white p-4 rounded shadow mb-4">
   <div class="font-semibold text-lg mb-1"><?= htmlspecialchars($user['name']) ?></div>

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -33,8 +33,8 @@ $priceBox   = $effectiveKg * $boxSize;
 $pricePerKg = round($effectiveKg, 2);
 $regularBox = $price * $boxSize;
 $role     = $_SESSION['role'] ?? '';
-$isStaff  = in_array($role, ['admin','manager'], true);
-$basePath = $role === 'manager' ? '/manager' : '/admin';
+$isStaff  = in_array($role, ['admin','manager','partner'], true);
+$basePath = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin');
 $regularKg  = round($price, 2);
 ?>
 <div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 h-full max-w-[350px]"

--- a/src/Views/layouts/main.php
+++ b/src/Views/layouts/main.php
@@ -254,6 +254,17 @@
         <span class="material-icons-round">dashboard</span>
       </a>
       <button id="managerToggle" class="material-icons-round text-2xl text-gray-600 hover:text-emerald-500 transition-colors p-2 hover:bg-emerald-50 rounded-xl">manage_accounts</button>
+    <?php elseif (($_SESSION['role'] ?? '') === 'partner'): ?>
+      <a href="/partner/users/edit" class="p-2 text-gray-600 hover:text-[#C86052]" title="Добавить пользователя">
+        <span class="material-icons-round">person_add</span>
+      </a>
+      <a href="/partner/orders/create" class="p-2 text-gray-600 hover:text-[#C86052]" title="Создать заказ">
+        <span class="material-icons-round">add_shopping_cart</span>
+      </a>
+      <a href="/partner/profile" class="p-2 text-gray-600 hover:text-[#C86052]" title="Дашборд">
+        <span class="material-icons-round">dashboard</span>
+      </a>
+      <button id="partnerToggle" class="material-icons-round text-2xl text-gray-600 hover:text-emerald-500 transition-colors p-2 hover:bg-emerald-50 rounded-xl">manage_accounts</button>
     <?php endif; ?>
 
     <?php if (!empty($_SESSION['user_id'])): ?>
@@ -352,6 +363,37 @@
         <span class="font-medium">Пользователи</span>
       </a>
       <a href="/manager/profile" class="flex items-center p-4 hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 rounded-2xl transition-all group">
+        <span class="material-icons-round mr-3 text-red-500 group-hover:scale-110 transition-transform">account_circle</span>
+        <span class="font-medium">Профиль</span>
+      </a>
+    </nav>
+  </aside>
+  <?php endif; ?>
+
+  <!-- Partner sidebar (off-canvas) -->
+  <?php if (($_SESSION['role'] ?? '') === 'partner'): ?>
+  <aside
+    id="partnerSidebar"
+    class="fixed top-0 right-0 h-full w-80 glass-effect shadow-2xl transform translate-x-full transition-transform duration-300 z-30 border-l border-white/20"
+  >
+    <div class="p-6 font-bold text-xl border-b border-gray-100 fresh-gradient text-white rounded-tr-xl">
+      <span class="material-icons-round mr-2">manage_accounts</span>
+      Партнёр
+    </div>
+    <nav class="p-4 space-y-1">
+      <a href="/partner/orders" class="flex items-center p-4 hover:bg-gradient-to-r hover:from-blue-50 hover:to-indigo-50 rounded-2xl transition-all group">
+        <span class="material-icons-round mr-3 text-blue-500 group-hover:scale-110 transition-transform">receipt_long</span>
+        <span class="font-medium">Заказы</span>
+      </a>
+      <a href="/partner/products" class="flex items-center p-4 hover:bg-gradient-to-r hover:from-purple-50 hover:to-pink-50 rounded-2xl transition-all group">
+        <span class="material-icons-round mr-3 text-purple-500 group-hover:scale-110 transition-transform">inventory_2</span>
+        <span class="font-medium">Товары</span>
+      </a>
+      <a href="/partner/users" class="flex items-center p-4 hover:bg-gradient-to-r hover:from-teal-50 hover:to-cyan-50 rounded-2xl transition-all group">
+        <span class="material-icons-round mr-3 text-teal-500 group-hover:scale-110 transition-transform">people</span>
+        <span class="font-medium">Пользователи</span>
+      </a>
+      <a href="/partner/profile" class="flex items-center p-4 hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 rounded-2xl transition-all group">
         <span class="material-icons-round mr-3 text-red-500 group-hover:scale-110 transition-transform">account_circle</span>
         <span class="font-medium">Профиль</span>
       </a>
@@ -572,6 +614,20 @@
       document.addEventListener('click', (e) => {
         if (!managerSidebar.contains(e.target) && !managerToggle.contains(e.target)) {
           managerSidebar.classList.add('translate-x-full');
+        }
+      });
+    }
+
+    // Partner sidebar
+    const partnerToggle = document.getElementById('partnerToggle');
+    const partnerSidebar = document.getElementById('partnerSidebar');
+    if (partnerToggle && partnerSidebar) {
+      partnerToggle.addEventListener('click', () => {
+        partnerSidebar.classList.toggle('translate-x-full');
+      });
+      document.addEventListener('click', (e) => {
+        if (!partnerSidebar.contains(e.target) && !partnerToggle.contains(e.target)) {
+          partnerSidebar.classList.add('translate-x-full');
         }
       });
     }

--- a/src/Views/layouts/manager_main.php
+++ b/src/Views/layouts/manager_main.php
@@ -1,3 +1,9 @@
+<?php
+$role = $_SESSION['role'] ?? '';
+$base = $role === 'partner' ? '/partner' : '/manager';
+$titleRole = $role === 'partner' ? 'Partner' : 'Manager';
+$labelRole = $role === 'partner' ? 'Партнёр' : 'Менеджер';
+?>
 <!DOCTYPE html>
 <html lang="ru" data-theme="dark">
 <head>
@@ -241,12 +247,12 @@
   <!-- Header -->
   <header class="flex items-center justify-between bg-white p-2 md:p-4 shadow">
     <div class="flex items-center space-x-2 md:space-x-4">
-      <div class="font-bold text-lg md:text-xl text-[#C86052]">BerryGo Manager</div>
+      <div class="font-bold text-lg md:text-xl text-[#C86052]">BerryGo <?= htmlspecialchars($titleRole) ?></div>
       <nav class="hidden md:flex space-x-2 md:space-x-4">
-        <a href="/manager/orders" class="hover:underline">Заказы</a>
-        <a href="/manager/products" class="hover:underline">Товары</a>
-        <a href="/manager/users" class="hover:underline">Пользователи</a>
-        <a href="/manager/profile" class="hover:underline">Профиль</a>
+        <a href="<?= $base ?>/orders" class="hover:underline">Заказы</a>
+        <a href="<?= $base ?>/products" class="hover:underline">Товары</a>
+        <a href="<?= $base ?>/users" class="hover:underline">Пользователи</a>
+        <a href="<?= $base ?>/profile" class="hover:underline">Профиль</a>
       </nav>
       <button id="burgerBtn" class="md:hidden p-2 text-gray-600">
         <span class="material-icons-round">menu</span>
@@ -262,21 +268,21 @@
   <!-- Sidebar for small screens -->
   <aside id="sidebar" class="md:hidden fixed top-16 left-0 w-52 md:w-64 bg-white shadow-md transform -translate-x-full transition-transform duration-300 z-40">
     <nav class="p-2 md:p-4">
-      <a href="/manager/orders" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
+      <a href="<?= $base ?>/orders" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2 text-base md:text-lg">receipt_long</span>
         <span class="menu-text text-sm md:text-base">Заказы</span>
       </a>
-      <a href="/manager/products" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
+      <a href="<?= $base ?>/products" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2 text-base md:text-lg">inventory_2</span>
         <span class="menu-text text-sm md:text-base">Товары</span>
       </a>
-      <a href="/manager/users" class="flex items-center p-2 rounded hover:bg-gray-200">
+      <a href="<?= $base ?>/users" class="flex items-center p-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2 text-base md:text-lg">people</span>
         <span class="menu-text text-sm md:text-base">Пользователи</span>
       </a>
-      <a href="/manager/profile" class="flex items-center p-2 mt-2 rounded hover:bg-gray-200">
-        <span class="material-icons-round mr-2 text-base md:text-lg">account_circle</span>
-        <span class="menu-text text-sm md:text-base">Профиль</span>
+      <a href="<?= $base ?>/profile" class="flex items-center p-2 mt-2 rounded hover:bg-gray-200">
+      <span class="material-icons-round mr-2 text-base md:text-lg">account_circle</span>
+      <span class="menu-text text-sm md:text-base">Профиль</span>
       </a>
     </nav>
   </aside>


### PR DESCRIPTION
## Summary
- Add partner-specific routes and access guard
- Extend controllers and layouts to support partner management views
- Implement partner profile statistics view

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688f990bf6d8832c961e3a93b99b0674