### PR TITLE
Fix HY093 error when creating purchase batches

### DIFF
--- a/src/Services/PurchaseBatchService.php
+++ b/src/Services/PurchaseBatchService.php
@@ -330,7 +330,7 @@ class PurchaseBatchService
                  preorder_unit_price = :preorder_unit_price,
                  instant_unit_price = :instant_unit_price,
                  discount_unit_price = :discount_unit_price,
-                 price = :instant_unit_price,
+                 price = :price,
                  stock_status = :stock_status
              WHERE id = :product_id'
         );
@@ -345,6 +345,7 @@ class PurchaseBatchService
             'preorder_unit_price' => $prices['preorder_unit_price'],
             'instant_unit_price' => $prices['instant_unit_price'],
             'discount_unit_price' => $prices['discount_unit_price'],
+            'price' => $prices['instant_unit_price'],
             'stock_status' => $stockStatus,
             'product_id' => $productId,
         ]);


### PR DESCRIPTION
### Motivation
- Prevent `SQLSTATE[HY093]: Invalid parameter number` when creating purchase batches caused by reusing the same named PDO placeholder in a single query.

### Description
- Update `upsertProductSnapshot()` in `src/Services/PurchaseBatchService.php` to set `price = :price` instead of reusing `:instant_unit_price` and bind `'price' => $prices['instant_unit_price']` in the execute parameters.

### Testing
- Ran `php -l src/Services/PurchaseBatchService.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b28a1210832c957215af700e6dac)