### PR TITLE
Add debug info for failed user deletion and improve auth redirect diagnostics

### DIFF
--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -1006,10 +1006,20 @@ class UsersController
 
             $this->pdo->commit();
         } catch (\Exception $e) {
-            $this->pdo->rollBack();
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
             $target = $redirectUrl !== '' ? $redirectUrl : $basePath . '/edit?id=' . $id;
             $separator = strpos($target, '?') === false ? '?' : '&';
-            header('Location: ' . $target . $separator . 'error=' . urlencode('Не удалось удалить пользователя'));
+            $debug = sprintf(
+                'delete_user_failed | user_id=%d | type=%s | code=%s | message=%s',
+                $id,
+                get_class($e),
+                (string)$e->getCode(),
+                $e->getMessage()
+            );
+            error_log($debug);
+            header('Location: ' . $target . $separator . 'error=' . urlencode('Не удалось удалить пользователя') . '&debug_delete=' . urlencode($debug));
             exit;
         }
 

--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -8,10 +8,45 @@ class AuthMiddleware
      */
     public function handle(array $allowedRoles, string $redirectTo = '/login'): void
     {
-        if (!$this->isAuthorized($allowedRoles)) {
-            header('Location: ' . $redirectTo);
+        $session = $_SESSION;
+        if (!$this->isAuthorized($allowedRoles, $session)) {
+            $location = $this->buildRedirectUrl($redirectTo, $allowedRoles, $session);
+            header('Location: ' . $location);
             exit;
         }
+    }
+
+    /**
+     * @param array<int, string> $allowedRoles
+     * @param array<string, mixed> $session
+     */
+    private function buildRedirectUrl(string $redirectTo, array $allowedRoles, array $session): string
+    {
+        if ($redirectTo !== '/login') {
+            return $redirectTo;
+        }
+
+        if (!$this->isStaffProtectedRoute($allowedRoles)) {
+            return $redirectTo;
+        }
+
+        $reason = empty($session['user_id']) ? 'empty_session' : 'role_mismatch';
+        $currentRole = (string)($session['role'] ?? 'guest');
+        $roles = implode(',', $allowedRoles);
+        $query = http_build_query([
+            'error' => 'Нет доступа к служебному разделу.',
+            'debug_auth' => sprintf('reason=%s; current_role=%s; allowed=%s', $reason, $currentRole, $roles),
+        ]);
+
+        return $redirectTo . '?' . $query;
+    }
+
+    /**
+     * @param array<int, string> $allowedRoles
+     */
+    private function isStaffProtectedRoute(array $allowedRoles): bool
+    {
+        return in_array('admin', $allowedRoles, true) || in_array('manager', $allowedRoles, true);
     }
 
     /**

--- a/src/Views/admin/users/show.php
+++ b/src/Views/admin/users/show.php
@@ -13,12 +13,38 @@ $roleNames = [
 ];
 $currentPath = $_SERVER['REQUEST_URI'] ?? '';
 $redirectPath = $currentPath ? (parse_url($currentPath, PHP_URL_PATH) ?: '') : '';
+$debugDelete = $_GET['debug_delete'] ?? '';
 ?>
 <?php if (!empty($_GET['error'])): ?>
   <div class="bg-red-50 border-l-4 border-red-400 p-3 mb-4 rounded">
     <p class="text-red-700 text-sm"><?= htmlspecialchars($_GET['error']) ?></p>
   </div>
 <?php endif; ?>
+
+<?php if (!empty($debugDelete)): ?>
+  <div id="delete-debug-console" class="fixed bottom-4 right-4 z-50 w-full max-w-xl bg-[#0f172a] text-slate-100 rounded-xl shadow-2xl border border-slate-700">
+    <div class="flex items-center justify-between px-4 py-2 border-b border-slate-700">
+      <strong class="text-sm">Debugger: удаление пользователя</strong>
+      <button type="button" id="delete-debug-close" class="text-slate-300 hover:text-white">✕</button>
+    </div>
+    <div class="p-4">
+      <p class="text-xs text-slate-400 mb-2">Техническая ошибка:</p>
+      <pre class="text-xs whitespace-pre-wrap break-words bg-slate-900/70 p-3 rounded"><?= htmlspecialchars($debugDelete) ?></pre>
+    </div>
+  </div>
+  <script>
+    (function () {
+      const panel = document.getElementById('delete-debug-console');
+      const closeBtn = document.getElementById('delete-debug-close');
+      if (!panel || !closeBtn) return;
+      closeBtn.addEventListener('click', function () {
+        panel.style.display = 'none';
+      });
+      console.error('Delete user debug:', <?= json_encode($debugDelete, JSON_UNESCAPED_UNICODE) ?>);
+    })();
+  </script>
+<?php endif; ?>
+
 <form action="<?= $base ?>/users/save" method="post" class="bg-white p-4 rounded shadow mb-4 space-y-4">
   <input type="hidden" name="id" value="<?= $user['id'] ?>">
   <?php if ($redirectPath): ?>

--- a/src/Views/client/login.php
+++ b/src/Views/client/login.php
@@ -1,4 +1,5 @@
 <?php /** @var string|null $error */ ?>
+<?php $debugAuth = $_GET['debug_auth'] ?? null; ?>
 
 <main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 flex flex-col items-center justify-center px-4 py-4 fixed inset-0 overflow-auto">
 
@@ -26,6 +27,13 @@
           <p class="text-red-700 font-medium"><?= htmlspecialchars($error) ?></p>
         </div>
       </div>
+    <?php endif; ?>
+
+    <?php if (!empty($debugAuth)): ?>
+      <details class="bg-gray-50 border border-gray-200 p-4 rounded-2xl mb-6">
+        <summary class="text-sm font-semibold text-gray-700 cursor-pointer">Debug авторизации (admin/manager)</summary>
+        <pre class="text-xs text-gray-600 mt-3 whitespace-pre-wrap"><?= htmlspecialchars($debugAuth) ?></pre>
+      </details>
     <?php endif; ?>
 
     <!-- Форма входа -->


### PR DESCRIPTION
### Motivation
- Improve observability when user deletion fails by preserving exception details and avoiding rollback errors when no transaction is active.
- Provide clearer redirect behavior and debugging information for unauthorized access to staff routes.
- Surface debug info in admin and login UIs to help operators investigate authorization and deletion issues.

### Description
- Update user deletion error handling in `UsersController` to only call `rollBack()` when a transaction is active, log a structured debug string via `error_log()`, and append a `debug_delete` query parameter to the error redirect.
- Enhance `AuthMiddleware` to pass session data into authorization checks, build richer redirect URLs when access is denied to staff routes, and include a `debug_auth` query parameter explaining the denial; add helper methods `buildRedirectUrl` and `isStaffProtectedRoute` and adjust `isAuthorized` to accept an optional `$session` parameter.
- Display the `debug_delete` payload in `src/Views/admin/users/show.php` as a dismissible debug console and write it to browser console, and display `debug_auth` in `src/Views/client/login.php` inside a collapsible details block for easier inspection.

### Testing
- Ran the project's automated unit test suite with `vendor/bin/phpunit` and the PHP lint check `php -l` over modified files, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc06cc530832cbc7e594195bf2987)