### PR TITLE
Fix checkout crash from nested PDO transactions

### DIFF
--- a/src/Services/StockService.php
+++ b/src/Services/StockService.php
@@ -51,8 +51,12 @@ class StockService
 
         $batchColumn = $this->resolveModeColumn($mode, true);
 
+        $ownsTransaction = !$this->pdo->inTransaction();
+
         try {
-            $this->pdo->beginTransaction();
+            if ($ownsTransaction) {
+                $this->pdo->beginTransaction();
+            }
             $this->appendMovement($batchId, $productId, $orderId, null, 'unreserve', $mode, $boxes);
             $this->updateBatchCounters($batchId, [
                 'boxes_reserved' => -$boxes,
@@ -60,9 +64,11 @@ class StockService
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
-            $this->pdo->commit();
+            if ($ownsTransaction) {
+                $this->pdo->commit();
+            }
         } catch (Throwable $e) {
-            if ($this->pdo->inTransaction()) {
+            if ($ownsTransaction && $this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
             throw $e;
@@ -75,8 +81,12 @@ class StockService
             throw new RuntimeException('Sell boxes must be greater than zero.');
         }
 
+        $ownsTransaction = !$this->pdo->inTransaction();
+
         try {
-            $this->pdo->beginTransaction();
+            if ($ownsTransaction) {
+                $this->pdo->beginTransaction();
+            }
             $this->appendMovement($batchId, $productId, $orderId, null, 'sale', 'internal', -$boxes);
             $this->updateBatchCounters($batchId, [
                 'boxes_reserved' => -$boxes,
@@ -84,9 +94,11 @@ class StockService
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
-            $this->pdo->commit();
+            if ($ownsTransaction) {
+                $this->pdo->commit();
+            }
         } catch (Throwable $e) {
-            if ($this->pdo->inTransaction()) {
+            if ($ownsTransaction && $this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
             throw $e;
@@ -101,17 +113,23 @@ class StockService
 
         $productId = $this->getBatchProductId($batchId);
 
+        $ownsTransaction = !$this->pdo->inTransaction();
+
         try {
-            $this->pdo->beginTransaction();
+            if ($ownsTransaction) {
+                $this->pdo->beginTransaction();
+            }
             $this->appendMovement($batchId, $productId, null, $userId, 'writeoff', 'internal', -$boxes, $comment);
             $this->updateBatchCounters($batchId, [
                 'boxes_written_off' => $boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
-            $this->pdo->commit();
+            if ($ownsTransaction) {
+                $this->pdo->commit();
+            }
         } catch (Throwable $e) {
-            if ($this->pdo->inTransaction()) {
+            if ($ownsTransaction && $this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
             throw $e;
@@ -184,8 +202,12 @@ class StockService
             throw new RuntimeException('Not enough stock in selected mode.');
         }
 
+        $ownsTransaction = !$this->pdo->inTransaction();
+
         try {
-            $this->pdo->beginTransaction();
+            if ($ownsTransaction) {
+                $this->pdo->beginTransaction();
+            }
 
             $this->appendMovement($batchId, $productId, $orderId, null, $movementType, $mode, $delta);
 
@@ -197,9 +219,11 @@ class StockService
             $this->updateBatchCounters($batchId, $updates);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
-            $this->pdo->commit();
+            if ($ownsTransaction) {
+                $this->pdo->commit();
+            }
         } catch (Throwable $e) {
-            if ($this->pdo->inTransaction()) {
+            if ($ownsTransaction && $this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
             throw $e;


### PR DESCRIPTION
### Motivation
- Order placement could call stock operations while a higher-level DB transaction was already active, causing `PDOException: There is already an active transaction` during checkout. 
- The goal is to make `StockService` safe to call from code that may already have an open transaction by avoiding nested `beginTransaction()` calls and by only committing/rolling back when the service started the transaction.

### Description
- Introduced ` $ownsTransaction = !$this->pdo->inTransaction();` and conditional `beginTransaction()`/`commit()`/`rollBack()` behavior to avoid starting or closing transactions owned by external callers. 
- Applied the ownership check to `changeStock()` (used by `reserve`), and to `unreserve`, `sell`, and `writeOff` flows so stock updates no longer force nested transactions. 
- Preserved existing error handling and invariants while making transaction boundaries conditional so orchestrator-level transactions can safely include stock operations.

### Testing
- Ran `php -l src/Services/StockService.php` and it reported no syntax errors. 
- Attempted to run unit tests with `vendor/bin/phpunit tests/StockServiceTest.php tests/ClientFifoAllocationTest.php`, but test runner was not available in the environment (`vendor/bin/phpunit` missing), so PHPUnit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b9328c64832c8229a6fbfa283691)