### PR TITLE
feat: add seller orders tab with commission and payouts

### DIFF
--- a/src/Views/admin/seller_orders.php
+++ b/src/Views/admin/seller_orders.php
@@ -1,8 +1,12 @@
 <?php /** @var array $orders */ ?>
 <h1 class="text-xl mb-4">Заказы</h1>
 <?php foreach ($orders as $o): ?>
+  <?php $info = order_status_info($o['status']); ?>
   <div class="mb-6 p-4 border rounded">
-    <div class="font-semibold mb-1">#<?= htmlspecialchars($o['id']) ?> | <?= htmlspecialchars($o['delivery_date']) ?> <?= htmlspecialchars($o['slot_from']) ?>–<?= htmlspecialchars($o['slot_to']) ?> | <?= htmlspecialchars($o['status']) ?></div>
+    <div class="font-semibold mb-1 flex justify-between">
+      <span>#<?= htmlspecialchars($o['id']) ?> | <?= htmlspecialchars($o['delivery_date']) ?> <?= htmlspecialchars($o['slot_from']) ?>–<?= htmlspecialchars($o['slot_to']) ?></span>
+      <span><?= htmlspecialchars($info['label']) ?></span>
+    </div>
     <div class="text-sm mb-2"><?= htmlspecialchars($o['client_name']) ?>, <?= htmlspecialchars($o['phone']) ?>, <?= htmlspecialchars($o['address']) ?></div>
     <div class="text-sm mb-1">Состав:</div>
     <ul class="text-sm mb-2">
@@ -19,5 +23,10 @@
     <div class="text-sm flex justify-between"><span>Оплачено клубничками</span><span><?= number_format($o['points_applied'], 2, '.', ' ') ?> ₽</span></div>
     <div class="text-sm flex justify-between"><span>Комиссия BerryGo (<?= (float)$o['commission_rate'] ?>%)</span><span><?= number_format($o['commission'], 2, '.', ' ') ?> ₽</span></div>
     <div class="text-sm flex justify-between font-semibold"><span>Выплата селлеру</span><span><?= number_format($o['payout'], 2, '.', ' ') ?> ₽</span></div>
+    <div class="mt-2 flex flex-wrap gap-2 text-sm">
+      <button class="border rounded px-3 py-1">✅ Подтвердить</button>
+      <button class="border rounded px-3 py-1">🧺 Готово к выдаче</button>
+      <button class="border rounded px-3 py-1">⚠️ Нет в наличии</button>
+    </div>
   </div>
 <?php endforeach; ?>

--- a/src/Views/layouts/seller_main.php
+++ b/src/Views/layouts/seller_main.php
@@ -250,6 +250,7 @@ $labelRole = 'Селлер';
       <div class="font-bold text-lg md:text-xl text-[#C86052]">BerryGo <?= htmlspecialchars($titleRole) ?></div>
       <nav class="hidden md:flex space-x-2 md:space-x-4">
         <a href="<?= $base ?>/dashboard" class="hover:underline">Статистика</a>
+        <a href="<?= $base ?>/orders" class="hover:underline">Заказы</a>
         <a href="<?= $base ?>/products" class="hover:underline">Товары</a>
         <a href="<?= $base ?>/product-types" class="hover:underline">Категории</a>
         <a href="<?= $base ?>/profile" class="hover:underline">Профиль</a>
@@ -272,6 +273,10 @@ $labelRole = 'Селлер';
         <span class="material-icons-round mr-2 text-base md:text-lg">bar_chart</span>
         <span class="menu-text text-sm md:text-base">Статистика</span>
       </a>
+      <a href="<?= $base ?>/orders" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
+        <span class="material-icons-round mr-2 text-base md:text-lg">shopping_bag</span>
+        <span class="menu-text text-sm md:text-base">Заказы</span>
+      </a>
       <a href="<?= $base ?>/products" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2 text-base md:text-lg">inventory_2</span>
         <span class="menu-text text-sm md:text-base">Товары</span>
@@ -281,8 +286,8 @@ $labelRole = 'Селлер';
         <span class="menu-text text-sm md:text-base">Категории</span>
       </a>
       <a href="<?= $base ?>/profile" class="flex items-center p-2 mt-2 rounded hover:bg-gray-200">
-      <span class="material-icons-round mr-2 text-base md:text-lg">account_circle</span>
-      <span class="menu-text text-sm md:text-base">Профиль</span>
+        <span class="material-icons-round mr-2 text-base md:text-lg">account_circle</span>
+        <span class="menu-text text-sm md:text-base">Профиль</span>
       </a>
     </nav>
   </aside>

--- a/tests/SellerOrdersTest.php
+++ b/tests/SellerOrdersTest.php
@@ -39,7 +39,6 @@ class SellerOrdersTest extends TestCase
         $pdo->exec('CREATE TABLE users (id INT, name TEXT, phone TEXT)');
         $pdo->exec('CREATE TABLE addresses (id INT, street TEXT)');
         $pdo->exec('CREATE TABLE delivery_slots (id INT, time_from TEXT, time_to TEXT)');
-        $pdo->exec('CREATE TABLE seller_payouts (id INTEGER PRIMARY KEY AUTOINCREMENT, seller_id INT, order_id INT, gross_amount REAL, commission_rate REAL, commission_amount REAL, payout_amount REAL, created_at TEXT)');
         $pdo->exec('CREATE TABLE order_items (id INTEGER PRIMARY KEY AUTOINCREMENT, order_id INT, product_id INT, quantity REAL, boxes REAL, unit_price REAL)');
         $pdo->exec('CREATE TABLE products (id INT, product_type_id INT, seller_id INT, box_size REAL, box_unit TEXT, variety TEXT)');
         $pdo->exec('CREATE TABLE product_types (id INT, name TEXT)');
@@ -53,7 +52,6 @@ class SellerOrdersTest extends TestCase
         $pdo->exec("INSERT INTO products (id,product_type_id,seller_id,box_size,box_unit,variety) VALUES (2,1,2,2.0,'кг','')");
         $pdo->exec("INSERT INTO order_items (order_id,product_id,quantity,boxes,unit_price) VALUES (1,1,2.0,1,600)");
         $pdo->exec("INSERT INTO order_items (order_id,product_id,quantity,boxes,unit_price) VALUES (1,2,3.0,1.5,800)");
-        $pdo->exec("INSERT INTO seller_payouts (seller_id,order_id,gross_amount,commission_rate,commission_amount,payout_amount,created_at) VALUES (1,1,1200,30,360,840,'2024-08-10')");
 
         $controller = new SellerController($pdo);
         ob_start();
@@ -69,6 +67,7 @@ class SellerOrdersTest extends TestCase
         $this->assertEquals(360, $order['commission']);
         $this->assertEquals(840, $order['payout']);
         $this->assertEquals(33.33, $order['points_applied']);
+        $this->assertEquals('79******385', $order['phone']);
     }
 }
 


### PR DESCRIPTION
## Summary
- allow sellers to browse their orders with payout, commission and points breakdown
- add seller orders view with action buttons
- expose orders tab in seller navigation

## Testing
- `./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a59f23ffa8832c916c534e32971031