### PR TITLE
Add seller management section to admin panel

### DIFF
--- a/index.php
+++ b/index.php
@@ -623,6 +623,15 @@ switch ("$method $uri") {
         (new App\Controllers\UsersController($pdo))->deleteAddressAdmin();
         break;
 
+    case 'GET /admin/sellers':
+        requireAdmin();
+        (new App\Controllers\SellersController($pdo))->index();
+        break;
+    case (bool)preg_match('#^GET /admin/sellers/(\\d+)$#', "$method $uri", $m):
+        requireAdmin();
+        (new App\Controllers\SellersController($pdo))->show((int)$m[1]);
+        break;
+
     case 'GET /admin/apps':
         requireAdmin();
         (new App\Controllers\AppsController($pdo))->index();

--- a/src/Controllers/SellersController.php
+++ b/src/Controllers/SellersController.php
@@ -1,0 +1,103 @@
+<?php
+namespace App\Controllers;
+
+use PDO;
+
+class SellersController
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * List all sellers
+     */
+    public function index(): void
+    {
+        $stmt = $this->pdo->query("SELECT id, company_name, name, phone, rub_balance FROM users WHERE role = 'seller' ORDER BY company_name");
+        $sellers = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        viewAdmin('sellers/index', [
+            'pageTitle' => 'Селлеры',
+            'sellers'   => $sellers,
+        ]);
+    }
+
+    /**
+     * Show seller profile with orders
+     */
+    public function show(int $id): void
+    {
+        $stmt = $this->pdo->prepare("SELECT id, company_name, pickup_address, name, phone, rub_balance FROM users WHERE id = ? AND role = 'seller'");
+        $stmt->execute([$id]);
+        $seller = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$seller) {
+            http_response_code(404);
+            echo 'Селлер не найден';
+            return;
+        }
+
+        // Orders for seller (similar to SellerController::orders)
+        $oStmt = $this->pdo->prepare(
+            "SELECT o.id, o.status, o.points_used, o.delivery_date,\n" .
+            "       d.time_from AS slot_from, d.time_to AS slot_to,\n" .
+            "       u.name AS client_name, u.phone, a.street AS address,\n" .
+            "       SUM(oi.quantity * oi.unit_price) AS seller_subtotal,\n" .
+            "       (SELECT SUM(quantity * unit_price) FROM order_items WHERE order_id = o.id) AS order_total\n" .
+            "FROM orders o\n" .
+            "JOIN order_items oi ON oi.order_id = o.id\n" .
+            "JOIN products p ON p.id = oi.product_id\n" .
+            "JOIN users u ON u.id = o.user_id\n" .
+            "LEFT JOIN addresses a ON a.id = o.address_id\n" .
+            "LEFT JOIN delivery_slots d ON d.id = o.slot_id\n" .
+            "WHERE p.seller_id = ?\n" .
+            "GROUP BY o.id, o.status, o.points_used, o.delivery_date, d.time_from, d.time_to, u.name, u.phone, a.street\n" .
+            "ORDER BY o.delivery_date DESC, d.time_from DESC"
+        );
+        $oStmt->execute([$id]);
+        $orders = $oStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        $orderIds = array_column($orders, 'id');
+        $itemsByOrder = [];
+        if ($orderIds) {
+            $placeholders = implode(',', array_fill(0, count($orderIds), '?'));
+            $iStmt = $this->pdo->prepare(
+                "SELECT oi.order_id, oi.quantity, oi.boxes, oi.unit_price,\n" .
+                "       t.name AS product_name, p.variety, p.box_size, p.box_unit\n" .
+                "FROM order_items oi\n" .
+                "JOIN products p ON p.id = oi.product_id\n" .
+                "JOIN product_types t ON t.id = p.product_type_id\n" .
+                "WHERE oi.order_id IN ($placeholders) AND p.seller_id = ?\n" .
+                "ORDER BY oi.order_id"
+            );
+            $iStmt->execute([...$orderIds, $id]);
+            while ($row = $iStmt->fetch(PDO::FETCH_ASSOC)) {
+                $itemsByOrder[$row['order_id']][] = $row;
+            }
+        }
+
+        foreach ($orders as &$o) {
+            $o['items'] = $itemsByOrder[$o['id']] ?? [];
+            $orderTotal = (float)($o['order_total'] ?? 0);
+            $sellerSubtotal = (float)($o['seller_subtotal'] ?? 0);
+            $pointsUsed = (float)($o['points_used'] ?? 0);
+            $o['commission_rate'] = 30.0;
+            $o['commission'] = round($sellerSubtotal * $o['commission_rate'] / 100, 2);
+            $o['payout'] = $sellerSubtotal - $o['commission'];
+            $o['points_applied'] = $orderTotal > 0
+                ? round($pointsUsed * $sellerSubtotal / $orderTotal, 2)
+                : 0.0;
+            unset($o['order_total']);
+        }
+        unset($o);
+
+        viewAdmin('sellers/show', [
+            'pageTitle' => 'Профиль селлера',
+            'seller'    => $seller,
+            'orders'    => $orders,
+        ]);
+    }
+}

