### PR TITLE
Refine mobile product cards

### DIFF
--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -38,7 +38,7 @@ $isStaff  = in_array($role, ['admin','manager'], true);
 $basePath = $role === 'manager' ? '/manager' : '/admin';
 $regularKg  = round($price, 2);
 ?>
-<div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 h-full max-w-[350px]"
+<div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 sm:h-full max-w-[350px]"
      data-search="<?= htmlspecialchars($search) ?>"
      data-type="<?= htmlspecialchars($p['type_alias'] ?? '') ?>"
      data-sale="<?= ($p['sale_price'] ?? 0) > 0 ? '1' : '0' ?>"
@@ -104,7 +104,7 @@ $regularKg  = round($price, 2);
     <!-- Название и сорт -->
     <div class="mb-2">
       <?php $boxLabel = htmlspecialchars($boxSize . ' ' . $boxUnit); ?>
-      <h3 class="text-base sm:text-lg font-semibold text-gray-800">
+      <h3 class="text-sm sm:text-lg font-semibold text-gray-800">
         <a href="/catalog/<?= urlencode($p['type_alias']) ?>/<?= urlencode($p['alias']) ?>" class="hover:underline">
           <?= htmlspecialchars($p['product']      ?? '') ?>
           <?php if (!empty($p['variety'])): ?>
@@ -120,11 +120,9 @@ $regularKg  = round($price, 2);
     <!-- Описание (если есть) -->
 
 <?php if (!empty($p['description'])): ?>
-  <p class="text-xs sm:text-sm text-gray-600 mb-1 flex-1">
+  <p class="hidden sm:block text-xs sm:text-sm text-gray-600 mb-1">
     <?= htmlspecialchars($p['description']) ?>
   </p>
-<?php else: ?>
-  <div class="flex-1"></div>
 <?php endif; ?>
 
     <div class="text-[10px] sm:text-xs text-gray-500 mb-2">Продавец: <?= htmlspecialchars($p['seller_name'] ?? 'berryGo') ?></div>
@@ -139,7 +137,7 @@ $regularKg  = round($price, 2);
           <div class="text-xs sm:text-sm text-gray-400 line-through">
             <?= number_format($regularBox, 0, '.', ' ') ?> ₽
           </div>
-          <div class="text-lg sm:text-xl font-bold text-red-600 box-price <?= $isStaff ? 'cursor-pointer' : '' ?>" <?= $isStaff ? 'data-edit-price="' . $p['id'] . '"' : '' ?>>
+          <div class="text-base sm:text-xl font-bold text-red-600 box-price <?= $isStaff ? 'cursor-pointer' : '' ?>" <?= $isStaff ? 'data-edit-price="' . $p['id'] . '"' : '' ?>>
             <?= number_format($priceBox, 0, '.', ' ') ?> ₽
           </div>
         </div>
@@ -149,7 +147,7 @@ $regularKg  = round($price, 2);
       <?php else: ?>
         <!-- Обычная цена -->
         <div class="flex justify-between items-center mb-3">
-          <div class="text-xl sm:text-2xl font-bold text-gray-800 box-price <?= $isStaff ? 'cursor-pointer' : '' ?>" <?= $isStaff ? 'data-edit-price="' . $p['id'] . '"' : '' ?>>
+          <div class="text-lg sm:text-2xl font-bold text-gray-800 box-price <?= $isStaff ? 'cursor-pointer' : '' ?>" <?= $isStaff ? 'data-edit-price="' . $p['id'] . '"' : '' ?>>
             <?= number_format($regularBox, 0, '.', ' ') ?> ₽
           </div>
           <div class="text-xs sm:text-sm text-gray-400 kg-price <?= $isStaff ? 'cursor-pointer' : '' ?>" <?= $isStaff ? 'data-edit-price="' . $p['id'] . '"' : '' ?>>

--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -105,11 +105,11 @@
       <div class="embla__viewport">
         <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
           <?php foreach ($saleProducts as $p): ?>
-            <div class="embla__slide flex-none w-[66vw] sm:w-1/2 md:w-1/3">
+            <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
               <?php include __DIR__ . '/_card.php'; ?>
             </div>
           <?php endforeach; ?>
-          <div class="embla__slide flex-none w-[66vw] sm:w-1/2 md:w-1/3">
+          <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
             <div class="h-full flex items-center justify-center bg-red-50 rounded-2xl shadow-lg p-4 text-center">
               <p class="text-sm font-semibold text-red-800">Акционная клубника в Красноярске: купите спелую фермерскую ягоду со скидкой до 25 %! Лучшие сорта Клери и Черный принц по невероятно выгодным ценам. Успейте заказать сегодня — акция действует до конца недели, пока ягоды не разобрали! 🍓</p>
             </div>
@@ -132,11 +132,11 @@
       <div class="embla__viewport">
         <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
           <?php foreach ($regularProducts as $p): ?>
-            <div class="embla__slide flex-none w-[66vw] sm:w-1/2 md:w-1/3">
+            <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
               <?php include __DIR__ . '/_card.php'; ?>
             </div>
           <?php endforeach; ?>
-          <div class="embla__slide flex-none w-[66vw] sm:w-1/2 md:w-1/3">
+          <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
             <div class="h-full flex items-center justify-center bg-green-50 rounded-2xl shadow-lg p-4 text-center">
               <p class="text-sm font-semibold text-green-800">Клубника в наличии в Красноярске: мгновенная доставка за 24 ч — прямо с фермы к вашему столу! Сорта Клери и Черный принц в фасовках от 1 кг. Купите клубнику онлайн с удобной оплатой и гарантий качества каждой ягодки. 🍓🚀</p>
             </div>
@@ -159,7 +159,7 @@
       <div class="embla__viewport">
         <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
           <?php foreach ($sellerProducts as $p): ?>
-            <div class="embla__slide flex-none w-[66vw] sm:w-1/2 md:w-1/3">
+            <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
               <?php include __DIR__ . '/_card.php'; ?>
             </div>
           <?php endforeach; ?>
@@ -181,11 +181,11 @@
       <div class="embla__viewport">
         <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
           <?php foreach ($preorderProducts as $p): ?>
-            <div class="embla__slide flex-none w-[66vw] sm:w-1/2 md:w-1/3">
+            <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
               <?php include __DIR__ . '/_card.php'; ?>
             </div>
           <?php endforeach; ?>
-          <div class="embla__slide flex-none w-[66vw] sm:w-1/2 md:w-1/3">
+          <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
             <div class="h-full flex items-center justify-center bg-blue-50 rounded-2xl shadow-lg p-4 text-center">
               <p class="text-sm font-semibold text-blue-800">Клубника другие ягоды и фрукты под заказ с доставкой в Красноярске: эксклюзивные сорта и объёмы от 1 кг. Идеально для праздников, корпоративов и подарков! Заранее выберите свой идеальный набор — индивидуальная упаковка, свежесть гарантирована, доставка в удобное время. 🍓✨</p>
             </div>


### PR DESCRIPTION
## Summary
- Slim product cards on phones: smaller fonts, no description, and no forced height
- Reduce mobile carousel slide width from 66vw to 52vw

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a7feaf5ef4832c8f6090c17ab6b682