### PR TITLE
Support stock_mode for cart items, enforce mode consistency, and default UI to instant

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -145,6 +145,10 @@ public function cart(): void
         $userId    = $_SESSION['user_id'];
         $productId = (int)($_POST['product_id'] ?? 0);
         $quantity  = (float)($_POST['quantity'] ?? 1.0);
+        $stockMode = (string)($_POST['stock_mode'] ?? 'instant');
+        if (!in_array($stockMode, ['preorder', 'instant', 'discount_stock'], true)) {
+            $stockMode = 'instant';
+        }
 
         // читаем выбор даты
         $dateOpt = $_POST['delivery_date'][$productId] ?? null;
@@ -154,25 +158,54 @@ public function cart(): void
 
         if ($productId && $quantity > 0) {
             $priceStmt = $this->pdo->prepare(
-                "SELECT price, sale_price, box_size FROM products WHERE id = ?"
+                "SELECT price, sale_price, box_size, preorder_unit_price, instant_unit_price, discount_unit_price, current_purchase_batch_id
+                 FROM products WHERE id = ?"
             );
             $priceStmt->execute([$productId]);
             $row = $priceStmt->fetch(PDO::FETCH_ASSOC);
             $priceBox = 0.0;
+            $purchaseBatchId = null;
             if ($row) {
+                $boxSize = (float)($row['box_size'] ?? 0);
                 $sale    = (float)($row['sale_price'] ?? 0); // per kg
                 $regular = (float)($row['price'] ?? 0);      // per kg
-                $boxSize = (float)($row['box_size'] ?? 0);
-                $kgPrice = $sale > 0 ? $sale : $regular;
+                $fallbackKgPrice = $sale > 0 ? $sale : $regular;
+                $kgPrice = match ($stockMode) {
+                    'preorder' => (float)($row['preorder_unit_price'] ?? 0),
+                    'discount_stock' => (float)($row['discount_unit_price'] ?? 0),
+                    default => (float)($row['instant_unit_price'] ?? 0),
+                };
+                if ($kgPrice <= 0) {
+                    $kgPrice = $fallbackKgPrice;
+                }
                 $priceBox = $kgPrice * $boxSize;
+                if ($stockMode !== 'preorder') {
+                    $purchaseBatchId = isset($row['current_purchase_batch_id']) ? (int)$row['current_purchase_batch_id'] : null;
+                }
+            }
+
+            $modeCheckStmt = $this->pdo->prepare(
+                "SELECT stock_mode FROM cart_items WHERE user_id = ? AND product_id = ? LIMIT 1"
+            );
+            $modeCheckStmt->execute([$userId, $productId]);
+            $existingMode = $modeCheckStmt->fetchColumn();
+            if ($existingMode !== false && (string)$existingMode !== $stockMode) {
+                $_SESSION['cart_error'] = 'Этот товар уже есть в корзине в другом режиме. Оформите текущую корзину или замените режим заказа.';
+                $referer = $_SERVER['HTTP_REFERER'] ?? '/cart';
+                header('Location: ' . $referer);
+                exit;
             }
 
             $this->pdo->prepare(
-                "INSERT INTO cart_items (user_id, product_id, quantity, unit_price)" .
-                " VALUES (?, ?, ?, ?)" .
+                "INSERT INTO cart_items (user_id, product_id, quantity, unit_price, stock_mode, purchase_batch_id, boxes, sale_price_per_box)" .
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)" .
                 " ON DUPLICATE KEY UPDATE quantity = quantity + VALUES(quantity)," .
-                " unit_price = VALUES(unit_price)"
-            )->execute([$userId, $productId, $quantity, $priceBox]);
+                " unit_price = VALUES(unit_price)," .
+                " stock_mode = VALUES(stock_mode)," .
+                " purchase_batch_id = VALUES(purchase_batch_id)," .
+                " boxes = VALUES(boxes)," .
+                " sale_price_per_box = VALUES(sale_price_per_box)"
+            )->execute([$userId, $productId, $quantity, $priceBox, $stockMode, $purchaseBatchId, $quantity, $priceBox]);
         }
 
         $this->refreshCartTotal();
