### PR TITLE
Добавить рабочий интерфейс заказов селлера: фильтр и обновление статуса

### DIFF
--- a/routes/seller.php
+++ b/routes/seller.php
@@ -8,6 +8,7 @@ return [
             'GET /seller/dashboard' => ['App\\Controllers\\SellerController', 'dashboard'],
             'GET /seller/profile' => ['App\\Controllers\\UsersController', 'sellerProfile'],
             'GET /seller/orders' => ['App\\Controllers\\SellerController', 'orders'],
+            'POST /seller/orders/status' => ['App\\Controllers\\SellerController', 'updateOrderStatus'],
             'GET /seller/products' => ['App\\Controllers\\ProductsController', 'index'],
             'GET /seller/products/edit' => ['App\\Controllers\\ProductsController', 'edit'],
             'POST /seller/products/save' => ['App\\Controllers\\ProductsController', 'save'],

--- a/src/Controllers/SellerController.php
+++ b/src/Controllers/SellerController.php
@@ -85,10 +85,14 @@ class SellerController
     public function orders(): void
     {
         $sellerId = (int)($_SESSION['user_id'] ?? 0);
+        $statusFilter = trim((string)($_GET['status'] ?? ''));
+        $allowedFilters = ['new', 'processing', 'assigned', 'delivered', 'cancelled'];
+        if (!in_array($statusFilter, $allowedFilters, true)) {
+            $statusFilter = '';
+        }
 
         // Получаем список заказов, в которых присутствуют товары текущего селлера
-        $stmt = $this->pdo->prepare(
-            "SELECT o.id, o.status, o.points_used, o.delivery_date,\n"
+        $sql = "SELECT o.id, o.status, o.points_used, o.delivery_date,\n"
             . "       d.time_from AS slot_from, d.time_to AS slot_to,\n"
             . "       u.name AS client_name, u.phone, a.street AS address,\n"
             . "       SUM(oi.quantity * oi.unit_price) AS seller_subtotal,\n"
@@ -99,11 +103,17 @@ class SellerController
             . "JOIN users u ON u.id = o.user_id\n"
             . "LEFT JOIN addresses a ON a.id = o.address_id\n"
             . "LEFT JOIN delivery_slots d ON d.id = o.slot_id\n"
-            . "WHERE p.seller_id = ?\n"
-            . "GROUP BY o.id, o.status, o.points_used, o.delivery_date, d.time_from, d.time_to, u.name, u.phone, a.street\n"
-            . "ORDER BY o.delivery_date DESC, d.time_from DESC"
-        );
-        $stmt->execute([$sellerId]);
+            . "WHERE p.seller_id = ?";
+        $params = [$sellerId];
+        if ($statusFilter !== '') {
+            $sql .= " AND o.status = ?";
+            $params[] = $statusFilter;
+        }
+        $sql .= "\nGROUP BY o.id, o.status, o.points_used, o.delivery_date, d.time_from, d.time_to, u.name, u.phone, a.street\n"
+            . "ORDER BY o.delivery_date DESC, d.time_from DESC";
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
         $orders = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
 
         // Получаем позиции заказа только для текущего селлера
@@ -150,6 +160,51 @@ class SellerController
         viewAdmin('seller_orders', [
             'pageTitle' => 'Заказы',
             'orders'    => $orders,
+            'statusFilter' => $statusFilter,
         ]);
+    }
+
+    public function updateOrderStatus(): void
+    {
+        $sellerId = (int)($_SESSION['user_id'] ?? 0);
+        $orderId = (int)($_POST['order_id'] ?? 0);
+        $status = trim((string)($_POST['status'] ?? ''));
+        $allowedStatuses = ['processing', 'assigned', 'cancelled'];
+
+        if ($orderId <= 0 || !in_array($status, $allowedStatuses, true)) {
+            header('Location: /seller/orders?error=invalid_status');
+            exit;
+        }
+
+        $ownershipStmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM order_items oi
+             JOIN products p ON p.id = oi.product_id
+             WHERE oi.order_id = ? AND p.seller_id = ?"
+        );
+        $ownershipStmt->execute([$orderId, $sellerId]);
+        if ((int)$ownershipStmt->fetchColumn() === 0) {
+            header('Location: /seller/orders?error=forbidden');
+            exit;
+        }
+
+        $currentStatusStmt = $this->pdo->prepare("SELECT status FROM orders WHERE id = ?");
+        $currentStatusStmt->execute([$orderId]);
+        $currentStatus = (string)($currentStatusStmt->fetchColumn() ?: '');
+        $allowedTransitions = [
+            'new' => ['processing', 'cancelled'],
+            'processing' => ['assigned', 'cancelled'],
+            'assigned' => ['assigned'],
+        ];
+
+        if (!isset($allowedTransitions[$currentStatus]) || !in_array($status, $allowedTransitions[$currentStatus], true)) {
+            header('Location: /seller/orders?error=transition');
+            exit;
+        }
+
+        $updateStmt = $this->pdo->prepare("UPDATE orders SET status = ? WHERE id = ?");
+        $updateStmt->execute([$status, $orderId]);
+
+        header('Location: /seller/orders?updated=1');
+        exit;
     }
 }

--- a/src/Views/admin/seller_orders.php
+++ b/src/Views/admin/seller_orders.php
@@ -1,5 +1,31 @@
 <?php /** @var array $orders */ ?>
 <h1 class="text-xl mb-4">Заказы</h1>
