### PR TITLE
Add seller products section to homepage

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -88,6 +88,32 @@ class ClientController
              LEFT JOIN users u ON u.id = p.seller_id
              WHERE p.is_active = 1
                AND p.delivery_date IS NOT NULL
+               AND p.seller_id IS NULL
+             ORDER BY p.id DESC
+             LIMIT 10"
+        )->fetchAll(PDO::FETCH_ASSOC);
+
+        $sellerProducts = $this->pdo->query(
+            "SELECT p.id,
+                    p.alias,
+                    t.name AS product,
+                    t.alias AS type_alias,
+                    p.variety,
+                    p.description,
+                    p.origin_country,
+                    p.box_size,
+                    p.box_unit,
+                    p.price,
+                    p.sale_price,
+                    p.is_active,
+                    p.image_path,
+                    p.delivery_date,
+                    COALESCE(u.company_name,u.name,'berryGo') AS seller_name
+             FROM products p
+             JOIN product_types t ON t.id = p.product_type_id
+             LEFT JOIN users u ON u.id = p.seller_id
+             WHERE p.is_active = 1
+               AND p.seller_id IS NOT NULL
              ORDER BY p.id DESC
              LIMIT 10"
         )->fetchAll(PDO::FETCH_ASSOC);
@@ -113,6 +139,7 @@ class ClientController
              LEFT JOIN users u ON u.id = p.seller_id
              WHERE p.is_active = 1
                AND p.delivery_date IS NULL
+               AND p.seller_id IS NULL
              ORDER BY p.id DESC
              LIMIT 10"
         )->fetchAll(PDO::FETCH_ASSOC);
@@ -129,6 +156,7 @@ class ClientController
         view('client/home', [
             'saleProducts'     => $sale,
             'regularProducts'  => $regular,
+            'sellerProducts'   => $sellerProducts,
             'preorderProducts' => $preorder,
             'materials'       => $materials,
             'userName'        => $_SESSION['name'] ?? null,

--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -1,6 +1,7 @@
 <?php /**
  * @var array $saleProducts
  * @var array $regularProducts
+ * @var array $sellerProducts
  * @var array $preorderProducts
  * @var string|null $userName
  */ ?>
@@ -140,6 +141,28 @@
               <p class="text-sm font-semibold text-green-800">Клубника в наличии в Красноярске: мгновенная доставка за 24 ч — прямо с фермы к вашему столу! Сорта Клери и Черный принц в фасовках от 1 кг. Купите клубнику онлайн с удобной оплатой и гарантий качества каждой ягодки. 🍓🚀</p>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Seller Products -->
+  <section class="px-4 mb-8">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4">🤝 Товары от селлеров</h2>
+    <div class="embla drag-free has-arrows relative">
+      <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_left</span>
+      </button>
+      <button data-dir="right" class="hidden md:flex items-center justify-center w-8 h-8 absolute right-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
+        <span class="material-icons-round text-gray-600">chevron_right</span>
+      </button>
+      <div class="embla__viewport">
+        <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
+          <?php foreach ($sellerProducts as $p): ?>
+            <div class="embla__slide flex-none w-[66vw] sm:w-1/2 md:w-1/3">
+              <?php include __DIR__ . '/_card.php'; ?>
+            </div>
+          <?php endforeach; ?>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Show seller-specific products on the homepage
- Separate regular and preorder listings from seller items

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a7eea7b548832c9e7ac16cb4de2da6