### PR TITLE
Remove invalid notifications DELETE from UsersController::delete

### DIFF
--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -990,9 +990,6 @@ class UsersController
                 ->execute([$id]);
             $this->pdo->prepare("DELETE FROM addresses WHERE user_id = ?")
                 ->execute([$id]);
-            $this->pdo->prepare("DELETE FROM notifications WHERE user_id = ?")
-                ->execute([$id]);
-
             // Снимаем назначения пользователя с заказов (например, курьер/менеджер),
             // чтобы не упереться в внешние ключи при удалении пользователя.
             $this->pdo->prepare("UPDATE orders SET assigned_to = NULL WHERE assigned_to = ?")


### PR DESCRIPTION
### Motivation
- Fix admin user deletion error `SQLSTATE[42S22]` caused by `DELETE FROM notifications WHERE user_id = ?` targeting a table that doesn't have a `user_id` column.

### Description
- Remove the erroneous `DELETE FROM notifications WHERE user_id = ?` statement from `UsersController::delete()` so the deletion transaction no longer queries the nonexistent column.

### Testing
- Ran `php -l src/Controllers/UsersController.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe99472808832c8f5665cb80d4130c)