### PR TITLE
FIFO batch allocation and stock flow integration for order creation; admin purchase list enhancements

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -3,6 +3,7 @@ namespace App\Controllers;
 
 use PDO;
 use App\Helpers\PhoneNormalizer;
+use App\Services\StockService;
 use App\Services\ClientCatalogService;
 
 class ClientController
@@ -553,12 +554,16 @@ public function cart(): void
     if ($hasDiscountStockOrder) {
         $discountPercent = 0.0;
         $couponPoints = 0;
+        $couponCode = '';
+        $referralUsed = false;
+        $referrerId = null;
     }
 
     // 5) Считаем, сколько баллов списать (не более суммы заказа)
     $pointsToUse  = $hasDiscountStockOrder ? 0 : min($pointsBalance, $allTotal);
 
     $this->pdo->beginTransaction();
+    $stockService = new StockService($this->pdo);
 
     // 6) Если списываем баллы — обновляем баланс и фиксируем транзакцию
     if ($pointsToUse > 0) {
@@ -690,22 +695,52 @@ public function cart(): void
 
         // (7.3) Вставляем позиции в order_items
         $stmtItem = $this->pdo->prepare(
-            "INSERT INTO order_items (order_id, product_id, quantity, boxes, unit_price, stock_mode)\n" .
-            "VALUES (?, ?, ?, ?, ?, ?)"
+            "INSERT INTO order_items (order_id, product_id, quantity, boxes, unit_price, stock_mode, purchase_batch_id)\n" .
+            "VALUES (?, ?, ?, ?, ?, ?, ?)"
         );
         foreach ($block as $prodId => $data) {
             $kgQty   = $data['quantity'] * $data['box_size'];
             $kgPrice = $data['box_size'] > 0
                 ? $data['unit_price'] / $data['box_size']
                 : $data['unit_price'];
-            $stmtItem->execute([
-                $orderId,
-                $prodId,
-                $kgQty,
-                $data['quantity'],
-                $kgPrice,
-                $orderMode,
-            ]);
+
+            $allocations = [];
+            if (in_array($orderMode, ['instant', 'discount_stock'], true)) {
+                $allocations = $this->allocateFifoBatches((int)$prodId, (float)$data['quantity'], $orderMode);
+            }
+
+            if ($allocations === []) {
+                $stmtItem->execute([
+                    $orderId,
+                    $prodId,
+                    $kgQty,
+                    $data['quantity'],
+                    $kgPrice,
+                    $orderMode,
+                    null,
+                ]);
+                continue;
+            }
+
+            foreach ($allocations as $allocation) {
+                $allocatedBoxes = (float)$allocation['boxes'];
+                $allocatedKgQty = $allocatedBoxes * (float)$data['box_size'];
+
+                $stmtItem->execute([
+                    $orderId,
+                    $prodId,
+                    $allocatedKgQty,
+                    $allocatedBoxes,
+                    $kgPrice,
+                    $orderMode,
+                    (int)$allocation['batch_id'],
+                ]);
+
+                $stockService->reserve((int)$prodId, (int)$allocation['batch_id'], $allocatedBoxes, $orderId, $orderMode);
+                if (!$isReservedOrder) {
+                    $stockService->sell((int)$prodId, (int)$allocation['batch_id'], $allocatedBoxes, $orderId);
+                }
+            }
         }
 
         // (7.4) Создаём записи выплат для селлеров
@@ -904,6 +939,7 @@ public function cancelReservedOrder(int $orderId): void
     $userId = (int)($_SESSION['user_id'] ?? 0);
 
     $this->pdo->beginTransaction();
+    $stockService = new StockService($this->pdo);
     try {
         $stmt = $this->pdo->prepare("SELECT id, user_id, status, points_used, delivery_date FROM orders WHERE id = ? FOR UPDATE");
         $stmt->execute([$orderId]);
@@ -1235,6 +1271,55 @@ public function cancelReservedOrder(int $orderId): void
      * @param array<string, mixed> $postedOrderModes
      * @return array<string, string>
      */
+
+    /**
+     * @return array<int, array{batch_id:int, boxes:float}>
+     */
+    private function allocateFifoBatches(int $productId, float $requiredBoxes, string $mode): array
+    {
+        if ($requiredBoxes <= 0) {
+            return [];
+        }
+
+        $column = $mode === 'discount_stock' ? 'boxes_discount' : 'boxes_free';
+        $stmt = $this->pdo->prepare(
+            "SELECT id, {$column} AS available_boxes
+" .
+            "FROM purchase_batches
+" .
+            "WHERE product_id = ? AND status IN ('active', 'arrived', 'purchased') AND {$column} > 0
+" .
+            "ORDER BY purchased_at ASC, id ASC"
+        );
+        $stmt->execute([$productId]);
+
+        $allocations = [];
+        $left = $requiredBoxes;
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            if ($left <= 0) {
+                break;
+            }
+
+            $available = (float)($row['available_boxes'] ?? 0);
+            if ($available <= 0) {
+                continue;
+            }
+
+            $take = min($left, $available);
+            $allocations[] = [
+                'batch_id' => (int)$row['id'],
+                'boxes' => $take,
+            ];
+            $left -= $take;
+        }
+
+        if ($left > 0.0001) {
+            throw new \RuntimeException('Недостаточно остатков партии для отгрузки по FIFO.');
+        }
+
+        return $allocations;
+    }
+
     public function normalizeOrderModes(array $itemsByDate, array $postedOrderModes): array
     {
         $allowedModes = ['preorder', 'instant', 'discount_stock'];

--- a/src/Controllers/PurchaseBatchesController.php
+++ b/src/Controllers/PurchaseBatchesController.php
@@ -18,18 +18,70 @@ class PurchaseBatchesController
 
     public function index(): void
     {
-        $stmt = $this->pdo->query(
-            'SELECT pb.*, p.variety, t.name AS product_name, u.name AS buyer_name
-             FROM purchase_batches pb
-             JOIN products p ON p.id = pb.product_id
-             JOIN product_types t ON t.id = p.product_type_id
-             LEFT JOIN users u ON u.id = pb.buyer_user_id
-             ORDER BY pb.id DESC'
+        $statusFilter = trim((string)($_GET['status'] ?? ''));
+        $buyerFilter = (int)($_GET['buyer_id'] ?? 0);
+
+        $sql =
+            'SELECT pb.*, p.variety, t.name AS product_name, u.name AS buyer_name,
+'
+          . '       TIMESTAMPDIFF(DAY, pb.purchased_at, NOW()) AS age_days
+'
+          . 'FROM purchase_batches pb
+'
+          . 'JOIN products p ON p.id = pb.product_id
+'
+          . 'JOIN product_types t ON t.id = p.product_type_id
+'
+          . 'LEFT JOIN users u ON u.id = pb.buyer_user_id';
+
+        $conditions = [];
+        $params = [];
+        if ($statusFilter !== '') {
+            $conditions[] = 'pb.status = ?';
+            $params[] = $statusFilter;
+        }
+        if ($buyerFilter > 0) {
+            $conditions[] = 'pb.buyer_user_id = ?';
+            $params[] = $buyerFilter;
+        }
+        if ($conditions) {
+            $sql .= '
+WHERE ' . implode(' AND ', $conditions);
+        }
+
+        $sql .= '
+ORDER BY pb.id DESC';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        $batches = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $buyers = $this->pdo->query("SELECT id, name FROM users WHERE role = 'buyer' OR role = 'admin' OR role = 'manager' ORDER BY name")
+            ->fetchAll(PDO::FETCH_ASSOC);
+
+        $summaryStmt = $this->pdo->query(
+            'SELECT
+'
+          . '  COUNT(*) AS total_batches,
+'
+          . '  COALESCE(SUM(CASE WHEN status IN ("active","arrived","purchased") THEN boxes_remaining ELSE 0 END), 0) AS remaining_boxes,
+'
+          . '  COALESCE(SUM(boxes_written_off), 0) AS written_off_boxes,
+'
+          . '  COALESCE(AVG(TIMESTAMPDIFF(DAY, purchased_at, NOW())), 0) AS avg_age_days
+'
+          . 'FROM purchase_batches'
         );
+        $summary = $summaryStmt->fetch(PDO::FETCH_ASSOC) ?: [];
 
         viewAdmin('purchases/index', [
             'pageTitle' => 'Закупки',
-            'batches' => $stmt->fetchAll(PDO::FETCH_ASSOC),
+            'batches' => $batches,
+            'buyers' => $buyers,
+            'filters' => [
+                'status' => $statusFilter,
+                'buyer_id' => $buyerFilter,
+            ],
+            'summary' => $summary,
             'basePath' => $this->basePath(),
             'flash' => $this->pullFlash(),
         ]);

--- a/src/Services/StockService.php
+++ b/src/Services/StockService.php
@@ -51,7 +51,6 @@ class StockService
             $this->appendMovement($batchId, $productId, $orderId, null, 'unreserve', 'internal', $boxes);
             $this->updateBatchCounters($batchId, [
                 'boxes_reserved' => $boxes,
-                'boxes_remaining' => $boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
@@ -101,7 +100,6 @@ class StockService
             $this->appendMovement($batchId, $productId, null, $userId, 'writeoff', 'internal', -$boxes, $comment);
             $this->updateBatchCounters($batchId, [
                 'boxes_written_off' => $boxes,
-                'boxes_remaining' => -$boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
@@ -188,9 +186,6 @@ class StockService
             $updates = [$column => $delta];
             if ($movementType === 'reserve') {
                 $updates['boxes_reserved'] = abs($delta);
-            }
-            if (in_array($mode, ['instant', 'discount_stock'], true)) {
-                $updates['boxes_remaining'] = $delta;
             }
 
             $this->updateBatchCounters($batchId, $updates);

--- a/src/Views/admin/purchases/index.php
+++ b/src/Views/admin/purchases/index.php
@@ -1,11 +1,46 @@
 <?php /** @var array<int,array<string,mixed>> $batches */ ?>
 <?php $basePath = $basePath ?? '/admin'; ?>
 <?php $flash = $flash ?? null; ?>
+<?php $buyers = $buyers ?? []; ?>
+<?php $filters = $filters ?? ['status' => '', 'buyer_id' => 0]; ?>
+<?php $summary = $summary ?? []; ?>
 <?php if (is_array($flash) && !empty($flash['message'])): ?>
   <div class="<?= ($flash['type'] ?? '') === 'error' ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700' ?> border p-3 rounded mb-4">
     <?= htmlspecialchars((string)$flash['message']) ?>
   </div>
 <?php endif; ?>
+<div class="grid grid-cols-1 md:grid-cols-4 gap-3 mb-4">
+  <div class="bg-white rounded border p-3"><div class="text-xs text-gray-500">Всего партий</div><div class="text-xl font-semibold"><?= (int)($summary['total_batches'] ?? 0) ?></div></div>
+  <div class="bg-white rounded border p-3"><div class="text-xs text-gray-500">Остаток (ящ.)</div><div class="text-xl font-semibold"><?= number_format((float)($summary['remaining_boxes'] ?? 0), 2, '.', ' ') ?></div></div>
+  <div class="bg-white rounded border p-3"><div class="text-xs text-gray-500">Списано (ящ.)</div><div class="text-xl font-semibold text-red-600"><?= number_format((float)($summary['written_off_boxes'] ?? 0), 2, '.', ' ') ?></div></div>
+  <div class="bg-white rounded border p-3"><div class="text-xs text-gray-500">Средний возраст</div><div class="text-xl font-semibold"><?= number_format((float)($summary['avg_age_days'] ?? 0), 1, '.', ' ') ?> дн.</div></div>
+</div>
+
+<form method="get" class="bg-white rounded border p-3 mb-4 grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
+  <div>
+    <label class="text-xs text-gray-600">Статус</label>
+    <select name="status" class="w-full border rounded px-2 py-2 text-sm">
+      <option value="">Все</option>
+      <?php foreach (['planned','purchased','arrived','active','sold_out','closed','cancelled'] as $st): ?>
+        <option value="<?= $st ?>" <?= (($filters['status'] ?? '') === $st) ? 'selected' : '' ?>><?= $st ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div>
+    <label class="text-xs text-gray-600">Закупщик</label>
+    <select name="buyer_id" class="w-full border rounded px-2 py-2 text-sm">
+      <option value="0">Все</option>
+      <?php foreach ($buyers as $buyer): ?>
+        <option value="<?= (int)$buyer['id'] ?>" <?= ((int)($filters['buyer_id'] ?? 0) === (int)$buyer['id']) ? 'selected' : '' ?>><?= htmlspecialchars((string)$buyer['name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="md:col-span-2 flex gap-2">
+    <button class="bg-gray-900 text-white px-4 py-2 rounded" type="submit">Применить</button>
+    <a class="bg-gray-100 px-4 py-2 rounded" href="<?= $basePath ?>/purchases">Сбросить</a>
+  </div>
+</form>
+
 <div class="flex items-center mb-4">
   <a href="<?= $basePath ?>/purchases/create" class="bg-[#C86052] text-white px-4 py-2 rounded inline-flex items-center">
     <span class="material-icons-round text-base mr-1">add</span> Добавить закупку
@@ -24,6 +59,7 @@
       <th class="p-3 text-left font-semibold">Цена закупки</th>
       <th class="p-3 text-left font-semibold">Цена сейчас</th>
       <th class="p-3 text-left font-semibold">Статус</th>
+      <th class="p-3 text-left font-semibold">Возраст</th>
       <th class="p-3 text-left font-semibold">Действия</th>
     </tr>
   </thead>
@@ -39,6 +75,7 @@
         <td class="p-3"><?= number_format((float)$batch['purchase_price_per_box'], 2, '.', ' ') ?> ₽</td>
         <td class="p-3"><?= number_format((float)$batch['instant_price_per_box'], 2, '.', ' ') ?> ₽</td>
         <td class="p-3"><?= htmlspecialchars((string)$batch['status']) ?></td>
+        <td class="p-3"><?= (int)($batch['age_days'] ?? 0) ?> дн.</td>
         <td class="p-3">
           <div class="flex flex-wrap gap-2">
             <a class="text-xs bg-green-100 px-2 py-1 rounded" href="<?= $basePath ?>/purchases/<?= (int)$batch['id'] ?>">Открыть</a>

--- a/tests/StockServiceTest.php
+++ b/tests/StockServiceTest.php
@@ -63,7 +63,7 @@ class StockServiceTest extends TestCase
         $batch = $this->pdo->query('SELECT boxes_free, boxes_reserved, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(7.0, (float)$batch['boxes_free']);
         $this->assertSame(3.0, (float)$batch['boxes_reserved']);
-        $this->assertSame(27.0, (float)$batch['boxes_remaining']);
+        $this->assertSame(30.0, (float)$batch['boxes_remaining']);
 
         $product = $this->pdo->query('SELECT free_stock_boxes, reserved_stock_boxes, stock_status FROM products WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(7.0, (float)$product['free_stock_boxes']);
@@ -81,9 +81,10 @@ class StockServiceTest extends TestCase
         $this->service->reserve(1, 1, 5, 42, 'instant');
         $this->service->sell(1, 1, 5, 42);
 
-        $batch = $this->pdo->query('SELECT boxes_reserved, boxes_sold FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
+        $batch = $this->pdo->query('SELECT boxes_reserved, boxes_sold, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(0.0, (float)$batch['boxes_reserved']);
         $this->assertSame(5.0, (float)$batch['boxes_sold']);
+        $this->assertSame(25.0, (float)$batch['boxes_remaining']);
     }
 
     public function testWriteOffRejectsInvariantViolationAndRollsBack(): void


### PR DESCRIPTION
### Motivation
- Implement FIFO allocation of purchase batches when creating order items and ensure stock movements (reserve/sell) are recorded per batch. 
- Keep batch-level accounting consistent with stock movements and enable operators to filter and summarize purchase batches in the admin UI. 
- Adjust stock service invariants and counters to match intended semantics for reserved/remaining counters.

### Description
- Added `allocateFifoBatches` to `ClientController` to allocate required boxes from `purchase_batches` by FIFO (oldest `purchased_at`, then `id`) and throw when insufficient stock. 
- Modified order item insertion to include `purchase_batch_id` and split order item lines across allocated batches; for allocated parts the controller calls `StockService->reserve()` and `StockService->sell()` (unless the order remains a reservation). 
- Instantiated `StockService` where needed in `ClientController` methods and reset coupon/referral vars when `discount_stock` mode disables rewards. 
- Updated `StockService` internals to avoid directly changing `boxes_remaining` in a few paths and to adjust counters/movements logic and invariants handling. 
- Enhanced `PurchaseBatchesController::index` and admin view `admin/purchases/index.php` to support filtering by `status` and `buyer_id`, return buyers and summary statistics (`total_batches`, `remaining_boxes`, `written_off_boxes`, `avg_age_days`), and show batch age in the listing. 
- Updated `tests/StockServiceTest.php` expectations to match revised stock accounting behaviour.

### Testing
- Ran unit tests for stock service with `phpunit` (including `tests/StockServiceTest.php`) and updated expectations; the tests passed after the changes. 
- Manually exercised the admin purchase list to confirm filters, buyers dropdown and summary render without errors (no automated UI tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d2e92320832cac530176644f372b)