+<?php $currentFilter = $statusFilter ?? ''; ?>
+<?php if (isset($_GET['updated'])): ?>
+  <div class="mb-4 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">Статус заказа обновлен.</div>
+<?php elseif (isset($_GET['error'])): ?>
+  <div class="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">Не удалось обновить статус. Проверьте доступ и последовательность шагов.</div>
+<?php endif; ?>
+
+<form method="get" action="/seller/orders" class="mb-4 flex items-end gap-3 rounded border p-3">
+  <div>
+    <label for="status" class="mb-1 block text-sm text-gray-600">Фильтр по статусу</label>
+    <select name="status" id="status" class="rounded border px-3 py-2 text-sm">
+      <option value="">Все заказы</option>
+      <option value="new" <?= $currentFilter === 'new' ? 'selected' : '' ?>>Новый заказ</option>
+      <option value="processing" <?= $currentFilter === 'processing' ? 'selected' : '' ?>>Принят</option>
+      <option value="assigned" <?= $currentFilter === 'assigned' ? 'selected' : '' ?>>В работе</option>
+      <option value="delivered" <?= $currentFilter === 'delivered' ? 'selected' : '' ?>>Выполнен</option>
+      <option value="cancelled" <?= $currentFilter === 'cancelled' ? 'selected' : '' ?>>Отменён</option>
+    </select>
+  </div>
+  <button type="submit" class="rounded border px-3 py-2 text-sm">Применить</button>
+  <a href="/seller/orders" class="rounded border px-3 py-2 text-sm">Сбросить</a>
+</form>
+
+<?php if (!$orders): ?>
+  <div class="rounded border border-dashed p-6 text-center text-gray-500">По выбранному фильтру заказов не найдено.</div>
+<?php endif; ?>
 <?php foreach ($orders as $o): ?>
   <?php $info = order_status_info($o['status']); ?>
   <div class="mb-6 p-4 border rounded">
@@ -24,9 +50,27 @@
     <div class="text-sm flex justify-between"><span>Комиссия BerryGo (<?= (float)$o['commission_rate'] ?>%)</span><span><?= number_format($o['commission'], 2, '.', ' ') ?> ₽</span></div>
     <div class="text-sm flex justify-between font-semibold"><span>Выплата селлеру</span><span><?= number_format($o['payout'], 2, '.', ' ') ?> ₽</span></div>
     <div class="mt-2 flex flex-wrap gap-2 text-sm">
-      <button class="border rounded px-3 py-1">✅ Подтвердить</button>
-      <button class="border rounded px-3 py-1">🧺 Готово к выдаче</button>
-      <button class="border rounded px-3 py-1">⚠️ Нет в наличии</button>
+      <?php if ($o['status'] === 'new'): ?>
+        <form method="post" action="/seller/orders/status">
+          <input type="hidden" name="order_id" value="<?= (int)$o['id'] ?>">
+          <input type="hidden" name="status" value="processing">
+          <button type="submit" class="border rounded px-3 py-1">✅ Подтвердить</button>
+        </form>
+      <?php endif; ?>
+      <?php if ($o['status'] === 'processing'): ?>
+        <form method="post" action="/seller/orders/status">
+          <input type="hidden" name="order_id" value="<?= (int)$o['id'] ?>">
+          <input type="hidden" name="status" value="assigned">
+          <button type="submit" class="border rounded px-3 py-1">🧺 Готово к выдаче</button>
+        </form>
+      <?php endif; ?>
+      <?php if (in_array($o['status'], ['new', 'processing'], true)): ?>
+        <form method="post" action="/seller/orders/status">
+          <input type="hidden" name="order_id" value="<?= (int)$o['id'] ?>">
+          <input type="hidden" name="status" value="cancelled">
+          <button type="submit" class="border rounded px-3 py-1">⚠️ Нет в наличии</button>
+        </form>
+      <?php endif; ?>
     </div>
   </div>
 <?php endforeach; ?>


### PR DESCRIPTION
### Motivation
- Сделать страницу `/seller/orders` рабочей: дать селлеру возможность фильтровать свои заказы и менять статусы через интерфейс вместо заглушек. 
- Обеспечить серверную валидацию прав владельца позиции и корректных переходов статусов, чтобы предотвратить неавторизованные или некорректные обновления.

### Description
- Добавлен маршрут `POST /seller/orders/status` в `routes/seller.php` для приёма изменений статуса со страницы селлера. 
- В `SellerController::orders()` добавлена серверная фильтрация по статусу (`new`, `processing`, `assigned`, `delivered`, `cancelled`) и фильтр включён в SQL-запрос с параметризованными параметрами. 
- Добавлен новый метод `SellerController::updateOrderStatus()` с проверкой входных данных, проверкой принадлежности заказа селлеру и контролем допустимых переходов статусов (`new -> processing|cancelled`, `processing -> assigned|cancelled`), затем обновлением поля `status` и редиректом с флагом результата. 
- Обновлён шаблон `src/Views/admin/seller_orders.php`: добавлен фильтр по статусу, показываются уведомления об успехе/ошибке, отображается пустое состояние при отсутствии заказов, а старые статические кнопки заменены на реальные POST-формы, вызывающие новый эндпоинт. 

### Testing
- Выполнены синтаксические проверки: `php -l src/Controllers/SellerController.php`, `php -l src/Views/admin/seller_orders.php`, `php -l routes/seller.php`, и все проверки прошли успешно (нет синтаксических ошибок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9139fae0832c9fa118970d4b35c4)