### PR TITLE
feat: add partner payout and balance info

### DIFF
--- a/index.php
+++ b/index.php
@@ -743,6 +743,10 @@ switch ("$method $uri") {
         requirePartner();
         (new App\Controllers\UsersController($pdo))->partnerProfile();
         break;
+    case 'POST /partner/payout':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->requestPayout();
+        break;
     case 'GET /partner/orders':
         requirePartner();
         (new App\Controllers\OrdersController($pdo))->index();

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -347,11 +347,30 @@ class UsersController
             $revenue = (int)($row['sum'] ?? 0);
         }
 
+        $tenPercent = (int)round($revenue * 0.10);
+
+        $balStmt = $this->pdo->prepare("SELECT points_balance, rub_balance FROM users WHERE id = ?");
+        $balStmt->execute([$partnerId]);
+        $balances = $balStmt->fetch(PDO::FETCH_ASSOC) ?: ['points_balance' => 0, 'rub_balance' => 0];
+        $pointsBalance = (int)$balances['points_balance'];
+        $rubBalance = (int)$balances['rub_balance'];
+
+        $payoutStmt = $this->pdo->prepare(
+            "SELECT id, amount, description, created_at FROM points_transactions \n" .
+            "WHERE user_id = ? AND transaction_type = 'payout' ORDER BY created_at DESC"
+        );
+        $payoutStmt->execute([$partnerId]);
+        $payoutTransactions = $payoutStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
         viewAdmin('partner_profile', [
             'pageTitle'   => 'Профиль партнёра',
             'clientCount' => $clientCount,
             'ordersCount' => $ordersCount,
             'revenue'     => $revenue,
+            'tenPercent'  => $tenPercent,
+            'pointsBalance' => $pointsBalance,
+            'rubBalance'    => $rubBalance,
+            'payoutTransactions' => $payoutTransactions,
         ]);
     }
 

--- a/src/Views/admin/partner_profile.php
+++ b/src/Views/admin/partner_profile.php
@@ -1,4 +1,14 @@
-<?php /** @var int $clientCount @var int $ordersCount @var int $revenue */ ?>
+<?php
+/**
+ * @var int   $clientCount
+ * @var int   $ordersCount
+ * @var int   $revenue
+ * @var int   $tenPercent
+ * @var int   $pointsBalance
+ * @var int   $rubBalance
+ * @var array $payoutTransactions
+ */
+?>
 <div class="space-y-6">
   <div class="bg-white rounded shadow p-2 md:p-4">
     <h2 class="text-base md:text-lg font-semibold mb-2">Общая статистика</h2>
@@ -16,5 +26,49 @@
         <div class="text-sm text-gray-600">оборот, ₽</div>
       </div>
     </div>
+  </div>
+  <div class="bg-white rounded shadow p-2 md:p-4">
+    <h2 class="text-base md:text-lg font-semibold mb-2">Баланс</h2>
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-2 md:gap-4 text-center">
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $tenPercent ?> ₽</div>
+        <div class="text-sm text-gray-600">10% от клиентов</div>
+      </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $pointsBalance ?> <span class="text-lg">🍓</span></div>
+        <div class="text-sm text-gray-600">баланс клубничек</div>
+      </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $rubBalance ?> ₽</div>
+        <div class="text-sm text-gray-600">баланс рублей</div>
+      </div>
+    </div>
+    <div class="text-center mt-4">
+      <form method="POST" action="/partner/payout">
+        <button class="bg-[#C86052] text-white px-4 py-2 rounded">Запросить выплату</button>
+      </form>
+    </div>
+    <?php if (!empty($payoutTransactions)): ?>
+    <div class="mt-4 overflow-x-auto">
+      <table class="min-w-full text-left text-sm">
+        <thead class="bg-gray-100">
+          <tr>
+            <th class="p-2">Дата</th>
+            <th class="p-2">Сумма</th>
+            <th class="p-2">Описание</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($payoutTransactions as $tx): ?>
+          <tr class="border-b">
+            <td class="p-2"><?= htmlspecialchars($tx['created_at']) ?></td>
+            <td class="p-2"><?= -$tx['amount'] ?> ₽</td>
+            <td class="p-2"><?= htmlspecialchars($tx['description']) ?></td>
+          </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+    <?php endif; ?>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- show 10% revenue share, balances, and payout history on partner profile
- wire partner payout request route

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68904a30a630832c89e9b83892485447