--- a/src/Views/admin/sellers/index.php
+++ b/src/Views/admin/sellers/index.php
@@ -1,0 +1,23 @@
+<?php /** @var array $sellers */ ?>
+<table class="min-w-full bg-white rounded shadow overflow-hidden">
+  <thead class="bg-gray-200 text-gray-700">
+    <tr>
+      <th class="p-3 text-left font-semibold">Компания</th>
+      <th class="p-3 text-left font-semibold">Имя</th>
+      <th class="p-3 text-left font-semibold">Телефон</th>
+      <th class="p-3 text-left font-semibold">Баланс</th>
+    </tr>
+  </thead>
+  <tbody>
+    <?php foreach ($sellers as $s): ?>
+    <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <td class="p-3">
+        <a href="/admin/sellers/<?= $s['id'] ?>" class="text-[#C86052] hover:underline"><?= htmlspecialchars($s['company_name']) ?></a>
+      </td>
+      <td class="p-3"><?= htmlspecialchars($s['name']) ?></td>
+      <td class="p-3 text-gray-600"><?= htmlspecialchars($s['phone']) ?></td>
+      <td class="p-3 text-gray-600"><?= (int)$s['rub_balance'] ?> ₽</td>
+    </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>

--- a/src/Views/admin/sellers/show.php
+++ b/src/Views/admin/sellers/show.php
@@ -1,0 +1,38 @@
+<?php /** @var array $seller @var array $orders */ ?>
+<div class="bg-white rounded shadow p-4 mb-6">
+  <div class="mb-2"><span class="font-semibold">Название:</span> <?= htmlspecialchars($seller['company_name']) ?></div>
+  <div class="mb-2"><span class="font-semibold">Адрес:</span> <?= htmlspecialchars($seller['pickup_address']) ?></div>
+  <div class="mb-2"><span class="font-semibold">Имя:</span> <?= htmlspecialchars($seller['name']) ?></div>
+  <div class="mb-2"><span class="font-semibold">Телефон:</span> <?= htmlspecialchars($seller['phone']) ?></div>
+  <div><span class="font-semibold">Баланс:</span> <?= (int)$seller['rub_balance'] ?> ₽</div>
+</div>
+<h2 class="text-lg font-semibold mb-4">Заказы</h2>
+<?php if ($orders): ?>
+  <?php foreach ($orders as $o): ?>
+    <?php $info = order_status_info($o['status']); ?>
+    <div class="mb-6 p-4 border rounded">
+      <div class="font-semibold mb-1 flex justify-between">
+        <span>#<?= htmlspecialchars($o['id']) ?> | <?= htmlspecialchars($o['delivery_date']) ?> <?= htmlspecialchars($o['slot_from']) ?>–<?= htmlspecialchars($o['slot_to']) ?></span>
+        <span><?= htmlspecialchars($info['label']) ?></span>
+      </div>
+      <div class="text-sm mb-2"><?= htmlspecialchars($o['client_name']) ?>, <?= htmlspecialchars($o['phone']) ?>, <?= htmlspecialchars($o['address']) ?></div>
+      <div class="text-sm mb-1">Состав:</div>
+      <ul class="text-sm mb-2">
+        <?php foreach ($o['items'] as $it): ?>
+          <?php $itemTotal = $it['quantity'] * $it['unit_price']; ?>
+          <li>
+            <?= htmlspecialchars($it['product_name']) ?><?php if ($it['variety']): ?> «<?= htmlspecialchars($it['variety']) ?>»<?php endif; ?>,
+            <?= rtrim(rtrim(number_format($it['boxes'],2,'.',''), '0'), '.') ?> ящ. (<?= rtrim(rtrim(number_format($it['quantity'],2,'.',''), '0'), '.') ?> <?= htmlspecialchars($it['box_unit']) ?>)
+            <span class="float-right"><?= number_format($itemTotal, 2, '.', ' ') ?> ₽</span>
+          </li>
+        <?php endforeach; ?>
+      </ul>
+      <div class="text-sm flex justify-between"><span>Стоимость позиций (итого)</span><span><?= number_format($o['seller_subtotal'], 2, '.', ' ') ?> ₽</span></div>
+      <div class="text-sm flex justify-between"><span>Оплачено клубничками</span><span><?= number_format($o['points_applied'], 2, '.', ' ') ?> ₽</span></div>
+      <div class="text-sm flex justify-between"><span>Комиссия BerryGo (<?= (float)$o['commission_rate'] ?>%)</span><span><?= number_format($o['commission'], 2, '.', ' ') ?> ₽</span></div>
+      <div class="text-sm flex justify-between font-semibold"><span>Выплата селлеру</span><span><?= number_format($o['payout'], 2, '.', ' ') ?> ₽</span></div>
+    </div>
+  <?php endforeach; ?>
+<?php else: ?>
+  <p class="text-sm text-gray-600">Заказов пока нет</p>
+<?php endif; ?>

