### PR TITLE
Restrict sellers to editing their own product categories

### DIFF
--- a/database/2025_22_product_types_seller.sql
+++ b/database/2025_22_product_types_seller.sql
@@ -1,0 +1,3 @@
+ALTER TABLE product_types
+  ADD COLUMN seller_id INT UNSIGNED NULL AFTER text,
+  ADD CONSTRAINT fk_product_types_seller FOREIGN KEY (seller_id) REFERENCES users(id) ON DELETE SET NULL;

--- a/src/Controllers/ProductTypesController.php
+++ b/src/Controllers/ProductTypesController.php
@@ -20,8 +20,15 @@ class ProductTypesController
 
     public function index(): void
     {
-        $types = $this->pdo->query("SELECT * FROM product_types ORDER BY id DESC")
-            ->fetchAll(PDO::FETCH_ASSOC);
+        $role = $_SESSION['role'] ?? '';
+        if ($role === 'seller') {
+            $stmt  = $this->pdo->prepare("SELECT * FROM product_types WHERE seller_id = ? ORDER BY id DESC");
+            $stmt->execute([(int)($_SESSION['user_id'] ?? 0)]);
+            $types = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        } else {
+            $types = $this->pdo->query("SELECT * FROM product_types ORDER BY id DESC")
+                ->fetchAll(PDO::FETCH_ASSOC);
+        }
 
         viewAdmin('product_types/index', [
             'pageTitle' => 'Категории товаров',
@@ -31,12 +38,22 @@ class ProductTypesController
 
     public function edit(): void
     {
-        $id = $_GET['id'] ?? null;
+        $id   = $_GET['id'] ?? null;
         $type = null;
         if ($id) {
-            $stmt = $this->pdo->prepare("SELECT * FROM product_types WHERE id = ?");
-            $stmt->execute([(int)$id]);
+            $role = $_SESSION['role'] ?? '';
+            if ($role === 'seller') {
+                $stmt = $this->pdo->prepare("SELECT * FROM product_types WHERE id = ? AND seller_id = ?");
+                $stmt->execute([(int)$id, (int)($_SESSION['user_id'] ?? 0)]);
+            } else {
+                $stmt = $this->pdo->prepare("SELECT * FROM product_types WHERE id = ?");
+                $stmt->execute([(int)$id]);
+            }
             $type = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!$type && $role === 'seller') {
+                header('Location: ' . $this->basePath());
+                exit;
+            }
         }
 
         viewAdmin('product_types/edit', [
@@ -56,17 +73,33 @@ class ProductTypesController
         $h1      = trim($_POST['h1'] ?? '');
         $short   = trim($_POST['short_description'] ?? '');
         $text    = trim($_POST['text'] ?? '');
+        $role    = $_SESSION['role'] ?? '';
+        $seller  = (int)($_SESSION['user_id'] ?? 0);
 
         if ($id) {
-            $stmt = $this->pdo->prepare(
-                "UPDATE product_types SET name=?, alias=?, meta_title=?, meta_description=?, meta_keywords=?, h1=?, short_description=?, text=? WHERE id=?"
-            );
-            $stmt->execute([$name, $alias, $metaT, $metaD, $metaK, $h1, $short, $text, (int)$id]);
+            if ($role === 'seller') {
+                $stmt = $this->pdo->prepare(
+                    "UPDATE product_types SET name=?, alias=?, meta_title=?, meta_description=?, meta_keywords=?, h1=?, short_description=?, text=? WHERE id=? AND seller_id=?"
+                );
+                $stmt->execute([$name, $alias, $metaT, $metaD, $metaK, $h1, $short, $text, (int)$id, $seller]);
+            } else {
+                $stmt = $this->pdo->prepare(
+                    "UPDATE product_types SET name=?, alias=?, meta_title=?, meta_description=?, meta_keywords=?, h1=?, short_description=?, text=? WHERE id=?"
+                );
+                $stmt->execute([$name, $alias, $metaT, $metaD, $metaK, $h1, $short, $text, (int)$id]);
+            }
         } else {
-            $stmt = $this->pdo->prepare(
-                "INSERT INTO product_types (name, alias, meta_title, meta_description, meta_keywords, h1, short_description, text) VALUES (?,?,?,?,?,?,?,?)"
-            );
-            $stmt->execute([$name, $alias, $metaT, $metaD, $metaK, $h1, $short, $text]);
+            if ($role === 'seller') {
+                $stmt = $this->pdo->prepare(
+                    "INSERT INTO product_types (name, alias, meta_title, meta_description, meta_keywords, h1, short_description, text, seller_id) VALUES (?,?,?,?,?,?,?,?,?)"
+                );
+                $stmt->execute([$name, $alias, $metaT, $metaD, $metaK, $h1, $short, $text, $seller]);
+            } else {
+                $stmt = $this->pdo->prepare(
+                    "INSERT INTO product_types (name, alias, meta_title, meta_description, meta_keywords, h1, short_description, text) VALUES (?,?,?,?,?,?,?,?)"
+                );
+                $stmt->execute([$name, $alias, $metaT, $metaD, $metaK, $h1, $short, $text]);
+            }
         }
         header('Location: ' . $this->basePath());
         exit;


### PR DESCRIPTION
## Summary
- Only show and allow editing of product categories created by the current seller
- Track category ownership via new `seller_id` column on `product_types`

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a57909395c832c8a1c8239ae6ee7c3