### PR TITLE
Add admin-only user deletion form and adjust user edit layout

### DIFF
--- a/src/Views/admin/users/show.php
+++ b/src/Views/admin/users/show.php
@@ -98,8 +98,30 @@ $redirectPath = $currentPath ? (parse_url($currentPath, PHP_URL_PATH) ?: '') : '
         <div><?= (int)$user['rub_balance'] ?> ₽</div>
       <?php endif; ?>
   </div>
-  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+  <div class="flex items-center justify-between">
+    <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+  </div>
 </form>
+
+<?php if ($role === 'admin'): ?>
+  <form
+    action="<?= $base ?>/users/delete"
+    method="post"
+    onsubmit="return confirm('Удалить пользователя? Это действие нельзя отменить.');"
+    class="mb-4"
+  >
+    <input type="hidden" name="id" value="<?= $user['id'] ?>">
+    <?php if ($redirectPath): ?>
+      <input type="hidden" name="redirect" value="<?= htmlspecialchars($redirectPath) ?>">
+    <?php endif; ?>
+    <button
+      type="submit"
+      class="border border-red-200 text-red-600 px-4 py-2 rounded hover:bg-red-50 transition"
+    >
+      Удалить
+    </button>
+  </form>
+<?php endif; ?>
 <script>
   (function () {
     const phoneInput = document.getElementById('user-phone-input');


### PR DESCRIPTION
### Motivation
- Provide a way for administrators to permanently delete a user from the admin user detail page with a confirmation prompt.
- Improve layout consistency for the user edit form by grouping the save button with the surrounding controls.

### Description
- Added an admin-only deletion form gated by `if ($role === 'admin')` that posts to `<?= $base ?>/users/delete` with a hidden `id` and optional `redirect` field and an onsubmit confirmation dialog. 
- Wrapped the existing save `button` in a `div` with `flex items-center justify-between` to improve spacing and alignment.
- Styled the delete button with a red border and hover state and left the phone input sanitation script unchanged.

### Testing
- Ran PHP lint on the modified view file using `php -l` and it reported no syntax errors. 
- Executed the project's automated test suite (`composer test`/`phpunit`) and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd502535e4832c977bcbb16a5508aa)