### PR TITLE
Disable invite code editing for staff-created users

### DIFF
--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -777,7 +777,9 @@ class UsersController
             }
 
             $referredBy = null;
-            if ($invite !== '') {
+            if ($authStaff) {
+                $referredBy = (int)$auth['id'];
+            } elseif ($invite !== '') {
                 $stmt = $this->pdo->prepare("SELECT id FROM users WHERE referral_code = ?");
                 $stmt->execute([$invite]);
                 $found = $stmt->fetch(PDO::FETCH_ASSOC);

--- a/src/Views/admin/users/edit.php
+++ b/src/Views/admin/users/edit.php
@@ -24,7 +24,11 @@
     </div>
     <div>
       <label class="block mb-1">Invite-код (необязательно)</label>
-      <input name="invite" type="text" value="<?= htmlspecialchars($_SESSION['referral_code'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+      <input name="invite" type="text" value="<?= htmlspecialchars($_SESSION['referral_code'] ?? '') ?>"
+             class="w-full border px-2 py-1 rounded" <?= $isManager ? 'disabled' : '' ?>>
+      <?php if ($isManager): ?>
+        <input type="hidden" name="invite" value="<?= htmlspecialchars($_SESSION['referral_code'] ?? '') ?>">
+      <?php endif; ?>
     </div>
     <div>
       <label class="block mb-1">PIN (4 цифры)</label>


### PR DESCRIPTION
## Summary
- Prevent managers and partners from editing the invite code when creating a user
- Automatically link new users to the creating staff member's referral

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a5807ab184832cb9639c836cb40bf6