### PR TITLE
Improve testbot Telegram request error diagnostics

### DIFF
--- a/testbot.php
+++ b/testbot.php
@@ -33,10 +33,40 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['message'])) {
             'timeout' => 5,
         ],
     ];
-    $context = stream_context_create($options);
-    $response = @file_get_contents($url, false, $context);
+    $payload = json_encode($data, JSON_UNESCAPED_UNICODE);
+    $response = false;
+    $transportError = null;
+
+    if (function_exists('curl_init')) {
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json; charset=UTF-8'],
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CONNECTTIMEOUT => 5,
+            CURLOPT_TIMEOUT => 10,
+        ]);
+        $response = curl_exec($ch);
+        if ($response === false) {
+            $transportError = 'cURL: ' . curl_error($ch);
+        }
+        curl_close($ch);
+    }
+
     if ($response === false) {
-        $sendResult = 'Ошибка при отправке запроса.';
+        $options['http']['content'] = $payload;
+        $context = stream_context_create($options);
+        $response = @file_get_contents($url, false, $context);
+        if ($response === false) {
+            $lastError = error_get_last();
+            $streamError = $lastError['message'] ?? 'неизвестная ошибка stream';
+            $transportError = $transportError ? ($transportError . '; stream: ' . $streamError) : ('stream: ' . $streamError);
+        }
+    }
+
+    if ($response === false) {
+        $sendResult = 'Ошибка при отправке запроса. ' . $transportError;
     } else {
         $sendResult = htmlspecialchars($response);
     }


### PR DESCRIPTION
### Motivation
- The test page previously showed only a generic `Ошибка при отправке запроса.` which made diagnosing network/transport problems difficult.
- Relying solely on `file_get_contents` is fragile in environments where streams or wrappers are restricted or where cURL is available and preferable.
- The change aims to provide actionable transport error details and make request behaviour consistent across transports.

### Description
- Added a cURL-first transport for sending Telegram requests with explicit timeouts and `CURLOPT_RETURNTRANSFER` to capture responses.
- Fell back to `file_get_contents` with a `stream_context` when cURL is not available or fails, and reused the same JSON payload for both transports via `JSON_UNESCAPED_UNICODE`.
- Collected transport diagnostics from `curl_error()` and `error_get_last()` and appended them to the previously generic error message so the page surfaces concrete failure causes.
- Kept existing logging of attempts and responses to `telegram_testbot.log` and preserved response HTML-escaping when showing results.

### Testing
- Ran `php -l testbot.php` to verify there are no PHP syntax errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1c768600832cbdb10bfad0c02c06)