### PR TITLE
Hide empty categories in catalog filter

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -171,8 +171,13 @@ class ClientController
                p.id DESC"
         )->fetchAll(PDO::FETCH_ASSOC);
 
+        // Получаем только те категории, у которых есть активные товары
         $types = $this->pdo->query(
-            "SELECT id, name, alias FROM product_types ORDER BY name"
+            "SELECT DISTINCT t.id, t.name, t.alias
+               FROM product_types t
+               JOIN products p ON p.product_type_id = t.id
+              WHERE p.is_active = 1
+              ORDER BY t.name"
         )->fetchAll(PDO::FETCH_ASSOC);
     
         $debugData = [


### PR DESCRIPTION
## Summary
- Only show categories with active products in the catalog filter

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a60e388d64832ca73be6ecf90c0797