### PR TITLE
Add monthly partner statistics charts

### DIFF
--- a/src/Views/admin/partner_profile.php
+++ b/src/Views/admin/partner_profile.php
@@ -7,6 +7,10 @@
  * @var int   $pointsBalance
  * @var int   $rubBalance
  * @var array $payoutTransactions
+ * @var array $chartLabels
+ * @var array $chartClients
+ * @var array $chartOrders
+ * @var array $chartRevenue
  */
 ?>
 <div class="space-y-6">
@@ -25,6 +29,14 @@
         <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $revenue ?></div>
         <div class="text-sm text-gray-600">оборот, ₽</div>
       </div>
+    </div>
+  </div>
+  <div class="bg-white rounded shadow p-2 md:p-4">
+    <h2 class="text-base md:text-lg font-semibold mb-2">Статистика по месяцам</h2>
+    <div class="space-y-4">
+      <div><canvas id="clientsChart" class="w-full h-48 md:h-64"></canvas></div>
+      <div><canvas id="ordersChart" class="w-full h-48 md:h-64"></canvas></div>
+      <div><canvas id="revenueChart" class="w-full h-48 md:h-64"></canvas></div>
     </div>
   </div>
   <div class="bg-white rounded shadow p-2 md:p-4">
@@ -72,3 +84,30 @@
     <?php endif; ?>
   </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const labels = <?= json_encode($chartLabels) ?>;
+  const clientsData = <?= json_encode($chartClients) ?>;
+  const ordersData = <?= json_encode($chartOrders) ?>;
+  const revenueData = <?= json_encode($chartRevenue) ?>;
+
+  const baseOptions = {responsive: true, maintainAspectRatio: false};
+
+  new Chart(document.getElementById('clientsChart').getContext('2d'), {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Клиенты', data: clientsData, backgroundColor: '#03A9F4' }] },
+    options: baseOptions
+  });
+
+  new Chart(document.getElementById('ordersChart').getContext('2d'), {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Заказы', data: ordersData, backgroundColor: '#C86052' }] },
+    options: baseOptions
+  });
+
+  new Chart(document.getElementById('revenueChart').getContext('2d'), {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Выручка', data: revenueData, backgroundColor: '#4CAF50' }] },
+    options: baseOptions
+  });
+</script>


### PR DESCRIPTION
## Summary
- compute monthly counts of referred clients, their orders, and revenue in partner profile
- display three Chart.js bar charts on partner profile with monthly stats

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68905628055c832caf25c7d21a410c6c