### PR TITLE
Stop direct updates of boxes_remaining in stock operations and adjust tests

### DIFF
--- a/src/Services/StockService.php
+++ b/src/Services/StockService.php
@@ -51,7 +51,6 @@ class StockService
             $this->appendMovement($batchId, $productId, $orderId, null, 'unreserve', 'internal', $boxes);
             $this->updateBatchCounters($batchId, [
                 'boxes_reserved' => $boxes,
-                'boxes_remaining' => $boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
@@ -101,7 +100,6 @@ class StockService
             $this->appendMovement($batchId, $productId, null, $userId, 'writeoff', 'internal', -$boxes, $comment);
             $this->updateBatchCounters($batchId, [
                 'boxes_written_off' => $boxes,
-                'boxes_remaining' => -$boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
@@ -188,9 +186,6 @@ class StockService
             $updates = [$column => $delta];
             if ($movementType === 'reserve') {
                 $updates['boxes_reserved'] = abs($delta);
-            }
-            if (in_array($mode, ['instant', 'discount_stock'], true)) {
-                $updates['boxes_remaining'] = $delta;
             }
 
             $this->updateBatchCounters($batchId, $updates);

--- a/tests/StockServiceTest.php
+++ b/tests/StockServiceTest.php
@@ -63,7 +63,7 @@ class StockServiceTest extends TestCase
         $batch = $this->pdo->query('SELECT boxes_free, boxes_reserved, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(7.0, (float)$batch['boxes_free']);
         $this->assertSame(3.0, (float)$batch['boxes_reserved']);
-        $this->assertSame(27.0, (float)$batch['boxes_remaining']);
+        $this->assertSame(30.0, (float)$batch['boxes_remaining']);
 
         $product = $this->pdo->query('SELECT free_stock_boxes, reserved_stock_boxes, stock_status FROM products WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(7.0, (float)$product['free_stock_boxes']);
@@ -81,9 +81,10 @@ class StockServiceTest extends TestCase
         $this->service->reserve(1, 1, 5, 42, 'instant');
         $this->service->sell(1, 1, 5, 42);
 
-        $batch = $this->pdo->query('SELECT boxes_reserved, boxes_sold FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
+        $batch = $this->pdo->query('SELECT boxes_reserved, boxes_sold, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(0.0, (float)$batch['boxes_reserved']);
         $this->assertSame(5.0, (float)$batch['boxes_sold']);
+        $this->assertSame(25.0, (float)$batch['boxes_remaining']);
     }
 
     public function testWriteOffRejectsInvariantViolationAndRollsBack(): void


### PR DESCRIPTION
### Motivation
- Prevent ad-hoc updates to `boxes_remaining` during individual stock operations and ensure remaining is derived consistently elsewhere.
- Avoid double-mutating remaining counts during `reserve`, `unreserve`, `sell`, and `writeOff` flows to reduce invariant violations.
- Align tests with the revised responsibility for maintaining `boxes_remaining`.

### Description
- Removed direct updates to `boxes_remaining` in `unreserve`, `writeOff`, and `changeStock` in `src/Services/StockService.php` so those methods no longer modify that column.
- Preserved movement creation via `appendMovement` and retained updates to the mode-specific columns and `boxes_reserved` where appropriate.
- Updated `tests/StockServiceTest.php` expectations to reflect the new behavior of `boxes_remaining` and added an extra assertion for `boxes_remaining` in the sell test.

### Testing
- Ran the unit test file `tests/StockServiceTest.php` with `phpunit` and all assertions passed.
- Verified `testReserveUpdatesCountersAndCreatesMovement` and `testSellMovesFromReservedToSold` reflect the new `boxes_remaining` expectations and `testWriteOffRejectsInvariantViolationAndRollsBack` still fails with the expected exception when applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d2e92320832cac530176644f372b)