### PR TITLE
feat: add seller order payout summary

### DIFF
--- a/index.php
+++ b/index.php
@@ -931,6 +931,10 @@ switch ("$method $uri") {
         requireSeller();
         (new App\Controllers\UsersController($pdo))->sellerProfile();
         break;
+    case 'GET /seller/orders':
+        requireSeller();
+        (new App\Controllers\SellerController($pdo))->orders();
+        break;
     case 'GET /seller/products':
         requireSeller();
         (new App\Controllers\ProductsController($pdo))->index();

--- a/src/Controllers/SellerController.php
+++ b/src/Controllers/SellerController.php
@@ -81,4 +81,65 @@ class SellerController
             'month'     => $month,
         ]);
     }
+
+    public function orders(): void
+    {
+        $sellerId = (int)($_SESSION['user_id'] ?? 0);
+
+        $stmt = $this->pdo->prepare(
+            "SELECT o.id, o.status, o.points_used, o.delivery_date,\n"
+            . "       d.time_from AS slot_from, d.time_to AS slot_to,\n"
+            . "       u.name AS client_name, u.phone, a.street AS address,\n"
+            . "       sp.gross_amount AS seller_subtotal,\n"
+            . "       sp.commission_rate, sp.commission_amount, sp.payout_amount,\n"
+            . "       (SELECT SUM(quantity * unit_price) FROM order_items WHERE order_id = o.id) AS order_total\n"
+            . "FROM seller_payouts sp\n"
+            . "JOIN orders o ON o.id = sp.order_id\n"
+            . "JOIN users u ON u.id = o.user_id\n"
+            . "LEFT JOIN addresses a ON a.id = o.address_id\n"
+            . "LEFT JOIN delivery_slots d ON d.id = o.slot_id\n"
+            . "WHERE sp.seller_id = ?\n"
+            . "ORDER BY o.delivery_date DESC, d.time_from DESC"
+        );
+        $stmt->execute([$sellerId]);
+        $orders = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        $orderIds = array_column($orders, 'id');
+        $itemsByOrder = [];
+        if ($orderIds) {
+            $placeholders = implode(',', array_fill(0, count($orderIds), '?'));
+            $iStmt = $this->pdo->prepare(
+                "SELECT oi.order_id, oi.quantity, oi.boxes, oi.unit_price,\n"
+                . "       t.name AS product_name, p.variety, p.box_size, p.box_unit\n"
+                . "FROM order_items oi\n"
+                . "JOIN products p ON p.id = oi.product_id\n"
+                . "JOIN product_types t ON t.id = p.product_type_id\n"
+                . "WHERE oi.order_id IN ($placeholders) AND p.seller_id = ?\n"
+                . "ORDER BY oi.order_id"
+            );
+            $iStmt->execute([...$orderIds, $sellerId]);
+            while ($row = $iStmt->fetch(PDO::FETCH_ASSOC)) {
+                $itemsByOrder[$row['order_id']][] = $row;
+            }
+        }
+
+        foreach ($orders as &$o) {
+            $o['items'] = $itemsByOrder[$o['id']] ?? [];
+            $orderTotal = (float)($o['order_total'] ?? 0);
+            $sellerSubtotal = (float)($o['seller_subtotal'] ?? 0);
+            $pointsUsed = (float)($o['points_used'] ?? 0);
+            $o['points_applied'] = $orderTotal > 0
+                ? round($pointsUsed * $sellerSubtotal / $orderTotal, 2)
+                : 0.0;
+            $o['commission'] = (float)($o['commission_amount'] ?? 0);
+            $o['payout'] = (float)($o['payout_amount'] ?? 0);
+            unset($o['order_total'], $o['commission_amount'], $o['payout_amount']);
+        }
+        unset($o);
+
+        viewAdmin('seller_orders', [
+            'pageTitle' => 'Заказы',
+            'orders'    => $orders,
+        ]);
+    }
 }

--- a/src/Views/admin/seller_orders.php
+++ b/src/Views/admin/seller_orders.php
@@ -1,0 +1,23 @@
+<?php /** @var array $orders */ ?>
+<h1 class="text-xl mb-4">Заказы</h1>
+<?php foreach ($orders as $o): ?>
+  <div class="mb-6 p-4 border rounded">
+    <div class="font-semibold mb-1">#<?= htmlspecialchars($o['id']) ?> | <?= htmlspecialchars($o['delivery_date']) ?> <?= htmlspecialchars($o['slot_from']) ?>–<?= htmlspecialchars($o['slot_to']) ?> | <?= htmlspecialchars($o['status']) ?></div>
+    <div class="text-sm mb-2"><?= htmlspecialchars($o['client_name']) ?>, <?= htmlspecialchars($o['phone']) ?>, <?= htmlspecialchars($o['address']) ?></div>
+    <div class="text-sm mb-1">Состав:</div>
+    <ul class="text-sm mb-2">
+      <?php foreach ($o['items'] as $it): ?>
+        <?php $itemTotal = $it['quantity'] * $it['unit_price']; ?>
+        <li>
+          <?= htmlspecialchars($it['product_name']) ?><?php if ($it['variety']): ?> «<?= htmlspecialchars($it['variety']) ?>»<?php endif; ?>,
+          <?= rtrim(rtrim(number_format($it['boxes'],2,'.',''), '0'), '.') ?> ящ. (<?= rtrim(rtrim(number_format($it['quantity'],2,'.',''), '0'), '.') ?> <?= htmlspecialchars($it['box_unit']) ?>)
+          <span class="float-right"><?= number_format($itemTotal, 2, '.', ' ') ?> ₽</span>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+    <div class="text-sm flex justify-between"><span>Стоимость позиций (итого)</span><span><?= number_format($o['seller_subtotal'], 2, '.', ' ') ?> ₽</span></div>
+    <div class="text-sm flex justify-between"><span>Оплачено клубничками</span><span><?= number_format($o['points_applied'], 2, '.', ' ') ?> ₽</span></div>
+    <div class="text-sm flex justify-between"><span>Комиссия BerryGo (<?= (float)$o['commission_rate'] ?>%)</span><span><?= number_format($o['commission'], 2, '.', ' ') ?> ₽</span></div>
+    <div class="text-sm flex justify-between font-semibold"><span>Выплата селлеру</span><span><?= number_format($o['payout'], 2, '.', ' ') ?> ₽</span></div>
+  </div>
+<?php endforeach; ?>

