### PR TITLE
Fix HTTPS redirect loop behind reverse proxy

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,7 +4,9 @@ AddDefaultCharset UTF-8
   RewriteEngine On
 
   # Force HTTPS for service worker and PWA installability
+  # Avoid redirect loops when behind a reverse proxy that already handles HTTPS
   RewriteCond %{HTTPS} !=on
+  RewriteCond %{HTTP:X-Forwarded-Proto} !https
   RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
   # Если запрашиваемый ресурс реально существует как файл или папка — отдать его напрямую


### PR DESCRIPTION
## Summary
- prevent infinite HTTPS redirects behind proxy by honoring `X-Forwarded-Proto`

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688fa2b15c50832ca64b52c7d9f10253