### PR TITLE
Добавить дату закупки по умолчанию и отображение в карточке товара

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -1338,10 +1338,12 @@ public function cancelReservedOrder(int $orderId): void
 
         $pStmt = $this->pdo->prepare(
             "SELECT p.id, p.alias, t.name AS product, t.alias AS type_alias, p.variety, p.description, p.origin_country, p.box_size, p.box_unit, p.price, p.sale_price, p.is_active, p.image_path, p.delivery_date,
-                    COALESCE(u.company_name,u.name,'berryGo') AS seller_name
+                    COALESCE(u.company_name,u.name,'berryGo') AS seller_name,
+                    pb_latest.purchased_at AS latest_purchase_date
              FROM products p
              JOIN product_types t ON t.id = p.product_type_id
              LEFT JOIN users u ON u.id = p.seller_id
+             LEFT JOIN purchase_batches pb_latest ON pb_latest.id = p.current_purchase_batch_id
              WHERE p.product_type_id = ? AND p.is_active = 1"
         );
         $pStmt->execute([$type['id']]);

--- a/src/Controllers/PurchaseBatchesController.php
+++ b/src/Controllers/PurchaseBatchesController.php
@@ -215,6 +215,7 @@ ORDER BY pb.id DESC';
             'purchase_price_per_box' => (float)($_POST['purchase_price_per_box'] ?? 0),
             'extra_cost_per_box' => (float)($_POST['extra_cost_per_box'] ?? 0),
             'status' => (string)($_POST['status'] ?? 'purchased'),
+            'purchased_at' => (string)($_POST['purchased_at'] ?? ''),
             'comment' => trim((string)($_POST['comment'] ?? '')),
         ];
 

--- a/src/Services/PurchaseBatchService.php
+++ b/src/Services/PurchaseBatchService.php
@@ -29,6 +29,7 @@ class PurchaseBatchService
         $extraCostPerBox = (float)($data['extra_cost_per_box'] ?? 0);
         $buyerUserId = isset($data['buyer_user_id']) ? (int)$data['buyer_user_id'] : null;
         $comment = isset($data['comment']) ? (string)$data['comment'] : null;
+        $purchasedAt = trim((string)($data['purchased_at'] ?? ''));
 
         if ($productId <= 0) {
             throw new RuntimeException('Invalid product_id for purchase batch.');
@@ -77,6 +78,7 @@ class PurchaseBatchService
                     instant_unit_price,
                     discount_unit_price,
                     status,
+                    purchased_at,
                     comment
                 ) VALUES (
                     :product_id,
@@ -100,6 +102,7 @@ class PurchaseBatchService
                     :instant_unit_price,
                     :discount_unit_price,
                     :status,
+                    :purchased_at,
                     :comment
                 )'
             );
@@ -127,6 +130,7 @@ class PurchaseBatchService
                 'instant_unit_price' => $prices['instant_unit_price'],
                 'discount_unit_price' => $prices['discount_unit_price'],
                 'status' => (string)($data['status'] ?? 'purchased'),
+                'purchased_at' => $purchasedAt !== '' ? $purchasedAt : date('Y-m-d'),
                 'comment' => $comment,
             ]);
 

--- a/src/Views/admin/purchases/create.php
+++ b/src/Views/admin/purchases/create.php
@@ -22,6 +22,10 @@
 
   <div class="grid grid-cols-2 gap-4">
     <div>
+      <label class="block mb-1">Дата закупки</label>
+      <input name="purchased_at" type="date" class="w-full border px-2 py-1 rounded" value="<?= date('Y-m-d') ?>" required>
+    </div>
+    <div>
       <label class="block mb-1">Количество ящиков</label>
       <input name="boxes_total" type="number" step="0.01" class="w-full border px-2 py-1 rounded" required>
     </div>

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -39,6 +39,7 @@ $isRegularViewer = in_array($role, ['', 'client'], true);
 $hidePriceForPreorder = (!$showDate && $isRegularViewer);
 $basePath = $role === 'manager' ? '/manager' : '/admin';
 $regularKg  = round($price, 2);
+$preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strtotime((string)$p['latest_purchase_date'])) : '';
 ?>
 <div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 sm:h-full max-w-[350px]"
      data-search="<?= htmlspecialchars($search) ?>"
@@ -210,6 +211,9 @@ $regularKg  = round($price, 2);
                   data-product-id="<?= (int)$p['id'] ?>">
             Предзаказ -10%
           </button>
+          <?php if ($preorderPurchaseDate !== ''): ?>
+            <div class="text-xs text-gray-500">Дата закупки: <?= htmlspecialchars($preorderPurchaseDate) ?></div>
+          <?php endif; ?>
           <div class="text-xs text-gray-500 hidden preorder-intent-hint"></div>
         </div>
       <?php else: ?>


### PR DESCRIPTION
### Motivation
- При создании новой закупки поле даты должно по умолчанию заполняться сегодняшним днём и быть видно покупателям рядом с кнопкой «Предзаказ». 

### Description
- Добавлено поле `purchased_at` в форму создания закупки в `src/Views/admin/purchases/create.php` с `value` по умолчанию `<?= date('Y-m-d') ?>`.
- Прокинул `purchased_at` из формы в контроллер через payload в `src/Controllers/PurchaseBatchesController.php` как `purchased_at`.
- В `src/Services/PurchaseBatchService.php` сохранение партии расширено колонкой `purchased_at` и реализован fallback на `date('Y-m-d')`, если поле пустое.
- В выборке товаров для клиентского каталога (`src/Controllers/ClientController.php`) добавлен `pb_latest.purchased_at AS latest_purchase_date` через `LEFT JOIN purchase_batches pb_latest ON pb_latest.id = p.current_purchase_batch_id`, а в карточке товара (`src/Views/client/_card.php`) рядом с кнопкой «Предзаказ -10%» выводится метка `Дата закупки: dd.mm.yyyy`, если дата доступна.

### Testing
- Прогон `php -l` для изменённых файлов (`src/Controllers/PurchaseBatchesController.php`, `src/Services/PurchaseBatchService.php`, `src/Controllers/ClientController.php`, `src/Views/admin/purchases/create.php`, `src/Views/client/_card.php`) не выявил синтаксических ошибок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08be337378832cab88b9863cc193e8)