### PR TITLE
Use square aspect ratio for product images

### DIFF
--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -191,7 +191,7 @@ class ProductsController
             if ($src) {
                 $w           = imagesx($src);
                 $h           = imagesy($src);
-                $targetRatio = 16 / 9;
+                $targetRatio = 1; // square
 
                 if ($w / $h > $targetRatio) {
                     $newH = $h;
@@ -212,11 +212,11 @@ class ProductsController
                     'height' => $newH,
                 ]);
                 if ($crop) {
-                    $resized = imagecreatetruecolor(640, 360);
+                    $resized = imagecreatetruecolor(640, 640);
                     imagecopyresampled(
                         $resized, $crop,
                         0, 0, 0, 0,
-                        640, 360,
+                        640, 640,
                         $newW, $newH
                     );
                     imagewebp($resized, $dst, 80);

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -49,10 +49,10 @@ $regularKg  = round($price, 2);
       <a href="/catalog/<?= urlencode($p['type_alias']) ?>/<?= urlencode($p['alias']) ?>">
         <img src="<?= htmlspecialchars($img) ?>"
              alt="<?= htmlspecialchars($p['product'] ?? '') ?>"
-             class="w-full object-cover h-40 sm:h-48">
+             class="w-full object-cover" style="aspect-ratio:1/1">
       </a>
     <?php else: ?>
-      <div class="w-full h-40 sm:h-48 bg-pink-50 flex flex-col items-center justify-center">
+      <div class="w-full bg-pink-50 flex flex-col items-center justify-center" style="aspect-ratio:1/1">
         <span class="material-icons-round text-4xl text-pink-400 mb-1">image</span>
         <span class="text-pink-700 text-sm">изображение подгружается</span>
       </div>

--- a/src/Views/client/favorites.php
+++ b/src/Views/client/favorites.php
@@ -21,7 +21,7 @@
           <img src="<?= htmlspecialchars($img) ?>"
                alt="<?= htmlspecialchars($p['product']) ?>"
                class="w-full object-cover rounded-lg mb-3"
-               style="aspect-ratio:16/9">
+               style="aspect-ratio:1/1">
 
           <div class="flex justify-between items-center mb-2">
             <div class="font-semibold"><?= htmlspecialchars($p['product']) ?></div>

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -4,7 +4,7 @@
     <div class="md:flex md:space-x-6">
       <div class="md:w-1/2 mb-4 md:mb-0">
         <?php if (!empty($product['image_path'])): ?>
-          <img src="<?= htmlspecialchars($product['image_path']) ?>" alt="<?= htmlspecialchars($product['product']) ?>" class="w-full rounded-2xl shadow-lg" itemprop="image">
+          <img src="<?= htmlspecialchars($product['image_path']) ?>" alt="<?= htmlspecialchars($product['product']) ?>" class="w-full object-cover rounded-2xl shadow-lg" style="aspect-ratio:1/1" itemprop="image">
         <?php endif; ?>
       </div>
       <div class="md:w-1/2 space-y-4">


### PR DESCRIPTION
## Summary
- Display product cards and favorites with square images
- Show square hero image on product detail page
- Crop uploaded product images to 640x640 squares in admin

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a7f74376bc832cab035810e7d48076