### PR TITLE
Add Telegram relay proxy support; update TelegramSender, testbot and service worker

### DIFF
--- a/config/telegram.example.php
+++ b/config/telegram.example.php
@@ -5,4 +5,6 @@ return [
     'admin_chat_id'  => '-1001234567890',
     'admin_topic_id' => 1,
     'secret_token'   => 'optional_webhook_secret',
+    'relay_url'      => 'https://kraswebsite.ru/bots/berrygo/telegram_proxy.php',
+    'relay_secret'   => 'shared_secret_between_hosts',
 ];

--- a/config/telegram.php
+++ b/config/telegram.php
@@ -9,4 +9,6 @@ return [
         ? (int)getenv('TELEGRAM_ADMIN_TOPIC_ID')
         : null,
     'secret_token'   => getenv('TELEGRAM_SECRET_TOKEN') ?: '',
+    'relay_url'      => getenv('TELEGRAM_RELAY_URL') ?: '',
+    'relay_secret'   => getenv('TELEGRAM_RELAY_SECRET') ?: '',
 ];

--- a/kraswebsite.ru/bots/berrygo/telegram_proxy.php
+++ b/kraswebsite.ru/bots/berrygo/telegram_proxy.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=UTF-8');
+
+$input = json_decode((string)file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'description' => 'invalid_json']);
+    exit;
+}
+
+$method = (string)($input['method'] ?? '');
+$params = $input['params'] ?? [];
+$botToken = (string)($input['bot_token'] ?? '');
+$secret = (string)($input['secret'] ?? '');
+
+if ($method === '' || !is_array($params) || $botToken === '') {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'description' => 'missing_required_fields']);
+    exit;
+}
+
+$allowedMethods = ['sendMessage', 'setWebhook', 'deleteWebhook', 'getWebhookInfo'];
+if (!in_array($method, $allowedMethods, true)) {
+    http_response_code(403);
+    echo json_encode(['ok' => false, 'description' => 'method_not_allowed']);
+    exit;
+}
+
+$expectedSecret = getenv('BERRYGO_RELAY_SECRET') ?: '';
+if ($expectedSecret !== '' && !hash_equals($expectedSecret, $secret)) {
+    http_response_code(403);
+    echo json_encode(['ok' => false, 'description' => 'forbidden']);
+    exit;
+}
+
+$telegramUrl = "https://api.telegram.org/bot{$botToken}/{$method}";
+$options = [
+    'http' => [
+        'method' => 'POST',
+        'header' => "Content-Type: application/json; charset=UTF-8\r\n",
+        'content' => json_encode($params, JSON_UNESCAPED_UNICODE),
+        'timeout' => 10,
+    ],
+];
+
+$response = @file_get_contents($telegramUrl, false, stream_context_create($options));
+if ($response === false) {
+    http_response_code(502);
+    $err = error_get_last();
+    echo json_encode(['ok' => false, 'description' => 'telegram_unreachable', 'error' => $err['message'] ?? 'unknown']);
+    exit;
+}
+
+echo $response;

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "berrygo-cache-v2";
+const CACHE_NAME = "berrygo-cache-v3";
 const urlsToCache = [
   ".",
   "manifest.json",
@@ -29,6 +29,13 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
+  const requestUrl = new URL(event.request.url);
+  const isHttpRequest = requestUrl.protocol === "http:" || requestUrl.protocol === "https:";
+
+  if (!isHttpRequest) {
+    return;
+  }
+
   if (event.request.mode === "navigate") {
     event.respondWith(
       fetch(event.request)
@@ -47,6 +54,17 @@ self.addEventListener("fetch", (event) => {
   }
 
   event.respondWith(
-    caches.match(event.request).then((cached) => cached || fetch(event.request))
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(event.request).catch(() => {
+        if (event.request.destination === "document") {
+          return caches.match(".");
+        }
+        return new Response("", { status: 504, statusText: "Gateway Timeout" });
+      });
+    })
   );
 });

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -308,7 +308,11 @@ public function register(): void
             $stmt->execute([$phone]);
             $chat = $stmt->fetch(PDO::FETCH_ASSOC);
             if ($chat && $chat['chat_id']) {
-                $tg = new TelegramSender($this->telegramConfig['bot_token'] ?? '');
+                $tg = new TelegramSender(
+                    $this->telegramConfig['bot_token'] ?? '',
+                    $this->telegramConfig['relay_url'] ?? null,
+                    $this->telegramConfig['relay_secret'] ?? null
+                );
                 $topicId = $this->telegramConfig['admin_topic_id'] ?? null;
                 $ok = $tg->send($chat['chat_id'], "Код подтверждения: {$code}", $topicId);
             }
