### PR TITLE
Unset order assignments before user deletion and add admin delete button in user view

### DIFF
--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -992,6 +992,12 @@ class UsersController
                 ->execute([$id]);
             $this->pdo->prepare("DELETE FROM notifications WHERE user_id = ?")
                 ->execute([$id]);
+
+            // Снимаем назначения пользователя с заказов (например, курьер/менеджер),
+            // чтобы не упереться в внешние ключи при удалении пользователя.
+            $this->pdo->prepare("UPDATE orders SET assigned_to = NULL WHERE assigned_to = ?")
+                ->execute([$id]);
+
             $this->pdo->prepare("DELETE FROM orders WHERE user_id = ?")
                 ->execute([$id]);
 

--- a/src/Views/admin/users/show.php
+++ b/src/Views/admin/users/show.php
@@ -98,8 +98,30 @@ $redirectPath = $currentPath ? (parse_url($currentPath, PHP_URL_PATH) ?: '') : '
         <div><?= (int)$user['rub_balance'] ?> ₽</div>
       <?php endif; ?>
   </div>
-  <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+  <div class="flex items-center justify-between">
+    <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить</button>
+  </div>
 </form>
+
+<?php if ($role === 'admin'): ?>
+  <form
+    action="<?= $base ?>/users/delete"
+    method="post"
+    onsubmit="return confirm('Удалить пользователя? Это действие нельзя отменить.');"
+    class="mb-4"
+  >
+    <input type="hidden" name="id" value="<?= $user['id'] ?>">
+    <?php if ($redirectPath): ?>
+      <input type="hidden" name="redirect" value="<?= htmlspecialchars($redirectPath) ?>">
+    <?php endif; ?>
+    <button
+      type="submit"
+      class="border border-red-200 text-red-600 px-4 py-2 rounded hover:bg-red-50 transition"
+    >
+      Удалить
+    </button>
+  </form>
+<?php endif; ?>
 <script>
   (function () {
     const phoneInput = document.getElementById('user-phone-input');


### PR DESCRIPTION
### Motivation
- Prevent foreign key constraint errors when deleting a user who is referenced as an assignee on `orders`.
- Provide an in-UI option for administrators to delete users with a confirmation and optional redirect.

### Description
- In `UsersController` adjust the user deletion transaction to run `UPDATE orders SET assigned_to = NULL WHERE assigned_to = ?` before removing related orders and other records to avoid FK conflicts.
- Add a delete form to `src/Views/admin/users/show.php` that is shown only for the `admin` role, includes a confirmation prompt, and forwards an optional `redirect` parameter.
- Slightly restructure the user edit view layout to group the Save button and accommodate the new Delete action.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd502535e4832c977bcbb16a5508aa)