### PR TITLE
Add seller work modes and balance tracking

### DIFF
--- a/database/2025_23_seller_work_mode.sql
+++ b/database/2025_23_seller_work_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+  ADD COLUMN work_mode ENUM('berrygo_store','own_store','warehouse_delivery') NOT NULL DEFAULT 'berrygo_store' AFTER delivery_cost;

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -9,7 +9,8 @@ class User extends Model
 
     protected $fillable = [
         'name', 'phone', 'password_hash',
-        'referral_code', 'referred_by', 'points_balance', 'rub_balance'
+        'referral_code', 'referred_by', 'points_balance', 'rub_balance',
+        'work_mode'
     ];
 
     protected $hidden = [

--- a/src/Views/admin/seller_profile.php
+++ b/src/Views/admin/seller_profile.php
@@ -3,12 +3,14 @@
  * @var int   $ordersCount
  * @var int   $revenue
  * @var array $payouts
+ * @var int   $balance
+ * @var string $workMode
  */
 ?>
 <div class="space-y-6">
   <div class="bg-white rounded shadow p-2 md:p-4">
     <h2 class="text-base md:text-lg font-semibold mb-2">Общая статистика</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 md:gap-4 text-center">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 md:gap-4 text-center">
       <div>
         <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $ordersCount ?></div>
         <div class="text-sm text-gray-600">продаж</div>
@@ -17,7 +19,19 @@
         <div class="text-xl md:text-2xl font-bold text-[#C86052]"><?= $revenue ?> ₽</div>
         <div class="text-sm text-gray-600">оборот</div>
       </div>
+      <div>
+        <div class="text-xl md:text-2xl font-bold <?= $balance >= 0 ? 'text-[#C86052]' : 'text-red-600' ?>"><?= $balance ?> ₽</div>
+        <div class="text-sm text-gray-600">баланс</div>
+      </div>
     </div>
+    <?php
+    $modeNames = [
+      'berrygo_store' => 'Товар в BerryGo',
+      'own_store' => 'Со своего магазина',
+      'warehouse_delivery' => 'Со своего склада',
+    ];
+    ?>
+    <p class="text-sm text-gray-600 mt-2">Режим: <?= $modeNames[$workMode] ?? htmlspecialchars($workMode) ?></p>
   </div>
 
   <?php if (!empty($payouts)): ?>

--- a/src/Views/admin/users/edit.php
+++ b/src/Views/admin/users/edit.php
@@ -79,14 +79,22 @@
       <label class="block mb-1">Адрес самовывоза</label>
       <input type="text" name="pickup_address" value="<?= htmlspecialchars($user['pickup_address'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
     </div>
-    <div>
-      <label class="block mb-1">Стоимость доставки</label>
-      <input type="number" step="0.01" name="delivery_cost" value="<?= htmlspecialchars($user['delivery_cost'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
-    </div>
-    <div class="flex items-center space-x-2">
-      <input type="checkbox" name="is_blocked" value="1" <?= !empty($user['is_blocked']) ? 'checked' : '' ?>>
-      <span>Заблокирован</span>
-    </div>
+      <div>
+        <label class="block mb-1">Стоимость доставки</label>
+        <input type="number" step="0.01" name="delivery_cost" value="<?= htmlspecialchars($user['delivery_cost'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+      </div>
+      <div>
+        <label class="block mb-1">Режим работы</label>
+        <select name="work_mode" class="w-full border px-2 py-1 rounded">
+          <option value="berrygo_store" <?= ($user['work_mode'] ?? '')==='berrygo_store' ? 'selected' : '' ?>>Товар в BerryGo</option>
+          <option value="own_store" <?= ($user['work_mode'] ?? '')==='own_store' ? 'selected' : '' ?>>Со своего магазина</option>
+          <option value="warehouse_delivery" <?= ($user['work_mode'] ?? '')==='warehouse_delivery' ? 'selected' : '' ?>>Со своего склада</option>
+        </select>
+      </div>
+      <div class="flex items-center space-x-2">
+        <input type="checkbox" name="is_blocked" value="1" <?= !empty($user['is_blocked']) ? 'checked' : '' ?>>
+        <span>Заблокирован</span>
+      </div>
     <?php if (!empty($user['rub_balance'])): ?>
     <div>
       <div class="mb-1">Баланс, ₽</div>

--- a/src/Views/admin/users/index.php
+++ b/src/Views/admin/users/index.php
@@ -64,10 +64,10 @@
       <td class="p-3 text-gray-600"><?= htmlspecialchars($u['address'] ?? '') ?></td>
       <td class="p-3 text-gray-600">
         <span><?= (int)($u['points_balance'] ?? 0) ?> 🍓</span>
-        <?php if (($u['rub_balance'] ?? 0) > 0): ?>
-          <br><span><?= (int)$u['rub_balance'] ?> ₽</span>
-        <?php endif; ?>
-      </td>
+          <?php if (($u['rub_balance'] ?? 0) != 0): ?>
+            <br><span><?= (int)$u['rub_balance'] ?> ₽</span>
+          <?php endif; ?>
+        </td>
       <td class="p-3 text-center">
         <form action="<?= $base ?>/users/toggle-block" method="post" class="inline-block">
           <input type="hidden" name="id" value="<?= $u['id'] ?>">

--- a/src/Views/admin/users/show.php
+++ b/src/Views/admin/users/show.php
@@ -62,19 +62,27 @@ $roleNames = [
     <label class="block text-sm mb-1">Название компании</label>
     <input name="company_name" class="border rounded px-2 py-1" value="<?= htmlspecialchars($user['company_name'] ?? '') ?>">
   </div>
-  <div>
-    <label class="block text-sm mb-1">Адрес самовывоза</label>
-    <input name="pickup_address" class="border rounded px-2 py-1" value="<?= htmlspecialchars($user['pickup_address'] ?? '') ?>">
-  </div>
-  <div>
-    <label class="block text-sm mb-1">Стоимость доставки</label>
-    <input name="delivery_cost" type="number" step="0.01" class="border rounded px-2 py-1" value="<?= htmlspecialchars($user['delivery_cost'] ?? '') ?>">
-  </div>
-  <div class="flex justify-between">
-    <div>Баланс: <?= (int)$user['points_balance'] ?> 🍓</div>
-    <?php if ($isManager): ?>
-      <div><?= (int)$user['rub_balance'] ?> ₽</div>
-    <?php endif; ?>
+    <div>
+      <label class="block text-sm mb-1">Адрес самовывоза</label>
+      <input name="pickup_address" class="border rounded px-2 py-1" value="<?= htmlspecialchars($user['pickup_address'] ?? '') ?>">
+    </div>
+    <div>
+      <label class="block text-sm mb-1">Стоимость доставки</label>
+      <input name="delivery_cost" type="number" step="0.01" class="border rounded px-2 py-1" value="<?= htmlspecialchars($user['delivery_cost'] ?? '') ?>">
+    </div>
+    <div>
+      <label class="block text-sm mb-1">Режим работы</label>
+      <select name="work_mode" class="border rounded px-2 py-1">
+        <option value="berrygo_store" <?= ($user['work_mode'] ?? '')==='berrygo_store' ? 'selected' : '' ?>>Товар в BerryGo</option>
+        <option value="own_store" <?= ($user['work_mode'] ?? '')==='own_store' ? 'selected' : '' ?>>Со своего магазина</option>
+        <option value="warehouse_delivery" <?= ($user['work_mode'] ?? '')==='warehouse_delivery' ? 'selected' : '' ?>>Со своего склада</option>
+      </select>
+    </div>
+    <div class="flex justify-between">
+      <div>Баланс: <?= (int)$user['points_balance'] ?> 🍓</div>
+      <?php if ($isManager): ?>
+        <div><?= (int)$user['rub_balance'] ?> ₽</div>
+      <?php endif; ?>
   </div>
   <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
 </form>

--- a/tests/SellerProfileTest.php
+++ b/tests/SellerProfileTest.php
@@ -37,7 +37,9 @@ class SellerProfileTest extends TestCase
 
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE seller_payouts (id INTEGER PRIMARY KEY AUTOINCREMENT, seller_id INT, gross_amount REAL, payout_amount REAL, status TEXT, created_at TEXT)');
+        $pdo->exec('CREATE TABLE users (id INT, rub_balance INT, work_mode TEXT)');
         $pdo->exec("INSERT INTO seller_payouts (seller_id, gross_amount, payout_amount, status, created_at) VALUES (1, 100, 70, 'pending', '2024-01-01')");
+        $pdo->exec("INSERT INTO users (id, rub_balance, work_mode) VALUES (1, -150, 'warehouse_delivery')");
 
         $controller = new UsersController($pdo);
         ob_start();
@@ -46,6 +48,8 @@ class SellerProfileTest extends TestCase
 
         $this->assertStringContainsString('seller_profile', $output);
         $this->assertStringContainsString('"ordersCount":1', $output);
+        $this->assertStringContainsString('"balance":-150', $output);
+        $this->assertStringContainsString('"workMode":"warehouse_delivery"', $output);
     }
 }
 


### PR DESCRIPTION
## Summary
- add `work_mode` column for sellers and expose in models and forms
- show seller balances and work mode on profile and listings
- update tests for seller balance and work mode

## Testing
- `./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a5acd6345c832cb5368a7ed1b52600