### PR TITLE
feat: show manager balance and payouts

### DIFF
--- a/index.php
+++ b/index.php
@@ -639,6 +639,10 @@ switch ("$method $uri") {
         requireManager();
         (new App\Controllers\UsersController($pdo))->managerProfile();
         break;
+    case 'POST /manager/payout':
+        requireManager();
+        (new App\Controllers\UsersController($pdo))->requestPayout();
+        break;
     case 'GET /manager/orders':
         requireManager();
         (new App\Controllers\OrdersController($pdo))->index();

--- a/src/Views/admin/manager_profile.php
+++ b/src/Views/admin/manager_profile.php
@@ -3,6 +3,11 @@
 /** @var int $secondClients */
 /** @var int $ordersCount */
 /** @var array $partnerStats */
+/** @var int $directBonus */
+/** @var int $secondBonus */
+/** @var int $pointsBalance */
+/** @var int $rubBalance */
+/** @var array $payoutTransactions */
 ?>
 <div class="space-y-6">
   <div class="bg-white rounded shadow p-2 md:p-4">
@@ -21,6 +26,54 @@
         <div class="text-sm text-gray-600">клиентов второго уровня</div>
       </div>
     </div>
+  </div>
+  <div class="bg-white rounded shadow p-2 md:p-4">
+    <h2 class="text-base md:text-lg font-semibold mb-2">Баланс</h2>
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4 text-center">
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $directBonus ?> ₽</div>
+        <div class="text-sm text-gray-600">3% от прямых</div>
+      </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $secondBonus ?> ₽</div>
+        <div class="text-sm text-gray-600">3% от второго уровня</div>
+      </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $pointsBalance ?> <span class="text-lg">🍓</span></div>
+        <div class="text-sm text-gray-600">баланс клубничек</div>
+      </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $rubBalance ?> ₽</div>
+        <div class="text-sm text-gray-600">баланс рублей</div>
+      </div>
+    </div>
+    <div class="text-center mt-4">
+      <form method="POST" action="/manager/payout">
+        <button class="bg-[#C86052] text-white px-4 py-2 rounded">Запросить выплату</button>
+      </form>
+    </div>
+    <?php if (!empty($payoutTransactions)): ?>
+    <div class="mt-4 overflow-x-auto">
+      <table class="min-w-full text-left text-sm">
+        <thead class="bg-gray-100">
+          <tr>
+            <th class="p-2">Дата</th>
+            <th class="p-2">Сумма</th>
+            <th class="p-2">Описание</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($payoutTransactions as $tx): ?>
+          <tr class="border-b">
+            <td class="p-2"><?= htmlspecialchars($tx['created_at']) ?></td>
+            <td class="p-2"><?= -$tx['amount'] ?> ₽</td>
+            <td class="p-2"><?= htmlspecialchars($tx['description']) ?></td>
+          </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+    <?php endif; ?>
   </div>
   <div class="bg-white rounded shadow p-2 md:p-4">
     <h2 class="text-base md:text-lg font-semibold mb-4">Партнёры</h2>


### PR DESCRIPTION
## Summary
- add manager balance widget with direct and second-level earnings
- allow managers to request payout converting points to rubles
- track payout transactions and wire up POST /manager/payout route

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689045ce4560832c8182cdfcf3fabb3c