### PR TITLE
Add delete button on admin user show page

### DIFF
--- a/src/Views/admin/users/show.php
+++ b/src/Views/admin/users/show.php
@@ -98,7 +98,20 @@ $redirectPath = $currentPath ? (parse_url($currentPath, PHP_URL_PATH) ?: '') : '
         <div><?= (int)$user['rub_balance'] ?> ₽</div>
       <?php endif; ?>
   </div>
-  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+  <div class="flex items-center justify-between">
+    <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+    <?php if ($role === 'admin'): ?>
+      <button
+        type="submit"
+        formaction="<?= $base ?>/users/delete"
+        formmethod="post"
+        onclick="return confirm('Удалить пользователя? Это действие нельзя отменить.');"
+        class="border border-red-200 text-red-600 px-4 py-2 rounded hover:bg-red-50 transition"
+      >
+        Удалить
+      </button>
+    <?php endif; ?>
+  </div>
 </form>
 <script>
   (function () {


### PR DESCRIPTION
### Motivation
- Позволить администраторам удалять пользователя прямо с страницы `/admin/users/[id]` рядом с формой редактирования.

### Description
- Изменён файл `src/Views/admin/users/show.php` — кнопка «Сохранить» обёрнута в контейнер и добавлена кнопка `Удалить` рядом с ней.
- Кнопка отправляет `POST` на `<?= $base ?>/users/delete` через атрибут `formaction` и использует `formmethod="post"` для отправки формы.
- Кнопка отображается только при `role === 'admin'` и показывает подтверждение удаления через `confirm()`.

### Testing
- Проверка синтаксиса выполнена командой `php -l src/Views/admin/users/show.php` и ошибок не показала.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd502535e4832c977bcbb16a5508aa)