### PR TITLE
Add payout transaction type for points transactions

### DIFF
--- a/database/2025_21_points_transactions_payout.sql
+++ b/database/2025_21_points_transactions_payout.sql
@@ -1,0 +1,2 @@
+ALTER TABLE points_transactions
+    MODIFY transaction_type ENUM('accrual', 'usage', 'payout') NOT NULL;


### PR DESCRIPTION
## Summary
- allow points transactions table to record payouts

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689053cab378832ca5e45d7f2d85d48d