@@ -388,7 +392,11 @@ public function register(): void
         $_SESSION['reset_phone'] = $phone;
         $_SESSION['reset_code'] = $code;
 
-        $tg = new TelegramSender($this->telegramConfig['bot_token'] ?? '');
+        $tg = new TelegramSender(
+            $this->telegramConfig['bot_token'] ?? '',
+            $this->telegramConfig['relay_url'] ?? null,
+            $this->telegramConfig['relay_secret'] ?? null
+        );
         $ok = $tg->send($chat['chat_id'], "Одноразовый код для сброса PIN: {$code}");
 
         echo json_encode(['success' => $ok]);

--- a/src/Helpers/TelegramSender.php
+++ b/src/Helpers/TelegramSender.php
@@ -4,10 +4,14 @@ namespace App\Helpers;
 class TelegramSender
 {
     private string $botToken;
+    private ?string $proxyUrl;
+    private ?string $proxySecret;
 
-    public function __construct(string $botToken)
+    public function __construct(string $botToken, ?string $proxyUrl = null, ?string $proxySecret = null)
     {
         $this->botToken = $botToken;
+        $this->proxyUrl = $proxyUrl ? rtrim($proxyUrl, '/') : null;
+        $this->proxySecret = $proxySecret;
     }
 
     public function send(int|string $chatId, string $message, ?int $topicId = null): bool
@@ -20,6 +24,17 @@ class TelegramSender
         if ($topicId !== null) {
             $payload['message_thread_id'] = $topicId;
         }
+
+        if ($this->proxyUrl) {
+            $url = $this->proxyUrl;
+            $payload = [
+                'bot_token' => $this->botToken,
+                'method' => 'sendMessage',
+                'params' => $payload,
+                'secret' => $this->proxySecret,
+            ];
+        }
+
         $options = [
             'http' => [
                 'header'  => "Content-Type: application/json; charset=UTF-8\r\n",

--- a/testbot.php
+++ b/testbot.php
@@ -12,12 +12,70 @@ $topicId      = $telegramConfig['admin_topic_id'] ?? null;
 // Файл лога для отладки
 $logFile = __DIR__ . '/telegram_testbot.log';
 
+function telegramApiRequest(string $botToken, string $method, array $data = []): array
+{
+    global $telegramConfig;
+
+    $relayUrl = trim((string)($telegramConfig['relay_url'] ?? ''));
+    $relaySecret = (string)($telegramConfig['relay_secret'] ?? '');
+
+    if ($relayUrl !== '') {
+        $url = $relayUrl;
+        $payload = json_encode([
+            'bot_token' => $botToken,
+            'method' => $method,
+            'params' => $data,
+            'secret' => $relaySecret,
+        ], JSON_UNESCAPED_UNICODE);
+    } else {
+        $url = "https://api.telegram.org/bot{$botToken}/{$method}";
+        $payload = json_encode($data, JSON_UNESCAPED_UNICODE);
+    }
+    $response = false;
+    $transportError = null;
+
+    if (function_exists('curl_init')) {
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json; charset=UTF-8'],
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CONNECTTIMEOUT => 5,
+            CURLOPT_TIMEOUT => 10,
+        ]);
+        $response = curl_exec($ch);
+        if ($response === false) {
+            $transportError = 'cURL: ' . curl_error($ch);
+        }
+        curl_close($ch);
+    }
+
+    if ($response === false) {
+        $context = stream_context_create([
+            'http' => [
+                'header' => "Content-Type: application/json; charset=UTF-8\r\n",
+                'method' => 'POST',
+                'content' => $payload,
+                'timeout' => 5,
+            ],
+        ]);
+        $response = @file_get_contents($url, false, $context);
+        if ($response === false) {
+            $lastError = error_get_last();
+            $streamError = $lastError['message'] ?? 'неизвестная ошибка stream';
+            $transportError = $transportError ? ($transportError . '; stream: ' . $streamError) : ('stream: ' . $streamError);
+        }
+    }
+
+    return ['response' => $response, 'error' => $transportError];
+}
+
 // Обработка отправки формы
 $sendResult = null;
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['message'])) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (($_POST['action'] ?? '') === 'send_message') && !empty($_POST['message'])) {
     $text = trim($_POST['message']);
-    // Отправляем сообщение через API Telegram
-    $url = "https://api.telegram.org/bot{$botToken}/sendMessage";
+    // Отправляем сообщение через API Telegram / relay
     $data = [
         'chat_id' => $chatId,
         'text'    => $text,
@@ -25,18 +83,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['message'])) {
     if ($topicId !== null) {
         $data['message_thread_id'] = (int)$topicId;
     }
-    $options = [
-        'http' => [
-            'header'  => "Content-Type: application/json; charset=UTF-8\r\n",
-            'method'  => 'POST',
-            'content' => json_encode($data),
-            'timeout' => 5,
-        ],
-    ];
-    $context = stream_context_create($options);
-    $response = @file_get_contents($url, false, $context);
+    $request = telegramApiRequest($botToken, 'sendMessage', $data);
+    $response = $request['response'];
+    $transportError = $request['error'];
+
     if ($response === false) {
-        $sendResult = 'Ошибка при отправке запроса.';
+        $sendResult = 'Ошибка при отправке запроса. ' . $transportError;
     } else {
         $sendResult = htmlspecialchars($response);
     }
@@ -44,6 +96,38 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['message'])) {
     $logEntry = date('Y-m-d H:i:s') . " | SendMessage: {$text} | Response: {$sendResult}\n";
     file_put_contents($logFile, $logEntry, FILE_APPEND);
 }
