### PR TITLE
Открыт доступ администратору к каталогу и оформлению заказов

### DIFF
--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -175,7 +175,7 @@ $regularKg  = round($price, 2);
       <?php endif; ?>
 
       <!-- Кнопка «В корзину» или «Войдите» -->
-      <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller']) && $active): ?>
+      <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller','admin']) && $active): ?>
         <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $p['id'] ?>" data-name="<?= htmlspecialchars($p['product'] . ($p['variety'] ? ' ' . $p['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
           <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
           <input type="hidden" name="stock_mode" value="instant">

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -85,7 +85,7 @@
             <link itemprop="availability" href="<?= $active ? 'http://schema.org/InStock' : 'http://schema.org/OutOfStock' ?>">
           </div>
 
-          <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller']) && $active): ?>
+          <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller','admin']) && $active): ?>
             <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $product['id'] ?>" data-name="<?= htmlspecialchars($product['product'] . ($product['variety'] ? ' ' . $product['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
               <input type="hidden" name="product_id" value="<?= $product['id'] ?>">
               <input type="hidden" name="stock_mode" value="instant">


### PR DESCRIPTION
### Motivation
- Администратор не мог видеть кнопку «В корзину» и пройти стандартный клиентский сценарий оформления заказа, поэтому нужно было дать администратору возможность добавлять товары в корзину и оформлять заказы через интерфейс клиента.

### Description
- В `src/Views/client/_card.php` и `src/Views/client/product.php` добавил роль `admin` в список ролей в проверках `in_array(..., ['client','partner','seller'])`, чтобы показывать форму добавления в корзину также для админа.

### Testing
- Запущены синтаксические проверки: `php -l src/Views/client/_card.php` и `php -l src/Views/client/product.php`, обе проверки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05bfdb7920832ca649e12f68c9a2af)