### PR TITLE
Add authorization debug info for admin/manager login redirects

### DIFF
--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -8,10 +8,45 @@ class AuthMiddleware
      */
     public function handle(array $allowedRoles, string $redirectTo = '/login'): void
     {
-        if (!$this->isAuthorized($allowedRoles)) {
-            header('Location: ' . $redirectTo);
+        $session = $_SESSION;
+        if (!$this->isAuthorized($allowedRoles, $session)) {
+            $location = $this->buildRedirectUrl($redirectTo, $allowedRoles, $session);
+            header('Location: ' . $location);
             exit;
         }
+    }
+
+    /**
+     * @param array<int, string> $allowedRoles
+     * @param array<string, mixed> $session
+     */
+    private function buildRedirectUrl(string $redirectTo, array $allowedRoles, array $session): string
+    {
+        if ($redirectTo !== '/login') {
+            return $redirectTo;
+        }
+
+        if (!$this->isStaffProtectedRoute($allowedRoles)) {
+            return $redirectTo;
+        }
+
+        $reason = empty($session['user_id']) ? 'empty_session' : 'role_mismatch';
+        $currentRole = (string)($session['role'] ?? 'guest');
+        $roles = implode(',', $allowedRoles);
+        $query = http_build_query([
+            'error' => 'Нет доступа к служебному разделу.',
+            'debug_auth' => sprintf('reason=%s; current_role=%s; allowed=%s', $reason, $currentRole, $roles),
+        ]);
+
+        return $redirectTo . '?' . $query;
+    }
+
+    /**
+     * @param array<int, string> $allowedRoles
+     */
+    private function isStaffProtectedRoute(array $allowedRoles): bool
+    {
+        return in_array('admin', $allowedRoles, true) || in_array('manager', $allowedRoles, true);
     }
 
     /**

--- a/src/Views/client/login.php
+++ b/src/Views/client/login.php
@@ -1,4 +1,5 @@
 <?php /** @var string|null $error */ ?>
+<?php $debugAuth = $_GET['debug_auth'] ?? null; ?>
 
 <main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 flex flex-col items-center justify-center px-4 py-4 fixed inset-0 overflow-auto">
 
@@ -26,6 +27,13 @@
           <p class="text-red-700 font-medium"><?= htmlspecialchars($error) ?></p>
         </div>
       </div>
+    <?php endif; ?>
+
+    <?php if (!empty($debugAuth)): ?>
+      <details class="bg-gray-50 border border-gray-200 p-4 rounded-2xl mb-6">
+        <summary class="text-sm font-semibold text-gray-700 cursor-pointer">Debug авторизации (admin/manager)</summary>
+        <pre class="text-xs text-gray-600 mt-3 whitespace-pre-wrap"><?= htmlspecialchars($debugAuth) ?></pre>
+      </details>
     <?php endif; ?>
 
     <!-- Форма входа -->


### PR DESCRIPTION
### Motivation
- Make it easier to diagnose why staff users (`admin`/`manager`) are redirected from protected pages by surfacing structured authorization debug info on the login page.

### Description
- `AuthMiddleware::handle` now captures `$_SESSION` and uses a new `buildRedirectUrl()` helper to append diagnostic query params when redirecting to `/login` for staff-protected routes.
- Added `buildRedirectUrl()` which attaches `error` and `debug_auth` (containing `reason`, `current_role`, and `allowed` roles) when the route is staff-only, and added `isStaffProtectedRoute()` to detect such routes.
- Updated `src/Views/client/login.php` to read `$_GET['debug_auth']` and display it in a collapsible `<details>` debug block on the login page for quick inspection.

### Testing
- Ran syntax checks with `php -l src/Middleware/AuthMiddleware.php` and `php -l src/Views/client/login.php`, both returned no syntax errors.
- Attempted `php -d detect_unicode=0 vendor/bin/phpunit tests/AuthMiddlewareTest.php` but `vendor/bin/phpunit` is not available in the current environment so automated PHPUnit tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc06cc530832cbc7e594195bf2987)