--- a/tests/SellerOrdersTest.php
+++ b/tests/SellerOrdersTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace {
+    if (!function_exists('viewAdmin')) {
+        function viewAdmin(string $template, array $data = []): void
+        {
+            echo $template . PHP_EOL;
+            echo json_encode($data);
+        }
+    }
+}
+
+namespace Tests {
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\SellerController;
+use PDO;
+
+class SellerOrdersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION = [];
+    }
+
+    public function testSellerOrderCalculations(): void
+    {
+        if (!class_exists('App\\Controllers\\SellerController')) {
+            require_once __DIR__ . '/../src/Controllers/SellerController.php';
+        }
+
+        $_SESSION['user_id'] = 1;
+        $_SESSION['role'] = 'seller';
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE orders (id INT, user_id INT, address_id INT, slot_id INT, status TEXT, points_used REAL, delivery_date TEXT)');
+        $pdo->exec('CREATE TABLE users (id INT, name TEXT, phone TEXT)');
+        $pdo->exec('CREATE TABLE addresses (id INT, street TEXT)');
+        $pdo->exec('CREATE TABLE delivery_slots (id INT, time_from TEXT, time_to TEXT)');
+        $pdo->exec('CREATE TABLE seller_payouts (id INTEGER PRIMARY KEY AUTOINCREMENT, seller_id INT, order_id INT, gross_amount REAL, commission_rate REAL, commission_amount REAL, payout_amount REAL, created_at TEXT)');
+        $pdo->exec('CREATE TABLE order_items (id INTEGER PRIMARY KEY AUTOINCREMENT, order_id INT, product_id INT, quantity REAL, boxes REAL, unit_price REAL)');
+        $pdo->exec('CREATE TABLE products (id INT, product_type_id INT, seller_id INT, box_size REAL, box_unit TEXT, variety TEXT)');
+        $pdo->exec('CREATE TABLE product_types (id INT, name TEXT)');
+
+        $pdo->exec("INSERT INTO users (id,name,phone) VALUES (2,'Людмила','79025505385')");
+        $pdo->exec("INSERT INTO addresses (id,street) VALUES (1,'Елены Стасовой 48Е')");
+        $pdo->exec("INSERT INTO delivery_slots (id,time_from,time_to) VALUES (1,'18:00','22:00')");
+        $pdo->exec("INSERT INTO orders (id,user_id,address_id,slot_id,status,points_used,delivery_date) VALUES (1,2,1,1,'new',100,'2024-08-12')");
+        $pdo->exec("INSERT INTO product_types (id,name) VALUES (1,'Клубника')");
+        $pdo->exec("INSERT INTO products (id,product_type_id,seller_id,box_size,box_unit,variety) VALUES (1,1,1,2.0,'кг','Клери')");
+        $pdo->exec("INSERT INTO products (id,product_type_id,seller_id,box_size,box_unit,variety) VALUES (2,1,2,2.0,'кг','')");
+        $pdo->exec("INSERT INTO order_items (order_id,product_id,quantity,boxes,unit_price) VALUES (1,1,2.0,1,600)");
+        $pdo->exec("INSERT INTO order_items (order_id,product_id,quantity,boxes,unit_price) VALUES (1,2,3.0,1.5,800)");
+        $pdo->exec("INSERT INTO seller_payouts (seller_id,order_id,gross_amount,commission_rate,commission_amount,payout_amount,created_at) VALUES (1,1,1200,30,360,840,'2024-08-10')");
+
+        $controller = new SellerController($pdo);
+        ob_start();
+        $controller->orders();
+        $output = ob_get_clean();
+
+        [$template, $json] = explode("\n", trim($output), 2);
+        $this->assertSame('seller_orders', $template);
+        $data = json_decode($json, true);
+        $this->assertEquals(1, count($data['orders']));
+        $order = $data['orders'][0];
+        $this->assertEquals(1200, $order['seller_subtotal']);
+        $this->assertEquals(360, $order['commission']);
+        $this->assertEquals(840, $order['payout']);
+        $this->assertEquals(33.33, $order['points_applied']);
+    }
+}
+
+}

--- a/tests/SellerProfileTest.php
+++ b/tests/SellerProfileTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace {
-    function viewAdmin(string $template, array $data = []): void
-    {
-        echo $template . PHP_EOL;
-        echo json_encode($data);
+    if (!function_exists('viewAdmin')) {
+        function viewAdmin(string $template, array $data = []): void
+        {
+            echo $template . PHP_EOL;
+            echo json_encode($data);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add /seller/orders route and compute seller commissions/payouts
- render seller order cards with item and financial details
- test seller payout calculations

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a59a801590832ca3f047ee46a5f9fa