--- a/src/Views/layouts/admin_main.php
+++ b/src/Views/layouts/admin_main.php
@@ -262,6 +262,7 @@
         <a href="/admin/coupons" class="hover:underline">Промокоды</a>
         <a href="/admin/content" class="hover:underline">Контент</a>
         <a href="/admin/users" class="hover:underline">Пользователи</a>
+        <a href="/admin/sellers" class="hover:underline">Селлеры</a>
         <a href="/admin/apps" class="hover:underline">Приложения</a>
         <a href="/admin/settings" class="hover:underline">Настройки</a>
       </nav>
@@ -310,6 +311,10 @@
       <a href="/admin/users" class="flex items-center p-2 mb-2 rounded">
         <span class="material-icons-round mr-2">people</span>
         <span class="menu-text">Пользователи</span>
+      </a>
+      <a href="/admin/sellers" class="flex items-center p-2 mb-2 rounded">
+        <span class="material-icons-round mr-2">storefront</span>
+        <span class="menu-text">Селлеры</span>
       </a>
       <a href="/admin/apps" class="flex items-center p-2 mb-2 rounded">
         <span class="material-icons-round mr-2">apps</span>


### PR DESCRIPTION
## Summary
- Implement SellersController to list sellers and display individual profiles with order details
- Add admin views for sellers list and profile
- Wire routes and navigation links for the new sellers section

## Testing
- `php -l src/Controllers/SellersController.php`
- `php -l src/Views/admin/sellers/index.php`
- `php -l src/Views/admin/sellers/show.php`
- `php -l src/Views/layouts/admin_main.php`
- `php -l index.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a5e232dd8c832c9054fac46282cd24