### PR TITLE
feat: move seller fields to dedicated edit page

### DIFF
--- a/index.php
+++ b/index.php
@@ -627,6 +627,14 @@ switch ("$method $uri") {
         requireAdmin();
         (new App\Controllers\SellersController($pdo))->index();
         break;
+    case 'GET /admin/sellers/edit':
+        requireAdmin();
+        (new App\Controllers\SellersController($pdo))->edit();
+        break;
+    case 'POST /admin/sellers/save':
+        requireAdmin();
+        (new App\Controllers\SellersController($pdo))->save();
+        break;
     case (bool)preg_match('#^GET /admin/sellers/(\\d+)$#', "$method $uri", $m):
         requireAdmin();
         (new App\Controllers\SellersController($pdo))->show((int)$m[1]);

--- a/src/Controllers/SellersController.php
+++ b/src/Controllers/SellersController.php
@@ -12,6 +12,11 @@ class SellersController
         $this->pdo = $pdo;
     }
 
+    private function basePath(): string
+    {
+        return '/admin/sellers';
+    }
+
     /**
      * List all sellers
      */
@@ -99,5 +104,42 @@ class SellersController
             'seller'    => $seller,
             'orders'    => $orders,
         ]);
+    }
+
+    public function edit(): void
+    {
+        $id = (int)($_GET['id'] ?? 0);
+        $seller = null;
+        if ($id) {
+            $stmt = $this->pdo->prepare("SELECT id, company_name, pickup_address, delivery_cost, work_mode FROM users WHERE id = ? AND role = 'seller'");
+            $stmt->execute([$id]);
+            $seller = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!$seller) {
+                header('Location: ' . $this->basePath());
+                exit;
+            }
+        }
+
+        viewAdmin('sellers/edit', [
+            'pageTitle' => 'Редактировать селлера',
+            'seller'    => $seller,
+        ]);
+    }
+
+    public function save(): void
+    {
+        $id = (int)($_POST['id'] ?? 0);
+        $company = trim($_POST['company_name'] ?? '');
+        $pickup  = trim($_POST['pickup_address'] ?? '');
+        $cost    = (float)($_POST['delivery_cost'] ?? 0);
+        $mode    = $_POST['work_mode'] ?? 'berrygo_store';
+
+        if ($id) {
+            $stmt = $this->pdo->prepare("UPDATE users SET company_name = ?, pickup_address = ?, delivery_cost = ?, work_mode = ? WHERE id = ? AND role = 'seller'");
+            $stmt->execute([$company, $pickup, $cost, $mode, $id]);
+        }
+
+        header('Location: ' . $this->basePath());
+        exit;
     }
 }

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -668,14 +668,14 @@ class UsersController
         if ($id) {
             try {
                 $stmt = $this->pdo->prepare(
-                    "SELECT id, name, phone, role, is_blocked, rub_balance, company_name, pickup_address, delivery_cost, work_mode
+                    "SELECT id, name, phone, role, is_blocked, rub_balance
                      FROM users
                      WHERE id = ?"
                 );
                 $stmt->execute([$id]);
             } catch (\PDOException $e) {
                 $stmt = $this->pdo->prepare(
-                    "SELECT id, name, phone, role, rub_balance, company_name, pickup_address, delivery_cost, work_mode
+                    "SELECT id, name, phone, role, rub_balance
                      FROM users
                      WHERE id = ?"
                 );
@@ -754,16 +754,6 @@ class UsersController
                     $stmt->execute([$role, $id]);
                 }
             }
