### PR TITLE
Пересчитать партнерское начисление: 10% только с первой покупки клиента

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -376,7 +376,17 @@ class OrdersController
                             $refRole = $refInfo['role'] ?? '';
                             $mgrId   = (int)($refInfo['referred_by'] ?? 0);
 
-                            $refPercent   = ($refRole === 'partner') ? 0.10 : 0.03;
+                            $isPartnerReferrer = ($refRole === 'partner');
+                            $isFirstClientOrder = false;
+                            if ($isPartnerReferrer) {
+                                $ordersCountStmt = $this->pdo->prepare(
+                                    "SELECT COUNT(*) FROM orders WHERE user_id = ? AND status = 'delivered' AND id <> ?"
+                                );
+                                $ordersCountStmt->execute([$userId, $orderId]);
+                                $isFirstClientOrder = ((int)$ordersCountStmt->fetchColumn() === 0);
+                            }
+
+                            $refPercent   = ($isPartnerReferrer && $isFirstClientOrder) ? 0.10 : 0.03;
                             $refBonus     = (int) floor($sum * $refPercent);
                             $managerBonus = 0;
 

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -40,10 +40,14 @@ class Order extends Model
         return (int) floor($sumAfterPoints * 0.05);
     }
 
-    // Метод для подсчёта реферального бонуса (3% или 10% для партнёра)
-    public static function calculateReferralBonus(int $sumBeforeDiscount, bool $isPartner = false): int
+    // Метод для подсчёта реферального бонуса: для партнёра 10% с первого заказа клиента, затем 3%
+    public static function calculateReferralBonus(int $sumBeforeDiscount, bool $isPartner = false, bool $isFirstClientOrder = false): int
     {
-        $rate = $isPartner ? 0.10 : 0.03;
+        if (!$isPartner) {
+            return (int) floor($sumBeforeDiscount * 0.03);
+        }
+
+        $rate = $isFirstClientOrder ? 0.10 : 0.03;
         return (int) floor($sumBeforeDiscount * $rate);
     }
 }

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -32,6 +32,7 @@ class OrderTest extends TestCase
     public function testCalculateReferralBonus(): void
     {
         $this->assertSame(3, \App\Models\Order::calculateReferralBonus(100));
-        $this->assertSame(10, \App\Models\Order::calculateReferralBonus(100, true));
+        $this->assertSame(10, \App\Models\Order::calculateReferralBonus(100, true, true));
+        $this->assertSame(3, \App\Models\Order::calculateReferralBonus(100, true, false));
     }
 }


### PR DESCRIPTION
### Motivation
- Изменить правило реферальных начислений: партнёр получает 10% только с первой доставленной покупки привлечённого клиента, с последующих покупок — 3%.

### Description
- В `src/Controllers/OrdersController.php` добавлена проверка числа ранее доставленных заказов клиента и выбор ставки: 10% для первого доставленного заказа партнёра, иначе 3%.
- В `src/Models/Order.php` метод `calculateReferralBonus` расширен сигнатурой до `(..., bool $isFirstClientOrder = false)` и реализует логику `10%/3%` для партнёра, для остальных — всегда `3%`.
- Обновлён тест `tests/OrderTest.php` для новой сигнатуры и сценариев: общий случай, партнёр первый заказ и партнёр не первый заказ.

### Testing
- Проверки синтаксиса выполнены: `php -l src/Controllers/OrdersController.php`, `php -l src/Models/Order.php`, `php -l tests/OrderTest.php` — все успешно.
- Юнит-тест `tests/OrderTest` обновлён но `phpunit --filter OrderTest` не был выполнен из-за отсутствия `phpunit` в окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03f167aab4832ca809cb84b2d86feb)