### PR TITLE
Add name-based search to admin users filter

### DIFF
--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -517,7 +517,8 @@ class UsersController
         $params     = [];
         $conditions = [];
         if ($search !== '') {
-            $conditions[] = "(u.phone LIKE ? OR EXISTS(SELECT 1 FROM addresses a WHERE a.user_id = u.id AND a.street LIKE ?))";
+            $conditions[] = "(u.name LIKE ? OR u.phone LIKE ? OR EXISTS(SELECT 1 FROM addresses a WHERE a.user_id = u.id AND a.street LIKE ?))";
+            $params[]     = "%$search%";
             $params[]     = "%$search%";
             $params[]     = "%$search%";
         }
@@ -544,7 +545,8 @@ class UsersController
             $conditions = [];
             $params     = [];
             if ($search !== '') {
-                $conditions[] = "(u.phone LIKE ? OR EXISTS(SELECT 1 FROM addresses a WHERE a.user_id = u.id AND a.street LIKE ?))";
+                $conditions[] = "(u.name LIKE ? OR u.phone LIKE ? OR EXISTS(SELECT 1 FROM addresses a WHERE a.user_id = u.id AND a.street LIKE ?))";
+                $params[]     = "%$search%";
                 $params[]     = "%$search%";
                 $params[]     = "%$search%";
             }

--- a/src/Views/admin/users/index.php
+++ b/src/Views/admin/users/index.php
@@ -32,7 +32,7 @@
   </table>
 <?php endif; ?>
 <form method="get" class="mb-4 flex">
-  <input type="text" name="q" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Телефон или адрес" class="border rounded px-3 py-2 mr-2 flex-grow">
+  <input type="text" name="q" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Имя, телефон или адрес" class="border rounded px-3 py-2 mr-2 flex-grow">
   <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Поиск</button>
 </form>
 <a href="<?= $base ?>/users/edit" class="bg-[#C86052] text-white px-4 py-2 rounded mb-4 inline-flex items-center">


### PR DESCRIPTION
### Motivation
- Allow admins to search users by name in the `/admin/users` list in addition to phone and address so users can be found more easily.

### Description
- Updated the SQL filter in `UsersController::index` to include `u.name LIKE ?` and added the matching parameter in both the primary and fallback query branches.
- Updated the search input placeholder in `src/Views/admin/users/index.php` to `Имя, телефон или адрес` to reflect the added capability.

### Testing
- Ran `php -l src/Controllers/UsersController.php` and it reported no syntax errors.
- Ran `php -l src/Views/admin/users/index.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02061bdf2c832cbaea33c79b912d5a)