-            $cStmt = $this->pdo->prepare(
-                "UPDATE users SET company_name = ?, pickup_address = ?, delivery_cost = ?, work_mode = ? WHERE id = ?"
-            );
-            $cStmt->execute([
-                trim($_POST['company_name'] ?? ''),
-                trim($_POST['pickup_address'] ?? ''),
-                (float)($_POST['delivery_cost'] ?? 0),
-                $_POST['work_mode'] ?? 'berrygo_store',
-                $id
-            ]);
         } else {
             $nameRaw  = $_POST['name'] ?? '';
             $phoneRaw = $_POST['phone'] ?? '';

--- a/src/Views/admin/sellers/edit.php
+++ b/src/Views/admin/sellers/edit.php
@@ -1,0 +1,26 @@
+<?php /** @var array|null $seller */ ?>
+<?php $base = '/admin'; ?>
+<form action="<?= $base ?>/sellers/save" method="post" class="bg-white p-6 rounded shadow max-w-md space-y-4">
+  <input type="hidden" name="id" value="<?= $seller['id'] ?? '' ?>">
+  <div>
+    <label class="block mb-1">Название компании</label>
+    <input type="text" name="company_name" value="<?= htmlspecialchars($seller['company_name'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+  </div>
+  <div>
+    <label class="block mb-1">Адрес самовывоза</label>
+    <input type="text" name="pickup_address" value="<?= htmlspecialchars($seller['pickup_address'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+  </div>
+  <div>
+    <label class="block mb-1">Стоимость доставки</label>
+    <input type="number" step="0.01" name="delivery_cost" value="<?= htmlspecialchars($seller['delivery_cost'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+  </div>
+  <div>
+    <label class="block mb-1">Режим работы</label>
+    <select name="work_mode" class="w-full border px-2 py-1 rounded">
+      <option value="berrygo_store" <?= ($seller['work_mode'] ?? '')==='berrygo_store' ? 'selected' : '' ?>>Товар в BerryGo</option>
+      <option value="own_store" <?= ($seller['work_mode'] ?? '')==='own_store' ? 'selected' : '' ?>>Со своего магазина</option>
+      <option value="warehouse_delivery" <?= ($seller['work_mode'] ?? '')==='warehouse_delivery' ? 'selected' : '' ?>>Со своего склада</option>
+    </select>
+  </div>
+  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+</form>

--- a/src/Views/admin/sellers/index.php
+++ b/src/Views/admin/sellers/index.php
@@ -6,6 +6,7 @@
       <th class="p-3 text-left font-semibold">Имя</th>
       <th class="p-3 text-left font-semibold">Телефон</th>
       <th class="p-3 text-left font-semibold">Баланс</th>
+      <th class="p-3 text-center font-semibold">Редактировать</th>
     </tr>
   </thead>
   <tbody>
@@ -17,6 +18,9 @@
       <td class="p-3"><?= htmlspecialchars($s['name']) ?></td>
       <td class="p-3 text-gray-600"><?= htmlspecialchars($s['phone']) ?></td>
       <td class="p-3 text-gray-600"><?= (int)$s['rub_balance'] ?> ₽</td>
+      <td class="p-3 text-center">
+        <a href="/admin/sellers/edit?id=<?= $s['id'] ?>" class="text-[#C86052] hover:underline">Редактировать</a>
+      </td>
     </tr>
     <?php endforeach; ?>
   </tbody>

--- a/src/Views/admin/sellers/show.php
+++ b/src/Views/admin/sellers/show.php
@@ -5,6 +5,9 @@
   <div class="mb-2"><span class="font-semibold">Имя:</span> <?= htmlspecialchars($seller['name']) ?></div>
   <div class="mb-2"><span class="font-semibold">Телефон:</span> <?= htmlspecialchars($seller['phone']) ?></div>
   <div><span class="font-semibold">Баланс:</span> <?= (int)$seller['rub_balance'] ?> ₽</div>
+  <div class="mt-4">
+    <a href="/admin/sellers/edit?id=<?= $seller['id'] ?>" class="text-[#C86052] hover:underline">Редактировать</a>
+  </div>
 </div>
 <h2 class="text-lg font-semibold mb-4">Заказы</h2>
 <?php if ($orders): ?>

--- a/src/Views/admin/users/edit.php
+++ b/src/Views/admin/users/edit.php
@@ -71,30 +71,10 @@
         <option value="seller" <?= $user['role']==='seller'?'selected':'' ?>>Селлер</option>
       </select>
     </div>
-    <div>
-      <label class="block mb-1">Название компании</label>
-      <input type="text" name="company_name" value="<?= htmlspecialchars($user['company_name'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
+    <div class="flex items-center space-x-2">
+      <input type="checkbox" name="is_blocked" value="1" <?= !empty($user['is_blocked']) ? 'checked' : '' ?>>
+      <span>Заблокирован</span>
     </div>
-    <div>
-      <label class="block mb-1">Адрес самовывоза</label>
-      <input type="text" name="pickup_address" value="<?= htmlspecialchars($user['pickup_address'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
-    </div>
-      <div>
-        <label class="block mb-1">Стоимость доставки</label>
-        <input type="number" step="0.01" name="delivery_cost" value="<?= htmlspecialchars($user['delivery_cost'] ?? '') ?>" class="w-full border px-2 py-1 rounded">
-      </div>
-      <div>
-        <label class="block mb-1">Режим работы</label>
-        <select name="work_mode" class="w-full border px-2 py-1 rounded">
-          <option value="berrygo_store" <?= ($user['work_mode'] ?? '')==='berrygo_store' ? 'selected' : '' ?>>Товар в BerryGo</option>
-          <option value="own_store" <?= ($user['work_mode'] ?? '')==='own_store' ? 'selected' : '' ?>>Со своего магазина</option>
-          <option value="warehouse_delivery" <?= ($user['work_mode'] ?? '')==='warehouse_delivery' ? 'selected' : '' ?>>Со своего склада</option>
-        </select>
-      </div>
-      <div class="flex items-center space-x-2">
-        <input type="checkbox" name="is_blocked" value="1" <?= !empty($user['is_blocked']) ? 'checked' : '' ?>>
-        <span>Заблокирован</span>
-      </div>
     <?php if (!empty($user['rub_balance'])): ?>
     <div>
       <div class="mb-1">Баланс, ₽</div>

--- a/src/Views/admin/users/show.php
+++ b/src/Views/admin/users/show.php
@@ -58,32 +58,12 @@ $roleNames = [
       </select>
     </div>
   <?php endif; ?>
-  <div>
-    <label class="block text-sm mb-1">Название компании</label>
-    <input name="company_name" class="border rounded px-2 py-1" value="<?= htmlspecialchars($user['company_name'] ?? '') ?>">
-  </div>
-    <div>
-      <label class="block text-sm mb-1">Адрес самовывоза</label>
-      <input name="pickup_address" class="border rounded px-2 py-1" value="<?= htmlspecialchars($user['pickup_address'] ?? '') ?>">
-    </div>
-    <div>
-      <label class="block text-sm mb-1">Стоимость доставки</label>
-      <input name="delivery_cost" type="number" step="0.01" class="border rounded px-2 py-1" value="<?= htmlspecialchars($user['delivery_cost'] ?? '') ?>">
-    </div>
-    <div>
-      <label class="block text-sm mb-1">Режим работы</label>
-      <select name="work_mode" class="border rounded px-2 py-1">
-        <option value="berrygo_store" <?= ($user['work_mode'] ?? '')==='berrygo_store' ? 'selected' : '' ?>>Товар в BerryGo</option>
-        <option value="own_store" <?= ($user['work_mode'] ?? '')==='own_store' ? 'selected' : '' ?>>Со своего магазина</option>
-        <option value="warehouse_delivery" <?= ($user['work_mode'] ?? '')==='warehouse_delivery' ? 'selected' : '' ?>>Со своего склада</option>
-      </select>
-    </div>
     <div class="flex justify-between">
       <div>Баланс: <?= (int)$user['points_balance'] ?> 🍓</div>
       <?php if ($isManager): ?>
         <div><?= (int)$user['rub_balance'] ?> ₽</div>
       <?php endif; ?>
-  </div>
+    </div>
   <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
 </form>
 


### PR DESCRIPTION
## Summary
- add admin routes to edit and save seller details
- create seller edit view and controller actions
- remove seller fields from user editing forms

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a5fe63ebe8832c8844f9f91c68b1ec