### PR TITLE
Add 'accrued' seller payout status

### DIFF
--- a/database/2025_21_sellers.sql
+++ b/database/2025_21_sellers.sql
@@ -16,7 +16,7 @@ CREATE TABLE seller_payouts (
   commission_rate DECIMAL(5,2) NOT NULL DEFAULT 30.00,
   commission_amount DECIMAL(10,2) NOT NULL,
   payout_amount DECIMAL(10,2) NOT NULL,
-  status ENUM('pending','scheduled','paid','cancelled') NOT NULL DEFAULT 'pending',
+  status ENUM('pending','scheduled','accrued','paid','cancelled') NOT NULL DEFAULT 'pending',
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   paid_at DATETIME NULL,
   CONSTRAINT fk_sp_seller FOREIGN KEY (seller_id) REFERENCES users(id) ON DELETE CASCADE,

--- a/database/2025_24_seller_payout_status.sql
+++ b/database/2025_24_seller_payout_status.sql
@@ -1,0 +1,3 @@
+ALTER TABLE seller_payouts
+  MODIFY status ENUM('pending','scheduled','accrued','paid','cancelled') NOT NULL DEFAULT 'pending';
+


### PR DESCRIPTION
## Summary
- Allow seller payouts to use new `accrued` status
- Provide migration to update existing databases

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a5f32a6914832ca46d8fb011f05ba9