### PR TITLE
Add discount-stock rollover job, FIFO allocation and mode-aware StockService changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: migrate status test supply-smoke supply-digest supply-release-check
+.PHONY: migrate status test supply-smoke supply-digest supply-release-check supply-discount-rollover
 
 migrate:
 	php bin/migrate.php up
@@ -18,3 +18,7 @@ supply-digest:
 
 supply-release-check:
 	php bin/supply_release_check.php
+
+
+supply-discount-rollover:
+	php bin/supply_discount_rollover.php --dry-run --min-age-days=1

--- a/bin/supply_discount_rollover.php
+++ b/bin/supply_discount_rollover.php
@@ -1,0 +1,196 @@
+<?php
+declare(strict_types=1);
+
+$baseDir = dirname(__DIR__);
+$dbConfig = require $baseDir . '/config/database.php';
+
+$dsn = sprintf(
+    'mysql:host=%s;dbname=%s;charset=%s',
+    $dbConfig['host'],
+    $dbConfig['dbname'],
+    $dbConfig['charset']
+);
+
+$minAgeDays = 1;
+$dryRun = false;
+$limit = 50;
+
+for ($i = 1; $i < count($argv); $i++) {
+    $arg = (string)$argv[$i];
+    if ($arg === '--dry-run') {
+        $dryRun = true;
+        continue;
+    }
+    if (str_starts_with($arg, '--min-age-days=')) {
+        $minAgeDays = (int)substr($arg, strlen('--min-age-days='));
+        continue;
+    }
+    if (str_starts_with($arg, '--limit=')) {
+        $limit = (int)substr($arg, strlen('--limit='));
+        continue;
+    }
+}
+
+$minAgeDays = max(1, $minAgeDays);
+$limit = max(1, $limit);
+
+try {
+    $pdo = new PDO($dsn, $dbConfig['user'], $dbConfig['password'], $dbConfig['options']);
+} catch (PDOException $e) {
+    fwrite(STDERR, "Database connection failed: {$e->getMessage()}\n");
+    exit(1);
+}
+
+
+$settingsStmt = $pdo->query(
+    "SELECT setting_key, setting_value FROM settings WHERE setting_key IN ('pricing_discount_stock_rollover_min_age_days', 'pricing_discount_stock_rollover_limit')"
+);
+$settings = [];
+foreach ($settingsStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+    $settings[(string)$row['setting_key']] = (string)$row['setting_value'];
+}
+
+if (isset($settings['pricing_discount_stock_rollover_min_age_days']) && $settings['pricing_discount_stock_rollover_min_age_days'] !== '') {
+    $minAgeDays = max(1, (int)$settings['pricing_discount_stock_rollover_min_age_days']);
+}
+if (isset($settings['pricing_discount_stock_rollover_limit']) && $settings['pricing_discount_stock_rollover_limit'] !== '') {
+    $limit = max(1, (int)$settings['pricing_discount_stock_rollover_limit']);
+}
+
+$lockStmt = $pdo->query("SELECT GET_LOCK('supply_discount_rollover_lock', 1)");
+$lockAcquired = (int)$lockStmt->fetchColumn() === 1;
+if (!$lockAcquired) {
+    fwrite(STDOUT, json_encode([
+        'generated_at' => (new DateTimeImmutable('now'))->format(DATE_ATOM),
+        'dry_run' => $dryRun,
+        'locked' => false,
+        'message' => 'Another rollover process is running; skipped.',
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) . PHP_EOL);
+    exit(0);
+}
+
+$sql = 'SELECT id, product_id, purchased_at, boxes_free, status
+        FROM purchase_batches
+        WHERE status IN ("active", "arrived", "purchased")
+          AND boxes_free > 0
+          AND TIMESTAMPDIFF(DAY, purchased_at, NOW()) >= ?
+        ORDER BY purchased_at ASC, id ASC
+        LIMIT ' . (int)$limit;
+
+$stmt = $pdo->prepare($sql);
+$stmt->execute([$minAgeDays]);
+$batches = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$processed = [];
+
+foreach ($batches as $batch) {
+    $batchId = (int)$batch['id'];
+    $productId = (int)$batch['product_id'];
+    $boxes = (float)$batch['boxes_free'];
+    if ($boxes <= 0) {
+        continue;
+    }
+
+    if ($dryRun) {
+        $processed[] = [
+            'batch_id' => $batchId,
+            'product_id' => $productId,
+            'moved_boxes' => $boxes,
+            'mode' => 'dry-run',
+        ];
+        continue;
+    }
+
+    try {
+        $pdo->beginTransaction();
+
+        $upd = $pdo->prepare(
+            'UPDATE purchase_batches
+             SET boxes_free = boxes_free - :boxes,
+                 boxes_discount = boxes_discount + :boxes
+             WHERE id = :id'
+        );
+        $upd->execute([
+            'boxes' => $boxes,
+            'id' => $batchId,
+        ]);
+
+        $movement = $pdo->prepare(
+            'INSERT INTO stock_movements
+                (purchase_batch_id, product_id, movement_type, stock_mode, boxes_delta, comment)
+             VALUES
+                (:purchase_batch_id, :product_id, :movement_type, :stock_mode, :boxes_delta, :comment)'
+        );
+        $movement->execute([
+            'purchase_batch_id' => $batchId,
+            'product_id' => $productId,
+            'movement_type' => 'move_to_discount',
+            'stock_mode' => 'discount_stock',
+            'boxes_delta' => $boxes,
+            'comment' => 'Auto rollover to discount stock by age policy',
+        ]);
+
+        $sync = $pdo->prepare(
+            'UPDATE products
+             SET free_stock_boxes = (
+                    SELECT COALESCE(SUM(boxes_free), 0) FROM purchase_batches WHERE product_id = :product_id_1 AND status IN ("active", "arrived", "purchased")
+                 ),
+                 reserved_stock_boxes = (
+                    SELECT COALESCE(SUM(boxes_reserved), 0) FROM purchase_batches WHERE product_id = :product_id_2 AND status IN ("active", "arrived", "purchased")
+                 ),
+                 discount_stock_boxes = (
+                    SELECT COALESCE(SUM(boxes_discount), 0) FROM purchase_batches WHERE product_id = :product_id_3 AND status IN ("active", "arrived", "purchased")
+                 ),
+                 stock_status = CASE
+                    WHEN (
+                        SELECT COALESCE(SUM(boxes_free), 0) FROM purchase_batches WHERE product_id = :product_id_4 AND status IN ("active", "arrived", "purchased")
+                    ) > 0 THEN "in_stock"
+                    WHEN (
+                        SELECT COALESCE(SUM(boxes_reserved), 0) FROM purchase_batches WHERE product_id = :product_id_5 AND status IN ("active", "arrived", "purchased")
+                    ) > 0 THEN "preorder"
+                    ELSE "sold_out"
+                 END
+             WHERE id = :product_id_6'
+        );
+        $sync->execute([
+            'product_id_1' => $productId,
+            'product_id_2' => $productId,
+            'product_id_3' => $productId,
+            'product_id_4' => $productId,
+            'product_id_5' => $productId,
+            'product_id_6' => $productId,
+        ]);
+
+        $pdo->commit();
+
+        $processed[] = [
+            'batch_id' => $batchId,
+            'product_id' => $productId,
+            'moved_boxes' => $boxes,
+            'mode' => 'applied',
+        ];
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
+}
+
+$result = [
+    'generated_at' => (new DateTimeImmutable('now'))->format(DATE_ATOM),
+    'dry_run' => $dryRun,
+    'min_age_days' => $minAgeDays,
+    'limit' => $limit,
+    'processed_count' => count($processed),
+    'processed' => $processed,
+    'locked' => true,
+    'settings_applied' => [
+        'pricing_discount_stock_rollover_min_age_days' => $settings['pricing_discount_stock_rollover_min_age_days'] ?? null,
+        'pricing_discount_stock_rollover_limit' => $settings['pricing_discount_stock_rollover_limit'] ?? null,
+    ],
+];
+
+$pdo->query("SELECT RELEASE_LOCK('supply_discount_rollover_lock')");
+
+fwrite(STDOUT, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) . PHP_EOL);

--- a/docs/runbooks/supply-discount-rollover.md
+++ b/docs/runbooks/supply-discount-rollover.md
@@ -1,0 +1,44 @@
+# Supply discount rollover
+
+Скрипт: `bin/supply_discount_rollover.php`
+
+## Назначение
+
+Автоматически переводит свободные остатки старых партий (`boxes_free`) в режим выгодного остатка (`boxes_discount`) по правилу возраста партии.
+
+## Запуск
+
+Dry-run (рекомендуется перед боем):
+
+```bash
+php bin/supply_discount_rollover.php --dry-run --min-age-days=1 --limit=50
+```
+
+Боевой запуск:
+
+```bash
+php bin/supply_discount_rollover.php --min-age-days=1 --limit=50
+```
+
+## Параметры
+
+- `--dry-run` — не изменяет БД, только показывает кандидатов.
+- `--min-age-days=N` — минимальный возраст партии в днях для перевода.
+- `--limit=N` — максимум партий за один запуск.
+
+## Что делает скрипт
+
+1. Выбирает партии со статусами `active/arrived/purchased`, где `boxes_free > 0` и возраст >= `min-age-days`.
+2. Переводит весь `boxes_free` в `boxes_discount`.
+3. Пишет движение в `stock_movements` с типом `move_to_discount`.
+4. Синхронизирует агрегированные остатки в `products`.
+
+
+## Блокировка и настройки
+
+Скрипт использует MySQL lock `supply_discount_rollover_lock` и завершится без ошибок, если уже запущен другой экземпляр.
+
+Если в `settings` заданы ключи, они переопределяют дефолты запуска:
+
+- `pricing_discount_stock_rollover_min_age_days`
+- `pricing_discount_stock_rollover_limit`

--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -3,6 +3,7 @@ namespace App\Controllers;
 
 use PDO;
 use App\Helpers\PhoneNormalizer;
+use App\Services\StockService;
 use App\Services\ClientCatalogService;
 
 class ClientController
@@ -553,12 +554,16 @@ public function cart(): void
     if ($hasDiscountStockOrder) {
         $discountPercent = 0.0;
         $couponPoints = 0;
+        $couponCode = '';
+        $referralUsed = false;
+        $referrerId = null;
     }
 
     // 5) Считаем, сколько баллов списать (не более суммы заказа)
     $pointsToUse  = $hasDiscountStockOrder ? 0 : min($pointsBalance, $allTotal);
 
     $this->pdo->beginTransaction();
+    $stockService = new StockService($this->pdo);
 
     // 6) Если списываем баллы — обновляем баланс и фиксируем транзакцию
     if ($pointsToUse > 0) {
@@ -690,22 +695,52 @@ public function cart(): void
 
         // (7.3) Вставляем позиции в order_items
         $stmtItem = $this->pdo->prepare(
-            "INSERT INTO order_items (order_id, product_id, quantity, boxes, unit_price, stock_mode)\n" .
-            "VALUES (?, ?, ?, ?, ?, ?)"
+            "INSERT INTO order_items (order_id, product_id, quantity, boxes, unit_price, stock_mode, purchase_batch_id)\n" .
+            "VALUES (?, ?, ?, ?, ?, ?, ?)"
         );
         foreach ($block as $prodId => $data) {
             $kgQty   = $data['quantity'] * $data['box_size'];
             $kgPrice = $data['box_size'] > 0
                 ? $data['unit_price'] / $data['box_size']
                 : $data['unit_price'];
-            $stmtItem->execute([
-                $orderId,
-                $prodId,
-                $kgQty,
-                $data['quantity'],
-                $kgPrice,
-                $orderMode,
-            ]);
+
+            $allocations = [];
+            if (in_array($orderMode, ['preorder', 'instant', 'discount_stock'], true)) {
+                $allocations = $this->allocateFifoBatches((int)$prodId, (float)$data['quantity'], $orderMode);
+            }
+
+            if ($allocations === []) {
+                $stmtItem->execute([
+                    $orderId,
+                    $prodId,
+                    $kgQty,
+                    $data['quantity'],
+                    $kgPrice,
+                    $orderMode,
+                    null,
+                ]);
+                continue;
+            }
+
+            foreach ($allocations as $allocation) {
+                $allocatedBoxes = (float)$allocation['boxes'];
+                $allocatedKgQty = $allocatedBoxes * (float)$data['box_size'];
+
+                $stmtItem->execute([
+                    $orderId,
+                    $prodId,
+                    $allocatedKgQty,
+                    $allocatedBoxes,
+                    $kgPrice,
+                    $orderMode,
+                    (int)$allocation['batch_id'],
+                ]);
+
+                $stockService->reserve((int)$prodId, (int)$allocation['batch_id'], $allocatedBoxes, $orderId, $orderMode);
+                if (!$isReservedOrder) {
+                    $stockService->sell((int)$prodId, (int)$allocation['batch_id'], $allocatedBoxes, $orderId);
+                }
+            }
         }
 
         // (7.4) Создаём записи выплат для селлеров
@@ -904,6 +939,7 @@ public function cancelReservedOrder(int $orderId): void
     $userId = (int)($_SESSION['user_id'] ?? 0);
 
     $this->pdo->beginTransaction();
+    $stockService = new StockService($this->pdo);
     try {
         $stmt = $this->pdo->prepare("SELECT id, user_id, status, points_used, delivery_date FROM orders WHERE id = ? FOR UPDATE");
         $stmt->execute([$orderId]);
@@ -914,6 +950,21 @@ public function cancelReservedOrder(int $orderId): void
         $isReservation = (($order['status'] ?? '') === 'reserved');
         if (!$isReservation) {
             throw new \RuntimeException('invalid_status');
+        }
+
+        $itemsStmt = $this->pdo->prepare(
+            "SELECT product_id, purchase_batch_id, boxes, stock_mode FROM order_items WHERE order_id = ? AND purchase_batch_id IS NOT NULL"
+        );
+        $itemsStmt->execute([$orderId]);
+        $items = $itemsStmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($items as $item) {
+            $stockService->unreserve(
+                (int)$item['product_id'],
+                (int)$item['purchase_batch_id'],
+                (float)$item['boxes'],
+                $orderId,
+                (string)($item['stock_mode'] ?? 'instant')
+            );
         }
 
         $pointsUsed = (int)($order['points_used'] ?? 0);
@@ -1235,6 +1286,55 @@ public function cancelReservedOrder(int $orderId): void
      * @param array<string, mixed> $postedOrderModes
      * @return array<string, string>
      */
+
+    /**
+     * @return array<int, array{batch_id:int, boxes:float}>
+     */
+    private function allocateFifoBatches(int $productId, float $requiredBoxes, string $mode): array
+    {
+        if ($requiredBoxes <= 0) {
+            return [];
+        }
+
+        $column = $mode === 'discount_stock' ? 'boxes_discount' : 'boxes_free';
+        $stmt = $this->pdo->prepare(
+            "SELECT id, {$column} AS available_boxes
+" .
+            "FROM purchase_batches
+" .
+            "WHERE product_id = ? AND status IN ('active', 'arrived', 'purchased') AND {$column} > 0
+" .
+            "ORDER BY purchased_at ASC, id ASC"
+        );
+        $stmt->execute([$productId]);
+
+        $allocations = [];
+        $left = $requiredBoxes;
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            if ($left <= 0) {
+                break;
+            }
+
+            $available = (float)($row['available_boxes'] ?? 0);
+            if ($available <= 0) {
+                continue;
+            }
+
+            $take = min($left, $available);
+            $allocations[] = [
+                'batch_id' => (int)$row['id'],
+                'boxes' => $take,
+            ];
+            $left -= $take;
+        }
+
+        if ($left > 0.0001) {
+            throw new \RuntimeException('Недостаточно остатков партии для отгрузки по FIFO.');
+        }
+
+        return $allocations;
+    }
+
     public function normalizeOrderModes(array $itemsByDate, array $postedOrderModes): array
     {
         $allowedModes = ['preorder', 'instant', 'discount_stock'];

--- a/src/Controllers/PurchaseBatchesController.php
+++ b/src/Controllers/PurchaseBatchesController.php
@@ -18,18 +18,70 @@ class PurchaseBatchesController
 
     public function index(): void
     {
-        $stmt = $this->pdo->query(
-            'SELECT pb.*, p.variety, t.name AS product_name, u.name AS buyer_name
-             FROM purchase_batches pb
-             JOIN products p ON p.id = pb.product_id
-             JOIN product_types t ON t.id = p.product_type_id
-             LEFT JOIN users u ON u.id = pb.buyer_user_id
-             ORDER BY pb.id DESC'
+        $statusFilter = trim((string)($_GET['status'] ?? ''));
+        $buyerFilter = (int)($_GET['buyer_id'] ?? 0);
+
+        $sql =
+            'SELECT pb.*, p.variety, t.name AS product_name, u.name AS buyer_name,
+'
+          . '       TIMESTAMPDIFF(DAY, pb.purchased_at, NOW()) AS age_days
+'
+          . 'FROM purchase_batches pb
+'
+          . 'JOIN products p ON p.id = pb.product_id
+'
+          . 'JOIN product_types t ON t.id = p.product_type_id
+'
+          . 'LEFT JOIN users u ON u.id = pb.buyer_user_id';
+
+        $conditions = [];
+        $params = [];
+        if ($statusFilter !== '') {
+            $conditions[] = 'pb.status = ?';
+            $params[] = $statusFilter;
+        }
+        if ($buyerFilter > 0) {
+            $conditions[] = 'pb.buyer_user_id = ?';
+            $params[] = $buyerFilter;
+        }
+        if ($conditions) {
+            $sql .= '
+WHERE ' . implode(' AND ', $conditions);
+        }
+
+        $sql .= '
+ORDER BY pb.id DESC';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        $batches = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $buyers = $this->pdo->query("SELECT id, name FROM users WHERE role = 'buyer' OR role = 'admin' OR role = 'manager' ORDER BY name")
+            ->fetchAll(PDO::FETCH_ASSOC);
+
+        $summaryStmt = $this->pdo->query(
+            'SELECT
+'
+          . '  COUNT(*) AS total_batches,
+'
+          . '  COALESCE(SUM(CASE WHEN status IN ("active","arrived","purchased") THEN boxes_remaining ELSE 0 END), 0) AS remaining_boxes,
+'
+          . '  COALESCE(SUM(boxes_written_off), 0) AS written_off_boxes,
+'
+          . '  COALESCE(AVG(TIMESTAMPDIFF(DAY, purchased_at, NOW())), 0) AS avg_age_days
+'
+          . 'FROM purchase_batches'
         );
+        $summary = $summaryStmt->fetch(PDO::FETCH_ASSOC) ?: [];
 
         viewAdmin('purchases/index', [
             'pageTitle' => 'Закупки',
-            'batches' => $stmt->fetchAll(PDO::FETCH_ASSOC),
+            'batches' => $batches,
+            'buyers' => $buyers,
+            'filters' => [
+                'status' => $statusFilter,
+                'buyer_id' => $buyerFilter,
+            ],
+            'summary' => $summary,
             'basePath' => $this->basePath(),
             'flash' => $this->pullFlash(),
         ]);

--- a/src/Services/StockService.php
+++ b/src/Services/StockService.php
@@ -40,18 +40,23 @@ class StockService
         $this->changeStock($productId, $batchId, $orderId, $mode, -$boxes, 'reserve');
     }
 
-    public function unreserve(int $productId, int $batchId, float $boxes, int $orderId): void
+    public function unreserve(int $productId, int $batchId, float $boxes, int $orderId, string $mode = 'instant'): void
     {
         if ($boxes <= 0) {
             throw new RuntimeException('Unreserve boxes must be greater than zero.');
         }
+        if (!in_array($mode, ['preorder', 'instant', 'discount_stock'], true)) {
+            throw new RuntimeException('Unsupported stock mode for unreserve.');
+        }
+
+        $batchColumn = $this->resolveModeColumn($mode, true);
 
         try {
             $this->pdo->beginTransaction();
-            $this->appendMovement($batchId, $productId, $orderId, null, 'unreserve', 'internal', $boxes);
+            $this->appendMovement($batchId, $productId, $orderId, null, 'unreserve', $mode, $boxes);
             $this->updateBatchCounters($batchId, [
-                'boxes_reserved' => $boxes,
-                'boxes_remaining' => $boxes,
+                'boxes_reserved' => -$boxes,
+                $batchColumn => $boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
@@ -101,7 +106,6 @@ class StockService
             $this->appendMovement($batchId, $productId, null, $userId, 'writeoff', 'internal', -$boxes, $comment);
             $this->updateBatchCounters($batchId, [
                 'boxes_written_off' => $boxes,
-                'boxes_remaining' => -$boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
@@ -189,9 +193,6 @@ class StockService
             if ($movementType === 'reserve') {
                 $updates['boxes_reserved'] = abs($delta);
             }
-            if (in_array($mode, ['instant', 'discount_stock'], true)) {
-                $updates['boxes_remaining'] = $delta;
-            }
 
             $this->updateBatchCounters($batchId, $updates);
             $this->assertBatchInvariants($batchId);
@@ -208,7 +209,7 @@ class StockService
     private function resolveModeColumn(string $mode, bool $forBatch = false): string
     {
         if ($mode === 'preorder') {
-            return $forBatch ? 'boxes_reserved' : 'reserved_stock_boxes';
+            return $forBatch ? 'boxes_free' : 'reserved_stock_boxes';
         }
         if ($mode === 'instant') {
             return $forBatch ? 'boxes_free' : 'free_stock_boxes';

--- a/src/Views/admin/purchases/index.php
+++ b/src/Views/admin/purchases/index.php
@@ -1,11 +1,46 @@
 <?php /** @var array<int,array<string,mixed>> $batches */ ?>
 <?php $basePath = $basePath ?? '/admin'; ?>
 <?php $flash = $flash ?? null; ?>
+<?php $buyers = $buyers ?? []; ?>
+<?php $filters = $filters ?? ['status' => '', 'buyer_id' => 0]; ?>
+<?php $summary = $summary ?? []; ?>
 <?php if (is_array($flash) && !empty($flash['message'])): ?>
   <div class="<?= ($flash['type'] ?? '') === 'error' ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700' ?> border p-3 rounded mb-4">
     <?= htmlspecialchars((string)$flash['message']) ?>
   </div>
 <?php endif; ?>
+<div class="grid grid-cols-1 md:grid-cols-4 gap-3 mb-4">
+  <div class="bg-white rounded border p-3"><div class="text-xs text-gray-500">Всего партий</div><div class="text-xl font-semibold"><?= (int)($summary['total_batches'] ?? 0) ?></div></div>
+  <div class="bg-white rounded border p-3"><div class="text-xs text-gray-500">Остаток (ящ.)</div><div class="text-xl font-semibold"><?= number_format((float)($summary['remaining_boxes'] ?? 0), 2, '.', ' ') ?></div></div>
+  <div class="bg-white rounded border p-3"><div class="text-xs text-gray-500">Списано (ящ.)</div><div class="text-xl font-semibold text-red-600"><?= number_format((float)($summary['written_off_boxes'] ?? 0), 2, '.', ' ') ?></div></div>
+  <div class="bg-white rounded border p-3"><div class="text-xs text-gray-500">Средний возраст</div><div class="text-xl font-semibold"><?= number_format((float)($summary['avg_age_days'] ?? 0), 1, '.', ' ') ?> дн.</div></div>
+</div>
+
+<form method="get" class="bg-white rounded border p-3 mb-4 grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
+  <div>
+    <label class="text-xs text-gray-600">Статус</label>
+    <select name="status" class="w-full border rounded px-2 py-2 text-sm">
+      <option value="">Все</option>
+      <?php foreach (['planned','purchased','arrived','active','sold_out','closed','cancelled'] as $st): ?>
+        <option value="<?= $st ?>" <?= (($filters['status'] ?? '') === $st) ? 'selected' : '' ?>><?= $st ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div>
+    <label class="text-xs text-gray-600">Закупщик</label>
+    <select name="buyer_id" class="w-full border rounded px-2 py-2 text-sm">
+      <option value="0">Все</option>
+      <?php foreach ($buyers as $buyer): ?>
+        <option value="<?= (int)$buyer['id'] ?>" <?= ((int)($filters['buyer_id'] ?? 0) === (int)$buyer['id']) ? 'selected' : '' ?>><?= htmlspecialchars((string)$buyer['name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="md:col-span-2 flex gap-2">
+    <button class="bg-gray-900 text-white px-4 py-2 rounded" type="submit">Применить</button>
+    <a class="bg-gray-100 px-4 py-2 rounded" href="<?= $basePath ?>/purchases">Сбросить</a>
+  </div>
+</form>
+
 <div class="flex items-center mb-4">
   <a href="<?= $basePath ?>/purchases/create" class="bg-[#C86052] text-white px-4 py-2 rounded inline-flex items-center">
     <span class="material-icons-round text-base mr-1">add</span> Добавить закупку
@@ -24,6 +59,7 @@
       <th class="p-3 text-left font-semibold">Цена закупки</th>
       <th class="p-3 text-left font-semibold">Цена сейчас</th>
       <th class="p-3 text-left font-semibold">Статус</th>
+      <th class="p-3 text-left font-semibold">Возраст</th>
       <th class="p-3 text-left font-semibold">Действия</th>
     </tr>
   </thead>
@@ -39,6 +75,7 @@
         <td class="p-3"><?= number_format((float)$batch['purchase_price_per_box'], 2, '.', ' ') ?> ₽</td>
         <td class="p-3"><?= number_format((float)$batch['instant_price_per_box'], 2, '.', ' ') ?> ₽</td>
         <td class="p-3"><?= htmlspecialchars((string)$batch['status']) ?></td>
+        <td class="p-3"><?= (int)($batch['age_days'] ?? 0) ?> дн.</td>
         <td class="p-3">
           <div class="flex flex-wrap gap-2">
             <a class="text-xs bg-green-100 px-2 py-1 rounded" href="<?= $basePath ?>/purchases/<?= (int)$batch['id'] ?>">Открыть</a>

--- a/tests/ClientFifoAllocationTest.php
+++ b/tests/ClientFifoAllocationTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace Tests;
+
+use App\Controllers\ClientController;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class ClientFifoAllocationTest extends TestCase
+{
+    private PDO $pdo;
+    private ClientController $controller;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec('CREATE TABLE purchase_batches (
+            id INTEGER PRIMARY KEY,
+            product_id INTEGER,
+            purchased_at TEXT,
+            status TEXT,
+            boxes_free REAL DEFAULT 0,
+            boxes_discount REAL DEFAULT 0
+        )');
+
+        $this->controller = new ClientController($this->pdo);
+    }
+
+    public function testAllocateFifoBatchesSplitsAcrossOldestBatches(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_batches (id, product_id, purchased_at, status, boxes_free) VALUES
+            (10, 1, '2026-05-01 10:00:00', 'active', 3),
+            (11, 1, '2026-05-02 10:00:00', 'active', 5)");
+
+        $allocations = $this->invokeAllocate(1, 6.0, 'instant');
+
+        $this->assertCount(2, $allocations);
+        $this->assertSame(10, $allocations[0]['batch_id']);
+        $this->assertSame(3.0, $allocations[0]['boxes']);
+        $this->assertSame(11, $allocations[1]['batch_id']);
+        $this->assertSame(3.0, $allocations[1]['boxes']);
+    }
+
+    public function testAllocateFifoBatchesThrowsOnInsufficientStock(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_batches (id, product_id, purchased_at, status, boxes_free) VALUES
+            (10, 1, '2026-05-01 10:00:00', 'active', 1)");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Недостаточно остатков партии для отгрузки по FIFO.');
+
+        $this->invokeAllocate(1, 2.0, 'instant');
+    }
+
+    /** @return array<int, array{batch_id:int, boxes:float}> */
+    private function invokeAllocate(int $productId, float $requiredBoxes, string $mode): array
+    {
+        $method = new \ReflectionMethod(ClientController::class, 'allocateFifoBatches');
+        $method->setAccessible(true);
+
+        /** @var array<int, array{batch_id:int, boxes:float}> $result */
+        $result = $method->invoke($this->controller, $productId, $requiredBoxes, $mode);
+        return $result;
+    }
+}

--- a/tests/StockServiceTest.php
+++ b/tests/StockServiceTest.php
@@ -63,7 +63,7 @@ class StockServiceTest extends TestCase
         $batch = $this->pdo->query('SELECT boxes_free, boxes_reserved, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(7.0, (float)$batch['boxes_free']);
         $this->assertSame(3.0, (float)$batch['boxes_reserved']);
-        $this->assertSame(27.0, (float)$batch['boxes_remaining']);
+        $this->assertSame(30.0, (float)$batch['boxes_remaining']);
 
         $product = $this->pdo->query('SELECT free_stock_boxes, reserved_stock_boxes, stock_status FROM products WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(7.0, (float)$product['free_stock_boxes']);
@@ -81,9 +81,37 @@ class StockServiceTest extends TestCase
         $this->service->reserve(1, 1, 5, 42, 'instant');
         $this->service->sell(1, 1, 5, 42);
 
-        $batch = $this->pdo->query('SELECT boxes_reserved, boxes_sold FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
+        $batch = $this->pdo->query('SELECT boxes_reserved, boxes_sold, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(0.0, (float)$batch['boxes_reserved']);
         $this->assertSame(5.0, (float)$batch['boxes_sold']);
+        $this->assertSame(25.0, (float)$batch['boxes_remaining']);
+    }
+
+
+    public function testPreorderReserveConsumesFreeAndIncreasesReserved(): void
+    {
+        $this->service->reserve(1, 1, 2, 77, 'preorder');
+
+        $batch = $this->pdo->query('SELECT boxes_free, boxes_reserved, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(8.0, (float)$batch['boxes_free']);
+        $this->assertSame(2.0, (float)$batch['boxes_reserved']);
+        $this->assertSame(30.0, (float)$batch['boxes_remaining']);
+
+        $movement = $this->pdo->query('SELECT movement_type, stock_mode, boxes_delta FROM stock_movements ORDER BY id DESC LIMIT 1')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('reserve', $movement['movement_type']);
+        $this->assertSame('preorder', $movement['stock_mode']);
+        $this->assertSame(-2.0, (float)$movement['boxes_delta']);
+    }
+
+    public function testUnreserveRestoresModeStockAndDecreasesReserved(): void
+    {
+        $this->service->reserve(1, 1, 4, 55, 'instant');
+        $this->service->unreserve(1, 1, 4, 55, 'instant');
+
+        $batch = $this->pdo->query('SELECT boxes_free, boxes_reserved, boxes_remaining FROM purchase_batches WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(10.0, (float)$batch['boxes_free']);
+        $this->assertSame(0.0, (float)$batch['boxes_reserved']);
+        $this->assertSame(30.0, (float)$batch['boxes_remaining']);
     }
 
     public function testWriteOffRejectsInvariantViolationAndRollsBack(): void


### PR DESCRIPTION
### Motivation

- Provide an automated tool to move aged free stock to discount stock and expose it via Makefile and runbook. 
- Support FIFO allocation of order items across purchase batches and ensure proper per-batch reservation/sale/unreserve behavior. 
- Add admin filtering/summary for purchase batches and fix mode-aware stock counter logic in the `StockService`.

### Description

- Added a new CLI job `bin/supply_discount_rollover.php` with a Makefile target `supply-discount-rollover` and documentation at `docs/runbooks/supply-discount-rollover.md` to move `boxes_free` -> `boxes_discount` for aged batches, with locking, dry-run, limit and settings overrides. 
- Implemented FIFO allocation in `ClientController::allocateFifoBatches`, changed order item insertion to include `purchase_batch_id`, and allocate/split items across batches while calling `StockService::reserve` and `StockService::sell` for each allocation. 
- Integrated `StockService` into order/booking flows (`cart`, `cancelReservedOrder`) to unreserve previously allocated batches and to use stock-mode aware operations. 
- Extended `PurchaseBatchesController` and its admin view to support status and buyer filters, show `age_days`, list buyers and expose a small summary (`total_batches`, `remaining_boxes`, `written_off_boxes`, `avg_age_days`). 
- Updated `StockService` to be mode-aware: changed `unreserve` signature to accept `mode`, use mode-specific batch columns, adjust `resolveModeColumn` mapping for `preorder`, and ensure movements and batch counter updates use the correct columns and modes. 
- Updated admin view `src/Views/admin/purchases/index.php` to show filters, stats and age, and added/updated other plumbing code to propagate the new behavior.

### Testing

- Added unit tests `tests/ClientFifoAllocationTest.php` to verify FIFO splitting and insufficient-stock error and extended `tests/StockServiceTest.php` to cover reserve/sell/preorder/unreserve behaviors. 
- Ran the test suite with `vendor/bin/phpunit`, and the new and updated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d2e92320832cac530176644f372b)