### PR TITLE
Add purchase_batches and stock_movements schema, backfill, constraints and runbook (prod_patch_2026_17)

### DIFF
--- a/database/2026_17_prod_patch_part1_schema.sql
+++ b/database/2026_17_prod_patch_part1_schema.sql
@@ -1,0 +1,153 @@
+-- Part 1/3: schema-only changes (DDL)
+SET NAMES utf8mb4;
+SET @old_sql_mode := @@SESSION.sql_mode;
+
+DELIMITER $$
+DROP PROCEDURE IF EXISTS yg_add_column $$
+CREATE PROCEDURE yg_add_column(IN p_table VARCHAR(64), IN p_column VARCHAR(64), IN p_definition TEXT)
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = p_table AND COLUMN_NAME = p_column
+  ) THEN
+    SET @yg_sql = CONCAT('ALTER TABLE `', p_table, '` ADD COLUMN ', p_definition);
+    PREPARE yg_stmt FROM @yg_sql; EXECUTE yg_stmt; DEALLOCATE PREPARE yg_stmt;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS yg_add_index $$
+CREATE PROCEDURE yg_add_index(IN p_table VARCHAR(64), IN p_index VARCHAR(64), IN p_definition TEXT)
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = p_table AND INDEX_NAME = p_index
+  ) THEN
+    SET @yg_sql = CONCAT('ALTER TABLE `', p_table, '` ', p_definition);
+    PREPARE yg_stmt FROM @yg_sql; EXECUTE yg_stmt; DEALLOCATE PREPARE yg_stmt;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS yg_add_fk $$
+CREATE PROCEDURE yg_add_fk(IN p_table VARCHAR(64), IN p_constraint VARCHAR(64), IN p_definition TEXT)
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = p_table
+      AND CONSTRAINT_NAME = p_constraint AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+  ) THEN
+    SET @yg_sql = CONCAT('ALTER TABLE `', p_table, '` ', p_definition);
+    PREPARE yg_stmt FROM @yg_sql; EXECUTE yg_stmt; DEALLOCATE PREPARE yg_stmt;
+  END IF;
+END $$
+DELIMITER ;
+
+CREATE TABLE IF NOT EXISTS `purchase_batches` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `product_id` int UNSIGNED NOT NULL,
+  `buyer_user_id` int UNSIGNED DEFAULT NULL,
+  `purchased_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `arrived_at` datetime DEFAULT NULL,
+  `box_size_snapshot` decimal(10,2) NOT NULL DEFAULT 0,
+  `box_unit_snapshot` enum('кг','л') NOT NULL DEFAULT 'кг',
+  `boxes_total` decimal(10,2) NOT NULL DEFAULT 0,
+  `boxes_reserved` decimal(10,2) NOT NULL DEFAULT 0,
+  `boxes_free` decimal(10,2) NOT NULL DEFAULT 0,
+  `boxes_sold` decimal(10,2) NOT NULL DEFAULT 0,
+  `boxes_discount` decimal(10,2) NOT NULL DEFAULT 0,
+  `boxes_written_off` decimal(10,2) NOT NULL DEFAULT 0,
+  `boxes_remaining` decimal(10,2) NOT NULL DEFAULT 0,
+  `purchase_price_per_box` decimal(10,2) NOT NULL DEFAULT 0,
+  `extra_cost_per_box` decimal(10,2) NOT NULL DEFAULT 0,
+  `cost_price_per_box` decimal(10,2) NOT NULL DEFAULT 0,
+  `preorder_margin_percent` decimal(5,2) NOT NULL DEFAULT 30.00,
+  `instant_margin_percent` decimal(5,2) NOT NULL DEFAULT 50.00,
+  `discount_markup_fixed` decimal(10,2) NOT NULL DEFAULT 100.00,
+  `preorder_price_per_box` decimal(10,2) NOT NULL DEFAULT 0,
+  `instant_price_per_box` decimal(10,2) NOT NULL DEFAULT 0,
+  `discount_price_per_box` decimal(10,2) NOT NULL DEFAULT 0,
+  `preorder_unit_price` decimal(10,2) NOT NULL DEFAULT 0,
+  `instant_unit_price` decimal(10,2) NOT NULL DEFAULT 0,
+  `discount_unit_price` decimal(10,2) NOT NULL DEFAULT 0,
+  `status` enum('planned','purchased','arrived','active','sold_out','closed','cancelled') NOT NULL DEFAULT 'purchased',
+  `comment` text DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_purchase_batches_product` (`product_id`),
+  KEY `idx_purchase_batches_buyer` (`buyer_user_id`),
+  KEY `idx_purchase_batches_status` (`status`),
+  KEY `idx_purchase_batches_purchased_at` (`purchased_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `stock_movements` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `purchase_batch_id` int UNSIGNED NOT NULL,
+  `product_id` int UNSIGNED NOT NULL,
+  `order_id` int UNSIGNED DEFAULT NULL,
+  `user_id` int UNSIGNED DEFAULT NULL,
+  `movement_type` enum('purchase','reserve','unreserve','sale','return_to_stock','move_to_discount','writeoff','correction') NOT NULL,
+  `stock_mode` enum('preorder','instant','discount_stock','internal') NOT NULL DEFAULT 'internal',
+  `boxes_delta` decimal(10,2) NOT NULL,
+  `boxes_balance_after` decimal(10,2) DEFAULT NULL,
+  `comment` text DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_stock_movements_batch` (`purchase_batch_id`),
+  KEY `idx_stock_movements_product` (`product_id`),
+  KEY `idx_stock_movements_order` (`order_id`),
+  KEY `idx_stock_movements_type` (`movement_type`),
+  KEY `fk_stock_movements_user` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `purchase_batch_photos` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `purchase_batch_id` int UNSIGNED NOT NULL,
+  `image_path` varchar(255) NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_purchase_batch_photos_batch` (`purchase_batch_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CALL yg_add_column('products', 'current_purchase_batch_id', '`current_purchase_batch_id` int UNSIGNED DEFAULT NULL');
+CALL yg_add_column('addresses', 'street', '`street` varchar(255) NOT NULL DEFAULT ''''');
+CALL yg_add_column('addresses', 'recipient_name', '`recipient_name` varchar(100) NOT NULL DEFAULT ''''');
+CALL yg_add_column('addresses', 'recipient_phone', '`recipient_phone` varchar(20) NOT NULL DEFAULT ''''');
+CALL yg_add_column('addresses', 'is_primary', '`is_primary` tinyint(1) NOT NULL DEFAULT 0');
+CALL yg_add_column('users', 'address_id', '`address_id` int UNSIGNED DEFAULT NULL');
+CALL yg_add_index('users', 'idx_users_address_id', 'ADD KEY `idx_users_address_id` (`address_id`)');
+
+CALL yg_add_column('cart_items', 'purchase_batch_id', '`purchase_batch_id` int UNSIGNED DEFAULT NULL');
+CALL yg_add_column('cart_items', 'stock_mode', '`stock_mode` enum(''preorder'',''instant'',''discount_stock'') NOT NULL DEFAULT ''instant''');
+CALL yg_add_column('cart_items', 'boxes', '`boxes` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('cart_items', 'sale_price_per_box', '`sale_price_per_box` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_index('cart_items', 'idx_cart_items_purchase_batch', 'ADD KEY `idx_cart_items_purchase_batch` (`purchase_batch_id`)');
+CALL yg_add_index('cart_items', 'idx_cart_items_stock_mode', 'ADD KEY `idx_cart_items_stock_mode` (`stock_mode`)');
+
+CALL yg_add_column('orders', 'order_mode', '`order_mode` enum(''preorder'',''instant'',''discount_stock'') NOT NULL DEFAULT ''instant''');
+CALL yg_add_column('orders', 'purchase_batch_id', '`purchase_batch_id` int UNSIGNED DEFAULT NULL');
+CALL yg_add_column('orders', 'reserved_at', '`reserved_at` datetime DEFAULT NULL');
+CALL yg_add_column('orders', 'fulfilled_from_stock_at', '`fulfilled_from_stock_at` datetime DEFAULT NULL');
+CALL yg_add_column('orders', 'bonuses_allowed', '`bonuses_allowed` tinyint(1) NOT NULL DEFAULT 1');
+CALL yg_add_column('orders', 'coupons_allowed', '`coupons_allowed` tinyint(1) NOT NULL DEFAULT 1');
+
+CALL yg_add_column('order_items', 'purchase_batch_id', '`purchase_batch_id` int UNSIGNED DEFAULT NULL');
+CALL yg_add_column('order_items', 'stock_mode', '`stock_mode` enum(''preorder'',''instant'',''discount_stock'') NOT NULL DEFAULT ''instant''');
+CALL yg_add_column('order_items', 'cost_unit_price', '`cost_unit_price` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('order_items', 'cost_price_per_box', '`cost_price_per_box` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('order_items', 'sale_price_per_box', '`sale_price_per_box` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('order_items', 'margin_amount', '`margin_amount` decimal(10,2) NOT NULL DEFAULT 0');
+
+CALL yg_add_column('products', 'free_stock_boxes', '`free_stock_boxes` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'reserved_stock_boxes', '`reserved_stock_boxes` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'discount_stock_boxes', '`discount_stock_boxes` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'sold_stock_boxes', '`sold_stock_boxes` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'written_off_stock_boxes', '`written_off_stock_boxes` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'preorder_price_per_box', '`preorder_price_per_box` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'instant_price_per_box', '`instant_price_per_box` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'discount_price_per_box', '`discount_price_per_box` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'preorder_unit_price', '`preorder_unit_price` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'instant_unit_price', '`instant_unit_price` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'discount_unit_price', '`discount_unit_price` decimal(10,2) NOT NULL DEFAULT 0');
+CALL yg_add_column('products', 'stock_status', '`stock_status` enum(''in_stock'',''preorder'',''arriving_today'',''sold_out'',''hidden'') NOT NULL DEFAULT ''sold_out''');
+
+SET SESSION sql_mode = @old_sql_mode;

--- a/database/2026_17_prod_patch_part2_backfill.sql
+++ b/database/2026_17_prod_patch_part2_backfill.sql
@@ -1,0 +1,43 @@
+-- Part 2/3: data backfill and normalization
+SET NAMES utf8mb4;
+
+ALTER TABLE `users`
+  MODIFY `password_hash` varchar(255) NOT NULL DEFAULT '',
+  MODIFY `referral_code` varchar(20) NULL DEFAULT NULL;
+
+UPDATE `users`
+SET password_hash = CONCAT('bot-only:', SHA2(UUID(), 256))
+WHERE password_hash IS NULL OR password_hash = '';
+
+UPDATE `users`
+SET referral_code = UPPER(SUBSTRING(REPLACE(UUID(), '-', ''), 1, 8))
+WHERE referral_code IS NULL OR referral_code = '';
+
+UPDATE `cart_items` ci
+LEFT JOIN `products` p ON p.id = ci.product_id
+SET ci.boxes = CASE WHEN ci.boxes IS NULL OR ci.boxes = 0 THEN ci.quantity ELSE ci.boxes END,
+    ci.sale_price_per_box = CASE WHEN ci.sale_price_per_box IS NULL OR ci.sale_price_per_box = 0 THEN ci.unit_price ELSE ci.sale_price_per_box END,
+    ci.stock_mode = CASE WHEN ci.stock_mode IS NULL OR ci.stock_mode = '' THEN 'instant' ELSE ci.stock_mode END,
+    ci.purchase_batch_id = CASE WHEN ci.purchase_batch_id IS NULL THEN p.current_purchase_batch_id ELSE ci.purchase_batch_id END;
+
+UPDATE `order_items` oi
+JOIN `products` p ON p.id = oi.product_id
+SET oi.boxes = CASE
+      WHEN (oi.boxes IS NULL OR oi.boxes = 0) AND p.box_size > 0 THEN ROUND(oi.quantity / p.box_size, 2)
+      WHEN (oi.boxes IS NULL OR oi.boxes = 0) THEN oi.quantity
+      ELSE oi.boxes
+    END,
+    oi.sale_price_per_box = CASE
+      WHEN (oi.sale_price_per_box IS NULL OR oi.sale_price_per_box = 0) AND p.box_size > 0 THEN ROUND(oi.unit_price * p.box_size, 2)
+      WHEN (oi.sale_price_per_box IS NULL OR oi.sale_price_per_box = 0) THEN oi.unit_price
+      ELSE oi.sale_price_per_box
+    END,
+    oi.stock_mode = CASE WHEN oi.stock_mode IS NULL OR oi.stock_mode = '' THEN 'instant' ELSE oi.stock_mode END;
+
+UPDATE `products`
+SET instant_unit_price = CASE WHEN instant_unit_price = 0 THEN IF(sale_price > 0, sale_price, price) ELSE instant_unit_price END,
+    preorder_unit_price = CASE WHEN preorder_unit_price = 0 THEN IF(sale_price > 0, sale_price, price) ELSE preorder_unit_price END,
+    discount_unit_price = CASE WHEN discount_unit_price = 0 THEN IF(sale_price > 0, sale_price, price) ELSE discount_unit_price END,
+    instant_price_per_box = CASE WHEN instant_price_per_box = 0 AND box_size > 0 THEN ROUND(IF(sale_price > 0, sale_price, price) * box_size, 2) ELSE instant_price_per_box END,
+    preorder_price_per_box = CASE WHEN preorder_price_per_box = 0 AND box_size > 0 THEN ROUND(IF(sale_price > 0, sale_price, price) * box_size, 2) ELSE preorder_price_per_box END,
+    discount_price_per_box = CASE WHEN discount_price_per_box = 0 AND box_size > 0 THEN ROUND(IF(sale_price > 0, sale_price, price) * box_size, 2) ELSE discount_price_per_box END;

--- a/database/2026_17_prod_patch_part3_constraints_compat.sql
+++ b/database/2026_17_prod_patch_part3_constraints_compat.sql
@@ -1,0 +1,59 @@
+-- Part 3/3: constraints, checks, compatibility triggers and control queries
+SET NAMES utf8mb4;
+SET @old_sql_mode := @@SESSION.sql_mode;
+
+DELIMITER $$
+DROP PROCEDURE IF EXISTS yg_add_fk $$
+CREATE PROCEDURE yg_add_fk(IN p_table VARCHAR(64), IN p_constraint VARCHAR(64), IN p_definition TEXT)
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = p_table
+      AND CONSTRAINT_NAME = p_constraint AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+  ) THEN
+    SET @yg_sql = CONCAT('ALTER TABLE `', p_table, '` ', p_definition);
+    PREPARE yg_stmt FROM @yg_sql; EXECUTE yg_stmt; DEALLOCATE PREPARE yg_stmt;
+  END IF;
+END $$
+DELIMITER ;
+
+UPDATE `cart_items` ci LEFT JOIN `purchase_batches` pb ON pb.id = ci.purchase_batch_id
+SET ci.purchase_batch_id = NULL
+WHERE ci.purchase_batch_id IS NOT NULL AND pb.id IS NULL;
+
+CALL yg_add_fk('cart_items', 'fk_cart_items_purchase_batch',
+  'ADD CONSTRAINT `fk_cart_items_purchase_batch` FOREIGN KEY (`purchase_batch_id`) REFERENCES `purchase_batches` (`id`) ON DELETE SET NULL');
+
+CALL yg_add_fk('purchase_batches', 'fk_purchase_batches_product',
+  'ADD CONSTRAINT `fk_purchase_batches_product` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE RESTRICT');
+CALL yg_add_fk('purchase_batches', 'fk_purchase_batches_buyer',
+  'ADD CONSTRAINT `fk_purchase_batches_buyer` FOREIGN KEY (`buyer_user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL');
+
+INSERT INTO `settings` (`setting_key`, `setting_value`) VALUES
+  ('pricing_preorder_margin_percent', '30'),
+  ('pricing_instant_margin_percent', '50'),
+  ('pricing_discount_stock_markup_fixed', '100'),
+  ('pricing_rounding_step', '10'),
+  ('pricing_free_boxes_default', '10'),
+  ('pricing_discount_stock_bonuses_allowed', '0'),
+  ('pricing_discount_stock_coupons_allowed', '0')
+ON DUPLICATE KEY UPDATE `setting_value` = VALUES(`setting_value`);
+
+DELIMITER $$
+DROP TRIGGER IF EXISTS trg_users_bi_defaults $$
+CREATE TRIGGER trg_users_bi_defaults
+BEFORE INSERT ON `users`
+FOR EACH ROW
+BEGIN
+  IF NEW.password_hash IS NULL OR NEW.password_hash = '' THEN
+    SET NEW.password_hash = CONCAT('bot-only:', SHA2(UUID(), 256));
+  END IF;
+END $$
+DELIMITER ;
+
+SELECT 'cart_items' AS table_name, COUNT(*) AS rows_count,
+       SUM(CASE WHEN boxes IS NULL OR sale_price_per_box IS NULL OR stock_mode IS NULL THEN 1 ELSE 0 END) AS bad_rows
+FROM cart_items;
+
+DROP PROCEDURE IF EXISTS yg_add_fk;
+SET SESSION sql_mode = @old_sql_mode;

--- a/docs/prod_patch_2026_17_runbook.md
+++ b/docs/prod_patch_2026_17_runbook.md
@@ -1,0 +1,25 @@
+# PROD patch 2026_17 (split into 3 parts)
+
+1. `database/2026_17_prod_patch_part1_schema.sql` — только DDL (таблицы/колонки/индексы).
+2. `database/2026_17_prod_patch_part2_backfill.sql` — backfill и нормализация данных.
+3. `database/2026_17_prod_patch_part3_constraints_compat.sql` — FK/checks/совместимость/контрольные выборки.
+
+Рекомендуемый порядок:
+
+```sql
+SOURCE database/2026_17_prod_patch_part1_schema.sql;
+SOURCE database/2026_17_prod_patch_part2_backfill.sql;
+SOURCE database/2026_17_prod_patch_part3_constraints_compat.sql;
+```
+
+Перед запуском:
+
+- Сделать backup.
+- Прогнать на staging-копии прода.
+- Зафиксировать окно работ.
+
+После запуска:
+
+- Проверить контрольные SELECT из part3.
+- Запустить `php bin/migrate.php status`.
+- Запустить `php bin/migrate.php up --dry-run`.


### PR DESCRIPTION
### Motivation

- Introduce first-class purchase batch and stock movement tracking to support preorders, instant and discount stocks and to capture batch-level pricing and stock snapshots.
- Normalize and populate new columns on existing tables so application code can safely rely on `stock_mode`, `boxes`, `*_price_per_box` and related fields.
- Add compatibility constraints, triggers and configuration defaults to enforce referential integrity and sane defaults for new data shapes.

### Description

- Add schema DDL in `database/2026_17_prod_patch_part1_schema.sql` including new tables `purchase_batches`, `stock_movements`, `purchase_batch_photos`, helper stored procedures `yg_add_column`, `yg_add_index`, `yg_add_fk`, and many new columns/indices on `products`, `cart_items`, `orders`, `order_items`, `users`, and `addresses`.
- Add data backfill/normalization in `database/2026_17_prod_patch_part2_backfill.sql` to populate `password_hash`, `referral_code`, `cart_items`, `order_items` and product price/box fields using deterministic rules.
- Add constraints, FK creations, trigger `trg_users_bi_defaults` to ensure default `password_hash`, settings insertions and a cleanup query plus a control `SELECT` in `database/2026_17_prod_patch_part3_constraints_compat.sql`.
- Add a runbook `docs/prod_patch_2026_17_runbook.md` with recommended execution order (`SOURCE` the three SQL parts), pre-run checks and post-run verification steps.

### Testing

- No automated CI tests were executed as part of this change; runbook recommends running `php bin/migrate.php status` and `php bin/migrate.php up --dry-run` on staging before production deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a059f1f135c832c97872acc3ac0358f)