### PR TITLE
Ensure UTF-8 encoding is declared and served consistently

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,5 @@
+AddDefaultCharset UTF-8
+
 <IfModule mod_rewrite.c>
   RewriteEngine On
 

--- a/index.php
+++ b/index.php
@@ -3,8 +3,11 @@ declare(strict_types=1);
 ini_set('display_errors', '1');
 error_reporting(E_ALL);
 
+mb_internal_encoding('UTF-8');
+
 // Запуск сессии
 session_start();
+header('Content-Type: text/html; charset=UTF-8');
 
 // Сохраняем пригласительный код из URL в сессию (если передан)
 if (isset($_GET['invite'])) {

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -210,7 +210,7 @@ public function register(): void
         $phone = $this->normalizePhone($_POST['phone'] ?? '');
         $method = $_POST['method'] ?? 'sms';
         $email  = trim($_POST['email'] ?? '');
-        header('Content-Type: application/json');
+        header('Content-Type: application/json; charset=UTF-8');
 
         if (!preg_match('/^7\d{10}$/', $phone)) {
             echo json_encode(['error' => 'Неверный номер']);
@@ -279,7 +279,7 @@ public function register(): void
         if ($valid) {
             $_SESSION['reg_verified'] = true;
         }
-        header('Content-Type: application/json');
+        header('Content-Type: application/json; charset=UTF-8');
         echo json_encode(['success' => $valid]);
     }
 
@@ -296,7 +296,7 @@ public function register(): void
     {
         $phone = $this->normalizePhone($_POST['phone'] ?? '');
         if (!preg_match('/^7\d{10}$/', $phone)) {
-            header('Content-Type: application/json');
+            header('Content-Type: application/json; charset=UTF-8');
             echo json_encode(['error' => 'Неверный номер']);
             return;
         }
@@ -305,7 +305,7 @@ public function register(): void
         $_SESSION['reset_code'] = $code;
         $sms = new SmsRu($this->smsConfig['api_id'] ?? '');
         $ok = $sms->send($phone, "Код сброса PIN: {$code}");
-        header('Content-Type: application/json');
+        header('Content-Type: application/json; charset=UTF-8');
         echo json_encode(['success' => $ok]);
     }
 
@@ -316,7 +316,7 @@ public function register(): void
         $code  = trim($_POST['code'] ?? '');
         $valid = isset($_SESSION['reset_phone'], $_SESSION['reset_code']) &&
             $_SESSION['reset_phone'] === $phone && $_SESSION['reset_code'] == $code;
-        header('Content-Type: application/json');
+        header('Content-Type: application/json; charset=UTF-8');
         echo json_encode(['success' => $valid]);
     }
 

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -834,7 +834,7 @@ class OrdersController
         curl_setopt($ch, CURLOPT_TIMEOUT, 5);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            'Content-Type: application/json'
+            'Content-Type: application/json; charset=UTF-8'
         ]);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
 

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -620,7 +620,7 @@ class UsersController
         );
         $stmt->execute(['%' . $term . '%']);
         $res = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        header('Content-Type: application/json');
+        header('Content-Type: application/json; charset=UTF-8');
         echo json_encode($res);
     }
 
@@ -637,7 +637,7 @@ class UsersController
         );
         $stmt->execute([$uid]);
         $res = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        header('Content-Type: application/json');
+        header('Content-Type: application/json; charset=UTF-8');
         echo json_encode($res);
     }
 }

--- a/src/Helpers/TelegramSender.php
+++ b/src/Helpers/TelegramSender.php
@@ -22,7 +22,7 @@ class TelegramSender
         }
         $options = [
             'http' => [
-                'header'  => "Content-Type: application/json\r\n",
+                'header'  => "Content-Type: application/json; charset=UTF-8\r\n",
                 'method'  => 'POST',
                 'content' => json_encode($payload),
                 'timeout' => 5,

--- a/testbot.php
+++ b/testbot.php
@@ -1,4 +1,7 @@
 <?php
+mb_internal_encoding('UTF-8');
+header('Content-Type: text/html; charset=UTF-8');
+
 // testbot.php - тестовая страница для отправки сообщений и просмотра отладочной информации
 // Подключаем конфиг Telegram
 $telegramConfig = require __DIR__ . '/config/telegram.php';
@@ -24,7 +27,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['message'])) {
     }
     $options = [
         'http' => [
-            'header'  => "Content-Type: application/json\r\n",
+            'header'  => "Content-Type: application/json; charset=UTF-8\r\n",
             'method'  => 'POST',
             'content' => json_encode($data),
             'timeout' => 5,


### PR DESCRIPTION
## Summary
- enforce UTF-8 as default charset for the web server
- send explicit UTF-8 headers from entry scripts and JSON endpoints
- adjust helper and admin scripts to include UTF-8 in outbound JSON requests

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688f9f7714c8832ca7ca54c876106d2e