### PR TITLE
URL-encode redirect messages for proper UTF-8 display

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -69,7 +69,7 @@ public function register(): void
     $pin   = trim($pinRaw);
 
     if (empty($_SESSION['reg_verified']) || $_SESSION['reg_phone'] !== $phone) {
-        header('Location: /register?error=Подтвердите+номер');
+        header('Location: /register?error=' . urlencode('Подтвердите номер'));
         exit;
     }
 
@@ -80,7 +80,7 @@ public function register(): void
         !preg_match('/^\d{4}$/', $pin) ||
         $address === ''
     ) {
-        header('Location: /register?error=Неверные+данные');
+        header('Location: /register?error=' . urlencode('Неверные данные'));
         exit;
     }
 
@@ -134,7 +134,7 @@ public function register(): void
         $this->pdo->commit();
     } catch (\Exception $e) {
         $this->pdo->rollBack();
-        header('Location: /register?error=Ошибка+регистрации');
+        header('Location: /register?error=' . urlencode('Ошибка регистрации'));
         exit;
     }
 
@@ -160,6 +160,7 @@ public function register(): void
      */
     public function showLoginForm(): void
     {
+        $error = $_GET['error'] ?? null;
         include 'src/Views/client/login.php';
     }
 
@@ -176,7 +177,7 @@ public function register(): void
 
         // Валидация формата перед запросом
         if (!preg_match('/^7\d{10}$/', $phone) || !preg_match('/^\d{4}$/', $pin)) {
-            header('Location: /login?error=Неверный+телефон+или+PIN');
+            header('Location: /login?error=' . urlencode('Неверный телефон или PIN'));
             exit;
         }
 
@@ -199,7 +200,7 @@ public function register(): void
             header('Location: /');
             exit;
         } else {
-            header('Location: /login?error=Неверный+телефон+или+PIN');
+            header('Location: /login?error=' . urlencode('Неверный телефон или PIN'));
             exit;
         }
     }
@@ -329,14 +330,14 @@ public function register(): void
         $validCode = isset($_SESSION['reset_phone'], $_SESSION['reset_code']) &&
             $_SESSION['reset_phone'] === $phone && $_SESSION['reset_code'] == $code;
         if (!$validCode || !preg_match('/^\d{4}$/', $pin)) {
-            header('Location: /reset-pin?error=Неверные+данные');
+            header('Location: /reset-pin?error=' . urlencode('Неверные данные'));
             exit;
         }
         $hash = password_hash($pin, PASSWORD_DEFAULT);
         $stmt = $this->pdo->prepare("UPDATE users SET password_hash = ? WHERE phone = ?");
         $stmt->execute([$hash, $phone]);
         unset($_SESSION['reset_phone'], $_SESSION['reset_code']);
-        header('Location: /login?success=PIN+обновлен');
+        header('Location: /login?success=' . urlencode('PIN обновлен'));
         exit;
     }
 

--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -664,11 +664,11 @@ public function cart(): void
                     $referrerId = (int)$ref['id'];
                     $referralUsed = true;
                 } else {
-                    header('Location: /checkout?coupon_error=Промокод+действует+на+первый+заказ');
+                    header('Location: /checkout?coupon_error=' . urlencode('Промокод действует на первый заказ'));
                     exit;
                 }
             } else {
-                header('Location: /checkout?coupon_error=Неверный+купон');
+                header('Location: /checkout?coupon_error=' . urlencode('Неверный купон'));
                 exit;
             }
         } else {

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -330,7 +330,7 @@ class OrdersController
                     'pin'     => $pin,
                     'raw'     => $_POST,
                 ];
-                header('Location: ' . $this->basePath() . '/create?error=invalid+user');
+                header('Location: ' . $this->basePath() . '/create?error=' . urlencode('invalid user'));
                 exit;
             }
 
@@ -345,7 +345,7 @@ class OrdersController
                     'pin'     => $pin,
                     'raw'     => $_POST,
                 ];
-                header('Location: ' . $this->basePath() . '/create?error=phone_exists');
+                header('Location: ' . $this->basePath() . '/create?error=' . urlencode('phone_exists'));
                 exit;
             }
 
@@ -392,7 +392,7 @@ class OrdersController
           }
 
         if ($userId <= 0) {
-            header('Location: ' . $this->basePath() . '/create?error=user');
+            header('Location: ' . $this->basePath() . '/create?error=' . urlencode('user'));
             exit;
         }
 
@@ -402,7 +402,7 @@ class OrdersController
 
         $items = $_POST['items'] ?? [];
         if (!$items) {
-            header('Location: ' . $this->basePath() . '/create?error=empty');
+            header('Location: ' . $this->basePath() . '/create?error=' . urlencode('empty'));
             exit;
         }
 
@@ -689,7 +689,7 @@ class OrdersController
         $stmt->execute([$user['id']]);
         $cartItems = $stmt->fetchAll(PDO::FETCH_ASSOC);
         if (empty($cartItems)) {
-            header('Location: /cart?error=Корзина+пуста');
+            header('Location: /cart?error=' . urlencode('Корзина пуста'));
             exit;
         }
 
@@ -779,7 +779,7 @@ class OrdersController
 
         } catch (\Exception $e) {
             $this->pdo->rollBack();
-            header('Location: /checkout?error=Ошибка+при+оформлении+заказа');
+            header('Location: /checkout?error=' . urlencode('Ошибка при оформлении заказа'));
             exit;
         }
     }

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -475,7 +475,7 @@ class UsersController
 
         $address = trim($_POST['address'] ?? '');
         if ($address === '') {
-            header('Location: /profile?error=Введите+корректный+адрес');
+            header('Location: /profile?error=' . urlencode('Введите корректный адрес'));
             exit;
         }
 
@@ -501,7 +501,7 @@ class UsersController
             $isPrimary
         ]);
 
-        header('Location: /profile?success=Адрес+сохранён');
+        header('Location: /profile?success=' . urlencode('Адрес сохранён'));
         exit;
     }
 
@@ -772,7 +772,7 @@ class UsersController
                 !preg_match('/^\d{4}$/', $pin) ||
                 $address === ''
             ) {
-                header('Location: ' . $this->basePath() . '/edit?error=Неверные+данные');
+                header('Location: ' . $this->basePath() . '/edit?error=' . urlencode('Неверные данные'));
                 exit;
             }
 
@@ -817,7 +817,7 @@ class UsersController
                 $this->pdo->commit();
             } catch (\Exception $e) {
                 $this->pdo->rollBack();
-                header('Location: ' . $this->basePath() . '/edit?error=Ошибка+создания');
+                header('Location: ' . $this->basePath() . '/edit?error=' . urlencode('Ошибка создания'));
                 exit;
             }
         }


### PR DESCRIPTION
## Summary
- URL-encode error and success strings in redirect headers to avoid garbled Cyrillic text
- Pass the `error` query parameter into the login form for correct message rendering

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a5920b72e0832cb5d2aafb3d272d47