+
+$webhookResult = null;
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (($_POST['action'] ?? '') === 'set_webhook')) {
+    $webhookUrl = trim($_POST['webhook_url'] ?? '');
+    if ($webhookUrl === '') {
+        $webhookResult = 'Укажите webhook URL.';
+    } else {
+        $request = telegramApiRequest($botToken, 'setWebhook', ['url' => $webhookUrl]);
+        if ($request['response'] === false) {
+            $webhookResult = 'Ошибка setWebhook. ' . $request['error'];
+        } else {
+            $webhookResult = htmlspecialchars($request['response']);
+        }
+        $logEntry = date('Y-m-d H:i:s') . " | SetWebhook: {$webhookUrl} | Response: {$webhookResult}\n";
+        file_put_contents($logFile, $logEntry, FILE_APPEND);
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (($_POST['action'] ?? '') === 'delete_webhook')) {
+    $dropPendingUpdates = (($_POST['drop_pending_updates'] ?? '0') === '1');
+    $request = telegramApiRequest($botToken, 'deleteWebhook', ['drop_pending_updates' => $dropPendingUpdates]);
+    if ($request['response'] === false) {
+        $webhookResult = 'Ошибка deleteWebhook. ' . $request['error'];
+    } else {
+        $webhookResult = htmlspecialchars($request['response']);
+    }
+    $logEntry = date('Y-m-d H:i:s') . " | DeleteWebhook: drop_pending_updates=" . ($dropPendingUpdates ? '1' : '0') . " | Response: {$webhookResult}\n";
+    file_put_contents($logFile, $logEntry, FILE_APPEND);
+}
+
+$webhookInfo = telegramApiRequest($botToken, 'getWebhookInfo');
+$webhookInfoText = $webhookInfo['response'] !== false ? $webhookInfo['response'] : ('Ошибка getWebhookInfo. ' . $webhookInfo['error']);
 
 // Считываем последние строки лог-файла
 $debugInfo = '';
@@ -74,6 +158,7 @@ if (file_exists($logFile)) {
         <div class="column left">
             <h2>Отправить сообщение</h2>
             <form method="post">
+                <input type="hidden" name="action" value="send_message">
                 <label for="message">Текст сообщения:</label><br>
                 <textarea id="message" name="message" required><?php echo isset($_POST['message']) ? htmlspecialchars($_POST['message']) : ''; ?></textarea><br>
                 <button type="submit">Отправить</button>
@@ -84,8 +169,34 @@ if (file_exists($logFile)) {
                     <pre><?php echo $sendResult; ?></pre>
                 </div>
             <?php endif; ?>
+
+            <h2 style="margin-top: 30px;">Webhook</h2>
+            <form method="post">
+                <input type="hidden" name="action" value="set_webhook">
+                <label for="webhook_url">Webhook URL:</label><br>
+                <input id="webhook_url" name="webhook_url" type="url" style="width:100%;" placeholder="https://your-domain.tld/webhook.php" required>
+                <button type="submit">Установить webhook</button>
+            </form>
+
+            <form method="post" style="margin-top: 10px;">
+                <input type="hidden" name="action" value="delete_webhook">
+                <label style="display:block; margin-bottom: 8px;">
+                    <input type="checkbox" name="drop_pending_updates" value="1">
+                    Удалить pending updates
+                </label>
+                <button type="submit" style="background:#ffe6e6; border:1px solid #cc0000;">Удалить webhook</button>
+            </form>
+
+            <?php if ($webhookResult !== null): ?>
+                <div style="margin-top: 15px; padding: 10px; background: #fff0e0; border: 1px solid #cc7a00;">
+                    <strong>Webhook result:</strong>
+                    <pre><?php echo $webhookResult; ?></pre>
+                </div>
+            <?php endif; ?>
         </div>
         <div class="column right">
+            <h2>Webhook info</h2>
+            <pre><?php echo htmlspecialchars($webhookInfoText); ?></pre>
             <h2>Отладка формы</h2>
             <pre><?php echo htmlspecialchars($sendResult ?? ''); ?></pre>
         </div>


### PR DESCRIPTION
### Motivation
- Enable sending Telegram API requests via an intermediary relay/proxy for environments where direct access to api.telegram.org is restricted or to centralize token handling. 
- Allow configuration of relay URL/secret via config and environment variables so deployments can opt-in to proxying. 
- Improve PWA service worker caching behavior and offline/fallback handling.

### Description
- Added `relay_url` and `relay_secret` settings to `config/telegram.example.php` and environment-backed `config/telegram.php` to make relay configurable. 
- Implemented a new relay endpoint `kraswebsite.ru/bots/berrygo/telegram_proxy.php` that validates an optional shared secret, restricts allowed methods (`sendMessage`, `setWebhook`, `deleteWebhook`, `getWebhookInfo`) and forwards requests to Telegram API, returning Telegram responses and error conditions. 
- Extended `App\Helpers\TelegramSender` to accept optional `proxyUrl` and `proxySecret` and to send requests to the configured relay using a wrapped payload when `proxyUrl` is set. 
- Updated `AuthController` to pass `relay_url` and `relay_secret` into `TelegramSender` when sending registration/reset codes. 
- Reworked `testbot.php` to use a helper `telegramApiRequest()` that supports relay-based requests (preferring `cURL` if available, otherwise falling back to streams), added webhook controls (`setWebhook`, `deleteWebhook`, `getWebhookInfo`) and improved logging and error messages. 
- Bumped service worker cache name to `berrygo-cache-v3`, added non-HTTP request guard, improved fetch handler to provide a document fallback and return a `504` for failed non-document requests.

### Testing
- Ran PHP syntax checks with `php -l` on modified PHP files and they passed. 
- Performed a syntax check of the service worker with `node --check service-worker.js` which reported no syntax errors. 
- No repository unit test suite was modified; runtime integration (relay request/response) should be validated in staging due to reliance on external Telegram and network behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1c768600832cbdb10bfad0c02c06)