### PR TITLE
Expand manager and partner user access

### DIFF
--- a/src/Views/admin/users/index.php
+++ b/src/Views/admin/users/index.php
@@ -1,7 +1,6 @@
 <?php /** @var array $users */ ?>
-<?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
-<?php if (!$isManager): ?>
-  <?php if (!empty($payouts)): ?>
+<?php $role = $_SESSION['role'] ?? ''; $isStaff = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
+<?php if (!$isStaff && !empty($payouts)): ?>
   <h2 class="text-lg font-semibold mb-2">Запросы на выплаты</h2>
   <table class="min-w-full bg-white rounded shadow overflow-hidden mb-6">
     <thead class="bg-gray-200 text-gray-700">
@@ -31,36 +30,29 @@
       <?php endforeach; ?>
     </tbody>
   </table>
-  <?php endif; ?>
-  <form method="get" class="mb-4 flex">
-    <input type="text" name="q" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Телефон или адрес" class="border rounded px-3 py-2 mr-2 flex-grow">
-    <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Поиск</button>
-  </form>
-  <a href="<?= $base ?>/users/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
-    <span class="material-icons-round text-base mr-1">add</span> Добавить пользователя
-  </a>
 <?php endif; ?>
+<form method="get" class="mb-4 flex">
+  <input type="text" name="q" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Телефон или адрес" class="border rounded px-3 py-2 mr-2 flex-grow">
+  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Поиск</button>
+</form>
+<a href="<?= $base ?>/users/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">
+  <span class="material-icons-round text-base mr-1">add</span> Добавить пользователя
+</a>
 <table class="min-w-full bg-white rounded shadow overflow-hidden">
   <thead class="bg-gray-200 text-gray-700">
     <tr>
-      <?php if (!$isManager): ?>
       <th class="p-3 text-left font-semibold">ID</th>
-      <?php endif; ?>
       <th class="p-3 text-left font-semibold">Имя</th>
       <th class="p-3 text-left font-semibold">Телефон</th>
       <th class="p-3 text-left font-semibold">Адрес</th>
       <th class="p-3 text-left font-semibold">Баланс</th>
-      <?php if (!$isManager): ?>
       <th class="p-3 text-center font-semibold">Заблокирован</th>
-      <?php endif; ?>
     </tr>
   </thead>
   <tbody>
     <?php foreach($users as $u): ?>
     <tr class="border-b hover:bg-gray-50 transition-all duration-200">
-      <?php if (!$isManager): ?>
       <td class="p-3 font-medium text-gray-600"><?= $u['id'] ?></td>
-      <?php endif; ?>
       <td class="p-3">
         <div class="flex items-center">
             <a href="<?= $base ?>/users/<?= $u['id'] ?>" class="">
@@ -76,7 +68,6 @@
           <br><span><?= (int)$u['rub_balance'] ?> ₽</span>
         <?php endif; ?>
       </td>
-      <?php if (!$isManager): ?>
       <td class="p-3 text-center">
         <form action="<?= $base ?>/users/toggle-block" method="post" class="inline-block">
           <input type="hidden" name="id" value="<?= $u['id'] ?>">
@@ -86,7 +77,6 @@
           </label>
         </form>
       </td>
-      <?php endif; ?>
     </tr>
     <?php endforeach; ?>
   </tbody>


### PR DESCRIPTION
## Summary
- allow managers and partners to view and manage all non-staff users
- hide payout info but expose user management UI in partner/manager list view

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68946d70c4fc832c94cc20e3fd8145b2