@@ -204,8 +237,8 @@ public function cart(): void
                 default    => $current,
             };
             $this->pdo->prepare(
-                "UPDATE cart_items SET quantity = ? WHERE user_id = ? AND product_id = ?"
-            )->execute([$newQty, $userId, $productId]);
+                "UPDATE cart_items SET quantity = ?, boxes = ? WHERE user_id = ? AND product_id = ?"
+            )->execute([$newQty, $newQty, $userId, $productId]);
         }
 
         $this->refreshCartTotal();

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -178,6 +178,7 @@ $regularKg  = round($price, 2);
       <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller']) && $active): ?>
         <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $p['id'] ?>" data-name="<?= htmlspecialchars($p['product'] . ($p['variety'] ? ' ' . $p['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
           <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
+          <input type="hidden" name="stock_mode" value="instant">
           <div class="flex items-center space-x-2">
             <button type="button"
                     class="w-8 h-8 flex items-center justify-center bg-gray-100 rounded-full"

--- a/src/Views/client/cart.php
+++ b/src/Views/client/cart.php
@@ -4,6 +4,14 @@
 */ ?>
 
 <main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 min-h-screen pb-24">
+  <?php if (!empty($_SESSION['cart_error'])): ?>
+    <div class="px-4 pt-4">
+      <div class="bg-red-50 border border-red-200 text-red-700 rounded-xl px-4 py-3">
+        <?= htmlspecialchars((string)$_SESSION['cart_error']) ?>
+      </div>
+    </div>
+    <?php unset($_SESSION['cart_error']); ?>
+  <?php endif; ?>
 
 
   <?php if (empty($items)): ?>

--- a/src/Views/client/favorites.php
+++ b/src/Views/client/favorites.php
@@ -56,6 +56,7 @@
 
           <form action="/cart/add" method="post" class="mt-auto flex add-to-cart-form" data-id="<?= $p['id'] ?>" data-name="<?= htmlspecialchars($p['product'] . ($p['variety'] ? ' ' . $p['variety'] : '')) ?>" data-price="<?= $boxPrice ?>">
             <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
+            <input type="hidden" name="stock_mode" value="instant">
             <input type="number" name="quantity" value="1" min="1" step="1"
                    class="w-20 border border-gray-300 px-2 py-1 rounded-l text-center">
             <button type="submit"

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -88,6 +88,7 @@
           <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller']) && $active): ?>
             <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $product['id'] ?>" data-name="<?= htmlspecialchars($product['product'] . ($product['variety'] ? ' ' . $product['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
               <input type="hidden" name="product_id" value="<?= $product['id'] ?>">
+              <input type="hidden" name="stock_mode" value="instant">
               <div class="flex items-center space-x-2">
                 <button type="button" class="w-8 h-8 flex items-center justify-center bg-gray-100 rounded-full" onclick="let inp=this.nextElementSibling; if(+inp.value>1) inp.value=+inp.value-1;">
                   <span class="material-icons-round text-gray-600 text-base">remove</span>


### PR DESCRIPTION
### Motivation
- Add explicit support for different stock/pricing modes (preorder, instant, discount_stock) so cart pricing reflects the selected stock source.
- Prevent inconsistent cart state by disallowing the same product to exist in different stock modes for the same user.
- Surface meaningful feedback to the user when they attempt mixed-mode additions.

### Description
- Read and validate a new `stock_mode` POST value in `addToCart`, defaulting to `instant` when missing or invalid.
- Extend product query to fetch per-mode unit price columns and select the appropriate unit price with a fallback to sale/regular price, and capture `current_purchase_batch_id` for non-preorder items.
- Persist `stock_mode`, `purchase_batch_id`, `boxes`, and `sale_price_per_box` in the `cart_items` insert/update, and update `updateCart` to keep `boxes` in sync with `quantity`.
- Block adding a product with a different existing `stock_mode` for the same user by setting `$_SESSION['cart_error']` and redirecting, and display that error in the cart view; add hidden `stock_mode=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04dd76e2d8832caea15137f7a55f89)