### PR TITLE
Avoid nested transaction clashes and ensure boxes_remaining is maintained

### DIFF
--- a/src/Services/StockService.php
+++ b/src/Services/StockService.php
@@ -51,8 +51,12 @@ class StockService
 
         $batchColumn = $this->resolveModeColumn($mode, true);
 
+        $ownsTransaction = !$this->pdo->inTransaction();
+
         try {
-            $this->pdo->beginTransaction();
+            if ($ownsTransaction) {
+                $this->pdo->beginTransaction();
+            }
             $this->appendMovement($batchId, $productId, $orderId, null, 'unreserve', $mode, $boxes);
             $this->updateBatchCounters($batchId, [
                 'boxes_reserved' => -$boxes,
@@ -60,9 +64,11 @@ class StockService
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
-            $this->pdo->commit();
+            if ($ownsTransaction) {
+                $this->pdo->commit();
+            }
         } catch (Throwable $e) {
-            if ($this->pdo->inTransaction()) {
+            if ($ownsTransaction && $this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
             throw $e;
@@ -75,8 +81,12 @@ class StockService
             throw new RuntimeException('Sell boxes must be greater than zero.');
         }
 
+        $ownsTransaction = !$this->pdo->inTransaction();
+
         try {
-            $this->pdo->beginTransaction();
+            if ($ownsTransaction) {
+                $this->pdo->beginTransaction();
+            }
             $this->appendMovement($batchId, $productId, $orderId, null, 'sale', 'internal', -$boxes);
             $this->updateBatchCounters($batchId, [
                 'boxes_reserved' => -$boxes,
@@ -84,9 +94,11 @@ class StockService
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
-            $this->pdo->commit();
+            if ($ownsTransaction) {
+                $this->pdo->commit();
+            }
         } catch (Throwable $e) {
-            if ($this->pdo->inTransaction()) {
+            if ($ownsTransaction && $this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
             throw $e;
@@ -101,17 +113,23 @@ class StockService
 
         $productId = $this->getBatchProductId($batchId);
 
+        $ownsTransaction = !$this->pdo->inTransaction();
+
         try {
-            $this->pdo->beginTransaction();
+            if ($ownsTransaction) {
+                $this->pdo->beginTransaction();
+            }
             $this->appendMovement($batchId, $productId, null, $userId, 'writeoff', 'internal', -$boxes, $comment);
             $this->updateBatchCounters($batchId, [
                 'boxes_written_off' => $boxes,
             ]);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
-            $this->pdo->commit();
+            if ($ownsTransaction) {
+                $this->pdo->commit();
+            }
         } catch (Throwable $e) {
-            if ($this->pdo->inTransaction()) {
+            if ($ownsTransaction && $this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
             throw $e;
@@ -184,8 +202,12 @@ class StockService
             throw new RuntimeException('Not enough stock in selected mode.');
         }
 
+        $ownsTransaction = !$this->pdo->inTransaction();
+
         try {
-            $this->pdo->beginTransaction();
+            if ($ownsTransaction) {
+                $this->pdo->beginTransaction();
+            }
 
             $this->appendMovement($batchId, $productId, $orderId, null, $movementType, $mode, $delta);
 
@@ -197,9 +219,11 @@ class StockService
             $this->updateBatchCounters($batchId, $updates);
             $this->assertBatchInvariants($batchId);
             $this->syncProductStock($productId);
-            $this->pdo->commit();
+            if ($ownsTransaction) {
+                $this->pdo->commit();
+            }
         } catch (Throwable $e) {
-            if ($this->pdo->inTransaction()) {
+            if ($ownsTransaction && $this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
             throw $e;
@@ -256,6 +280,8 @@ class StockService
             $params[] = $delta;
         }
         $params[] = $batchId;
+
+        $parts[] = 'boxes_remaining = boxes_total - boxes_sold - boxes_written_off';
 
         $sql = 'UPDATE purchase_batches SET ' . implode(', ', $parts) . ' WHERE id = ?';
         $stmt = $this->pdo->prepare($sql);


### PR DESCRIPTION
### Motivation

- Prevent methods from unconditionally starting or committing transactions so they can be safely called inside existing transactions.
- Keep batch counters consistent by ensuring `boxes_remaining` is recomputed whenever batch counters are updated.

### Description

- Add `$ownsTransaction = !$this->pdo->inTransaction()` and guard calls to `beginTransaction`, `commit`, and `rollBack` with that flag in `unreserve`, `sell`, `writeOff`, and `changeStock`.
- Make `updateBatchCounters` include `boxes_remaining = boxes_total - boxes_sold - boxes_written_off` in the `UPDATE` SQL to maintain remaining count automatically.
- Keep existing validation and invariant checks (`assertBatchInvariants`) while avoiding interfering with outer transaction boundaries.

### Testing

- Ran the project's unit test suite with `vendor/bin/phpunit` and the tests completed successfully.
- Ran the existing database-related integration tests against a test database and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b9328c64832c8229a6fbfa283691)