### PR TITLE
Add "Закупки" (Purchases) menu item for admin and manager layouts

### DIFF
--- a/src/Views/layouts/admin_main.php
+++ b/src/Views/layouts/admin_main.php
@@ -334,6 +334,7 @@
     $menuItems = [
       ['href' => '/admin/dashboard', 'icon' => 'dashboard', 'label' => 'Dashboard'],
       ['href' => '/admin/orders', 'icon' => 'receipt_long', 'label' => 'Заказы'],
+      ['href' => '/admin/purchases', 'icon' => 'local_shipping', 'label' => 'Закупки'],
       ['href' => '/admin/products', 'icon' => 'inventory_2', 'label' => 'Товары'],
       ['href' => '/admin/product-types', 'icon' => 'category', 'label' => 'Категории'],
       ['href' => '/admin/slots', 'icon' => 'calendar_today', 'label' => 'Слоты'],

--- a/src/Views/layouts/manager_main.php
+++ b/src/Views/layouts/manager_main.php
@@ -283,6 +283,7 @@ $labelRole = $role === 'partner' ? 'Партнёр' : 'Менеджер';
       <div class="font-bold text-lg md:text-xl text-[#C86052]">BerryGo <?= htmlspecialchars($titleRole) ?></div>
       <nav class="hidden md:flex space-x-2 md:space-x-4">
         <a href="<?= $base ?>/orders" class="hover:underline">Заказы</a>
+        <a href="<?= $base ?>/purchases" class="hover:underline">Закупки</a>
         <a href="<?= $base ?>/products" class="hover:underline">Товары</a>
         <a href="<?= $base ?>/users" class="hover:underline">Пользователи</a>
         <a href="<?= $base ?>/profile" class="hover:underline">Профиль</a>
@@ -305,6 +306,10 @@ $labelRole = $role === 'partner' ? 'Партнёр' : 'Менеджер';
       <a href="<?= $base ?>/orders" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2 text-base md:text-lg">receipt_long</span>
         <span class="menu-text text-sm md:text-base">Заказы</span>
+      </a>
+      <a href="<?= $base ?>/purchases" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
+        <span class="material-icons-round mr-2 text-base md:text-lg">local_shipping</span>
+        <span class="menu-text text-sm md:text-base">Закупки</span>
       </a>
       <a href="<?= $base ?>/products" class="flex items-center p-2 mb-2 rounded hover:bg-gray-200">
         <span class="material-icons-round mr-2 text-base md:text-lg">inventory_2</span>


### PR DESCRIPTION
### Motivation
- Provide direct navigation to the purchases interface from both the admin and manager panels so users can access purchase batches pages (`/admin/purchases` and `/manager/purchases`).

### Description
- Added a `Закупки` (`Purchases`) entry with `local_shipping` icon to the admin sidebar (`src/Views/layouts/admin_main.php`) and added a `Закупки` link to the manager top navigation and mobile sidebar (`src/Views/layouts/manager_main.php`).

### Testing
- Verified both modified files pass PHP syntax checks with `php -l src/Views/layouts/admin_main.php` and `php -l src/Views/layouts/manager_main.php`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03fbbc7988832cb613a1e04408d571)