### PR TITLE
Remove box unit from price display

### DIFF
--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -137,10 +137,10 @@ $regularKg  = round($price, 2);
         <!-- Акционная цена -->
         <div class="flex items-baseline space-x-2 mb-3">
           <div class="text-xs sm:text-sm text-gray-400 line-through">
-            <?= number_format($regularBox, 0, '.', ' ') ?> ₽/ящик
+            <?= number_format($regularBox, 0, '.', ' ') ?> ₽
           </div>
           <div class="text-lg sm:text-xl font-bold text-red-600 box-price">
-            <?= number_format($priceBox, 0, '.', ' ') ?> ₽/ящик
+            <?= number_format($priceBox, 0, '.', ' ') ?> ₽
           </div>
         </div>
         <div class="text-xs sm:text-sm text-gray-400 mb-3 kg-price">
@@ -150,7 +150,7 @@ $regularKg  = round($price, 2);
         <!-- Обычная цена -->
         <div class="flex justify-between items-center mb-3">
           <div class="text-xl sm:text-2xl font-bold text-gray-800 box-price">
-            <?= number_format($regularBox, 0, '.', ' ') ?> ₽/ящик
+            <?= number_format($regularBox, 0, '.', ' ') ?> ₽
           </div>
           <div class="text-xs sm:text-sm text-gray-400 kg-price">
             <?= htmlspecialchars($regularKg) ?> ₽/кг

--- a/src/Views/client/cart.php
+++ b/src/Views/client/cart.php
@@ -76,7 +76,7 @@
             <?php endif; ?>
           </div>
           <div class="font-semibold text-gray-800">
-            <?= number_format($unitPriceToUse, 0, '.', ' ') ?> ₽/ящик
+            <?= number_format($unitPriceToUse, 0, '.', ' ') ?> ₽
           </div>
         </div>
 

--- a/src/Views/client/favorites.php
+++ b/src/Views/client/favorites.php
@@ -41,14 +41,14 @@
           <div class="flex justify-between items-baseline mb-3">
             <?php if ($sale > 0): ?>
               <div class="text-sm text-gray-400 line-through">
-                <?= number_format($regularBox, 0, '.', ' ') ?> ₽/ящик
+                <?= number_format($regularBox, 0, '.', ' ') ?> ₽
               </div>
               <div class="text-lg font-bold text-red-600">
-                <?= number_format($boxPrice, 0, '.', ' ') ?> ₽/ящик
+                <?= number_format($boxPrice, 0, '.', ' ') ?> ₽
               </div>
             <?php else: ?>
               <div class="text-lg font-bold">
-                <?= number_format($boxPrice, 0, '.', ' ') ?> ₽/ящик
+                <?= number_format($boxPrice, 0, '.', ' ') ?> ₽
               </div>
             <?php endif; ?>
             <div class="text-sm text-gray-500"><?= htmlspecialchars($kgPrice) ?> ₽/кг</div>

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -59,10 +59,10 @@
           <?php if ($sale > 0): ?>
             <div class="flex items-baseline space-x-2">
               <div class="text-sm text-gray-400 line-through">
-                <?= number_format($regularBox, 0, '.', ' ') ?> ₽/ящик
+                <?= number_format($regularBox, 0, '.', ' ') ?> ₽
               </div>
               <div class="text-xl font-bold text-red-600 box-price">
-                <?= number_format($priceBox, 0, '.', ' ') ?> ₽/ящик
+                <?= number_format($priceBox, 0, '.', ' ') ?> ₽
               </div>
             </div>
             <div class="text-sm text-gray-400 kg-price">
@@ -71,7 +71,7 @@
           <?php else: ?>
             <div class="flex justify-between items-center">
               <div class="text-2xl font-bold text-gray-800 box-price">
-                <?= number_format($regularBox, 0, '.', ' ') ?> ₽/ящик
+                <?= number_format($regularBox, 0, '.', ' ') ?> ₽
               </div>
               <div class="text-sm text-gray-400 kg-price">
                 <?= htmlspecialchars($regularKg) ?> ₽/кг


### PR DESCRIPTION
## Summary
- Drop `/ящик` unit from product price display to support different packaging
- Update cart, favorites and product templates accordingly

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a60ed7dfdc832ca4596e1d8478102a