### PR TITLE
Add seller profile page

### DIFF
--- a/index.php
+++ b/index.php
@@ -927,6 +927,10 @@ switch ("$method $uri") {
         requireSeller();
         (new App\Controllers\SellerController($pdo))->dashboard();
         break;
+    case 'GET /seller/profile':
+        requireSeller();
+        (new App\Controllers\UsersController($pdo))->sellerProfile();
+        break;
     case 'GET /seller/products':
         requireSeller();
         (new App\Controllers\ProductsController($pdo))->index();

--- a/src/Views/admin/seller_profile.php
+++ b/src/Views/admin/seller_profile.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @var int   $ordersCount
+ * @var int   $revenue
+ * @var array $payouts
+ */
+?>
+<div class="space-y-6">
+  <div class="bg-white rounded shadow p-2 md:p-4">
+    <h2 class="text-base md:text-lg font-semibold mb-2">Общая статистика</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 md:gap-4 text-center">
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $ordersCount ?></div>
+        <div class="text-sm text-gray-600">продаж</div>
+      </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $revenue ?> ₽</div>
+        <div class="text-sm text-gray-600">оборот</div>
+      </div>
+    </div>
+  </div>
+
+  <?php if (!empty($payouts)): ?>
+  <div class="bg-white rounded shadow p-2 md:p-4 overflow-x-auto">
+    <h2 class="text-base md:text-lg font-semibold mb-2">Последние выплаты</h2>
+    <table class="min-w-full text-left text-sm">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="p-2">Дата</th>
+          <th class="p-2">Сумма продажи</th>
+          <th class="p-2">Выплата</th>
+          <th class="p-2">Статус</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($payouts as $p): ?>
+        <tr class="border-b">
+          <td class="p-2"><?= htmlspecialchars($p['created_at']) ?></td>
+          <td class="p-2"><?= htmlspecialchars($p['gross_amount']) ?></td>
+          <td class="p-2"><?= htmlspecialchars($p['payout_amount']) ?></td>
+          <td class="p-2"><?= htmlspecialchars($p['status']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <?php else: ?>
+  <div class="bg-white rounded shadow p-2 md:p-4">
+    <p class="text-sm text-gray-600">Выплат пока нет</p>
+  </div>
+  <?php endif; ?>
+</div>

--- a/tests/SellerProfileTest.php
+++ b/tests/SellerProfileTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace {
+    function viewAdmin(string $template, array $data = []): void
+    {
+        echo $template . PHP_EOL;
+        echo json_encode($data);
+    }
+}
+
+namespace Tests {
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\UsersController;
+use PDO;
+
+class SellerProfileTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION = [];
+    }
+
+    public function testSellerProfileRenders(): void
+    {
+        if (!class_exists('App\\Controllers\\UsersController')) {
+            require_once __DIR__ . '/../src/Controllers/UsersController.php';
+            require_once __DIR__ . '/../src/Helpers/Auth.php';
+        }
+
+        $_SESSION['user_id'] = 1;
+        $_SESSION['role'] = 'seller';
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE seller_payouts (id INTEGER PRIMARY KEY AUTOINCREMENT, seller_id INT, gross_amount REAL, payout_amount REAL, status TEXT, created_at TEXT)');
+        $pdo->exec("INSERT INTO seller_payouts (seller_id, gross_amount, payout_amount, status, created_at) VALUES (1, 100, 70, 'pending', '2024-01-01')");
+
+        $controller = new UsersController($pdo);
+        ob_start();
+        $controller->sellerProfile();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('seller_profile', $output);
+        $this->assertStringContainsString('"ordersCount":1', $output);
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- add `/seller/profile` route
- implement `sellerProfile` controller to show seller stats
- create seller profile view and test

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a5206e22b8832c839192d375b2313c