### PR TITLE
feat: expand admin user profile editing

### DIFF
--- a/index.php
+++ b/index.php
@@ -586,6 +586,14 @@ switch ("$method $uri") {
         requireAdmin();
         (new App\Controllers\UsersController($pdo))->resetRubBalance();
         break;
+    case 'POST /admin/users/add-address':
+        requireAdmin();
+        (new App\Controllers\UsersController($pdo))->addAddressAdmin();
+        break;
+    case 'POST /admin/users/delete-address':
+        requireAdmin();
+        (new App\Controllers\UsersController($pdo))->deleteAddressAdmin();
+        break;
 
     case 'GET /admin/apps':
         requireAdmin();
@@ -733,6 +741,14 @@ switch ("$method $uri") {
         requireManager();
         (new App\Controllers\UsersController($pdo))->toggleBlock();
         break;
+    case 'POST /manager/users/add-address':
+        requireManager();
+        (new App\Controllers\UsersController($pdo))->addAddressAdmin();
+        break;
+    case 'POST /manager/users/delete-address':
+        requireManager();
+        (new App\Controllers\UsersController($pdo))->deleteAddressAdmin();
+        break;
 
     // === ROUTES FOR PARTNERS ===
     case 'GET /partner/dashboard':
@@ -836,6 +852,14 @@ switch ("$method $uri") {
     case 'POST /partner/users/toggle-block':
         requirePartner();
         (new App\Controllers\UsersController($pdo))->toggleBlock();
+        break;
+    case 'POST /partner/users/add-address':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->addAddressAdmin();
+        break;
+    case 'POST /partner/users/delete-address':
+        requirePartner();
+        (new App\Controllers\UsersController($pdo))->deleteAddressAdmin();
         break;
 
     // Любые другие запросы — 404

--- a/src/Views/admin/users/show.php
+++ b/src/Views/admin/users/show.php
@@ -1,16 +1,83 @@
-<?php /** @var array $user @var array $transactions */ ?>
+<?php /** @var array $user @var array $transactions @var array $addresses @var array $referrers */ ?>
 <?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
-<h1 class="text-xl font-semibold mb-4">Пользователь #<?= $user['id'] ?></h1>
-<div class="bg-white p-4 rounded shadow mb-4">
-  <div class="font-semibold text-lg mb-1"><?= htmlspecialchars($user['name']) ?></div>
-  <div class="text-sm text-gray-500 mb-2"><?= htmlspecialchars($user['phone']) ?></div>
+<form action="<?= $base ?>/users/save" method="post" class="bg-white p-4 rounded shadow mb-4 space-y-4">
+  <input type="hidden" name="id" value="<?= $user['id'] ?>">
+  <div class="flex justify-between">
+    <div>
+      <div class="font-semibold">ID: <?= $user['id'] ?></div>
+      <div><?= htmlspecialchars($user['name']) ?></div>
+      <div class="text-sm text-gray-500"><?= htmlspecialchars($user['phone']) ?></div>
+    </div>
+    <div>
+      <label class="block text-sm mb-1">Роль</label>
+      <select name="role" class="border rounded px-2 py-1">
+        <option value="client" <?= $user['role']==='client'?'selected':'' ?>>Клиент</option>
+        <option value="courier" <?= $user['role']==='courier'?'selected':'' ?>>Курьер</option>
+        <option value="admin" <?= $user['role']==='admin'?'selected':'' ?>>Админ</option>
+        <option value="manager" <?= $user['role']==='manager'?'selected':'' ?>>Менеджер</option>
+        <option value="partner" <?= $user['role']==='partner'?'selected':'' ?>>Партнёр</option>
+      </select>
+    </div>
+  </div>
+  <div class="flex justify-between items-center">
+    <label class="flex items-center space-x-2">
+      <input type="checkbox" name="is_blocked" value="1" <?= !empty($user['is_blocked']) ? 'checked' : '' ?>>
+      <span>Заблокирован</span>
+    </label>
+    <div class="text-sm text-gray-500">Создан: <?= date('d.m.Y H:i', strtotime($user['created_at'])) ?></div>
+  </div>
+  <div>Telegram: <?= htmlspecialchars($user['telegram_id'] ?? '') ?></div>
+  <div>Пригласительный код: <?= htmlspecialchars($user['referral_code']) ?></div>
   <div>
-    Баланс: <?= (int)$user['points_balance'] ?> 🍓
-    <?php if (($user['rub_balance'] ?? 0) > 0): ?>
-      <br><?= (int)$user['rub_balance'] ?> ₽
+    <label class="block text-sm mb-1">Реферансье</label>
+    <select name="referred_by" class="border rounded px-2 py-1">
+      <option value="">—</option>
+      <?php foreach ($referrers as $ref): ?>
+        <option value="<?= $ref['id'] ?>" <?= $user['referred_by'] == $ref['id'] ? 'selected' : '' ?>>
+          <?= htmlspecialchars($ref['name']) ?> (<?= htmlspecialchars($ref['phone']) ?>)
+        </option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="flex justify-between">
+    <div>Баланс: <?= (int)$user['points_balance'] ?> 🍓</div>
+    <?php if ($isManager): ?>
+      <div><?= (int)$user['rub_balance'] ?> ₽</div>
     <?php endif; ?>
   </div>
+  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+</form>
+
+<div class="bg-white p-4 rounded shadow mb-4">
+  <h2 class="font-semibold mb-2">Адреса доставки</h2>
+  <?php if (empty($addresses)): ?>
+    <p class="text-gray-500 text-sm mb-2">Адресов нет</p>
+  <?php else: ?>
+    <ul class="space-y-2 mb-4">
+      <?php foreach ($addresses as $addr): ?>
+        <li class="flex justify-between items-start">
+          <div>
+            <div><?= htmlspecialchars($addr['street']) ?></div>
+            <div class="text-sm text-gray-500"><?= htmlspecialchars($addr['recipient_name']) ?> <?= htmlspecialchars($addr['recipient_phone']) ?></div>
+          </div>
+          <form action="<?= $base ?>/users/delete-address" method="post" onsubmit="return confirm('Удалить адрес?');">
+            <input type="hidden" name="id" value="<?= $addr['id'] ?>">
+            <input type="hidden" name="user_id" value="<?= $user['id'] ?>">
+            <button type="submit" class="text-red-600">🗑️</button>
+          </form>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  <?php endif; ?>
+  <form action="<?= $base ?>/users/add-address" method="post" class="space-y-2">
+    <input type="hidden" name="user_id" value="<?= $user['id'] ?>">
+    <input name="address" class="w-full border px-2 py-1 rounded" placeholder="Новый адрес">
+    <input name="recipient_name" class="w-full border px-2 py-1 rounded" placeholder="Имя получателя">
+    <input name="recipient_phone" class="w-full border px-2 py-1 rounded" placeholder="Телефон получателя">
+    <button type="submit" class="bg-[#C86052] text-white px-4 py-1 rounded">Добавить адрес доставки</button>
+  </form>
 </div>
+
 <div class="bg-white p-4 rounded shadow">
   <h2 class="font-semibold mb-2">Транзакции</h2>
   <?php if (empty($transactions)): ?>


### PR DESCRIPTION
## Summary
- add routes for admin to add/remove user addresses for admins, managers and partners
- extend user controller to load full profile details and allow updating referrer and addresses
- redesign admin user profile view with role select, block toggle, referral info and address management

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6893805cbf44832c9b2f21dc1ee2eb23