### PR TITLE
FIFO batch allocation and StockService integration into order processing

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -3,6 +3,7 @@ namespace App\Controllers;
 
 use PDO;
 use App\Helpers\PhoneNormalizer;
+use App\Services\StockService;
 use App\Services\ClientCatalogService;
 
 class ClientController
@@ -553,12 +554,16 @@ public function cart(): void
     if ($hasDiscountStockOrder) {
         $discountPercent = 0.0;
         $couponPoints = 0;
+        $couponCode = '';
+        $referralUsed = false;
+        $referrerId = null;
     }
 
     // 5) Считаем, сколько баллов списать (не более суммы заказа)
     $pointsToUse  = $hasDiscountStockOrder ? 0 : min($pointsBalance, $allTotal);
 
     $this->pdo->beginTransaction();
+    $stockService = new StockService($this->pdo);
 
     // 6) Если списываем баллы — обновляем баланс и фиксируем транзакцию
     if ($pointsToUse > 0) {
@@ -690,22 +695,52 @@ public function cart(): void
 
         // (7.3) Вставляем позиции в order_items
         $stmtItem = $this->pdo->prepare(
-            "INSERT INTO order_items (order_id, product_id, quantity, boxes, unit_price, stock_mode)\n" .
-            "VALUES (?, ?, ?, ?, ?, ?)"
+            "INSERT INTO order_items (order_id, product_id, quantity, boxes, unit_price, stock_mode, purchase_batch_id)\n" .
+            "VALUES (?, ?, ?, ?, ?, ?, ?)"
         );
         foreach ($block as $prodId => $data) {
             $kgQty   = $data['quantity'] * $data['box_size'];
             $kgPrice = $data['box_size'] > 0
                 ? $data['unit_price'] / $data['box_size']
                 : $data['unit_price'];
-            $stmtItem->execute([
-                $orderId,
-                $prodId,
-                $kgQty,
-                $data['quantity'],
-                $kgPrice,
-                $orderMode,
-            ]);
+
+            $allocations = [];
+            if (in_array($orderMode, ['instant', 'discount_stock'], true)) {
+                $allocations = $this->allocateFifoBatches((int)$prodId, (float)$data['quantity'], $orderMode);
+            }
+
+            if ($allocations === []) {
+                $stmtItem->execute([
+                    $orderId,
+                    $prodId,
+                    $kgQty,
+                    $data['quantity'],
+                    $kgPrice,
+                    $orderMode,
+                    null,
+                ]);
+                continue;
+            }
+
+            foreach ($allocations as $allocation) {
+                $allocatedBoxes = (float)$allocation['boxes'];
+                $allocatedKgQty = $allocatedBoxes * (float)$data['box_size'];
+
+                $stmtItem->execute([
+                    $orderId,
+                    $prodId,
+                    $allocatedKgQty,
+                    $allocatedBoxes,
+                    $kgPrice,
+                    $orderMode,
+                    (int)$allocation['batch_id'],
+                ]);
+
+                $stockService->reserve((int)$prodId, (int)$allocation['batch_id'], $allocatedBoxes, $orderId, $orderMode);
+                if (!$isReservedOrder) {
+                    $stockService->sell((int)$prodId, (int)$allocation['batch_id'], $allocatedBoxes, $orderId);
+                }
+            }
         }
 
         // (7.4) Создаём записи выплат для селлеров
@@ -904,6 +939,7 @@ public function cancelReservedOrder(int $orderId): void
     $userId = (int)($_SESSION['user_id'] ?? 0);
 
     $this->pdo->beginTransaction();
+    $stockService = new StockService($this->pdo);
     try {
         $stmt = $this->pdo->prepare("SELECT id, user_id, status, points_used, delivery_date FROM orders WHERE id = ? FOR UPDATE");
         $stmt->execute([$orderId]);
@@ -1235,6 +1271,55 @@ public function cancelReservedOrder(int $orderId): void
      * @param array<string, mixed> $postedOrderModes
      * @return array<string, string>
      */
+
+    /**
+     * @return array<int, array{batch_id:int, boxes:float}>
+     */
+    private function allocateFifoBatches(int $productId, float $requiredBoxes, string $mode): array
+    {
+        if ($requiredBoxes <= 0) {
+            return [];
+        }
+
+        $column = $mode === 'discount_stock' ? 'boxes_discount' : 'boxes_free';
+        $stmt = $this->pdo->prepare(
+            "SELECT id, {$column} AS available_boxes
+" .
+            "FROM purchase_batches
+" .
+            "WHERE product_id = ? AND status IN ('active', 'arrived', 'purchased') AND {$column} > 0
+" .
+            "ORDER BY purchased_at ASC, id ASC"
+        );
+        $stmt->execute([$productId]);
+
+        $allocations = [];
+        $left = $requiredBoxes;
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            if ($left <= 0) {
+                break;
+            }
+
+            $available = (float)($row['available_boxes'] ?? 0);
+            if ($available <= 0) {
+                continue;
+            }
+
+            $take = min($left, $available);
+            $allocations[] = [
+                'batch_id' => (int)$row['id'],
+                'boxes' => $take,
+            ];
+            $left -= $take;
+        }
+
+        if ($left > 0.0001) {
+            throw new \RuntimeException('Недостаточно остатков партии для отгрузки по FIFO.');
+        }
+
+        return $allocations;
+    }
+
     public function normalizeOrderModes(array $itemsByDate, array $postedOrderModes): array
     {
         $allowedModes = ['preorder', 'instant', 'discount_stock'];

--- a/src/Services/StockService.php
+++ b/src/Services/StockService.php
@@ -51,7 +51,6 @@ class StockService
             $this->appendMovement($batchId, $productId, $orderId, null, 'unreserve', 'internal', $boxes);
             $this->updateBatchCounters($batchId, [
                 'boxes_reserved' => $boxes,
-                'boxes_remaining' => $boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
@@ -101,7 +100,6 @@ class StockService
             $this->appendMovement($batchId, $productId, null, $userId, 'writeoff', 'internal', -$boxes, $comment);
             $this->updateBatchCounters($batchId, [
                 'boxes_written_off' => $boxes,
-                'boxes_remaining' => -$boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
@@ -188,9 +186,6 @@ class StockService
             $updates = [$column => $delta];
             if ($movementType === 'reserve') {
                 $updates['boxes_reserved'] = abs($delta);
-            }
-            if (in_array($mode, ['instant', 'discount_stock'], true)) {
-                $updates['boxes_remaining'] = $delta;
             }
 
             $this->updateBatchCounters($batchId, $updates);

--- a/tests/StockServiceTest.php
+++ b/tests/StockServiceTest.php
@@ -63,7 +63,7 @@ class StockServiceTest extends TestCase
         $batch = $this->pdo->query('SELECT boxes_free, boxes_reserved, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(7.0, (float)$batch['boxes_free']);
         $this->assertSame(3.0, (float)$batch['boxes_reserved']);
-        $this->assertSame(27.0, (float)$batch['boxes_remaining']);
+        $this->assertSame(30.0, (float)$batch['boxes_remaining']);
 
         $product = $this->pdo->query('SELECT free_stock_boxes, reserved_stock_boxes, stock_status FROM products WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(7.0, (float)$product['free_stock_boxes']);
@@ -81,9 +81,10 @@ class StockServiceTest extends TestCase
         $this->service->reserve(1, 1, 5, 42, 'instant');
         $this->service->sell(1, 1, 5, 42);
 
-        $batch = $this->pdo->query('SELECT boxes_reserved, boxes_sold FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
+        $batch = $this->pdo->query('SELECT boxes_reserved, boxes_sold, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(0.0, (float)$batch['boxes_reserved']);
         $this->assertSame(5.0, (float)$batch['boxes_sold']);
+        $this->assertSame(25.0, (float)$batch['boxes_remaining']);
     }
 
     public function testWriteOffRejectsInvariantViolationAndRollsBack(): void


### PR DESCRIPTION
### Motivation

- Add deterministic FIFO allocation of purchase batches when creating orders and centralize stock mutations through `StockService` to ensure correct reservations and sales across modes.
- Prevent reward application for `discount_stock` mode and ensure order items reference the purchase batch used for fulfillment.

### Description

- Added `allocateFifoBatches(int $productId, float $requiredBoxes, string $mode)` to `ClientController` to consume purchase batches in FIFO order and throw on insufficient stock.  
- Extended order item insertion to include `purchase_batch_id` and split items into multiple `order_items` rows when allocations span batches.  
- Integrated `StockService` in `ClientController::cart()` and `cancelReservedOrder()` and call `reserve()` and `sell()` for each allocated batch when creating orders.  
- Cleared coupon/referral values when `shouldDisableRewardsForModes()` returns true to prevent applying discounts/points for `discount_stock` orders.  
- Tightened `StockService` stock-change logic by removing direct writes to `boxes_remaining` in mutating methods and ensuring updates flow via the existing counter update helpers and movement records.

### Testing

- Ran `tests/StockServiceTest.php` which was updated to reflect the new `boxes_remaining` behavior and additional selected columns; the test suite completed successfully.  
- Executed the modified stock-related unit tests verifying `reserve`, `sell`, and `writeOff` behaviors and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d2e92320832cac530176644f372b)