### PR TITLE
Увеличить ширину карточек на мобильных и заменить кнопку покупки на иконку

### DIFF
--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -201,9 +201,10 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
             </div>
 
             <button type="submit"
-                    class="ml-2 bg-gradient-to-r from-red-500 to-pink-500 accent-gradient text-white px-2 py-2 rounded-lg transition-all flex items-center text-sm">
-              <span class="material-icons-round text-base mr-1">shopping_cart</span>
-              Купить сейчас
+                    aria-label="Добавить в корзину"
+                    title="Добавить в корзину"
+                    class="ml-2 bg-gradient-to-r from-red-500 to-pink-500 accent-gradient text-white w-10 h-10 rounded-full transition-all flex items-center justify-center shrink-0">
+              <span class="material-icons-round text-lg">add_shopping_cart</span>
             </button>
           </form>
           <button type="button"

--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -107,11 +107,11 @@
         <div class="embla__viewport">
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($saleProducts as $p): ?>
-              <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
+              <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
-            <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
+            <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
               <div class="h-full flex items-center justify-center bg-red-50 rounded-2xl shadow-lg p-4 text-center">
                 <p class="text-sm font-semibold text-red-800">Акционная клубника в Красноярске: купите спелую фермерскую ягоду со скидкой до 25 %! Лучшие сорта Клери и Черный принц по невероятно выгодным ценам. Успейте заказать сегодня — акция действует до конца недели, пока ягоды не разобрали! 🍓</p>
               </div>
@@ -136,11 +136,11 @@
         <div class="embla__viewport">
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($regularProducts as $p): ?>
-              <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
+              <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
-            <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
+            <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
               <div class="h-full flex items-center justify-center bg-green-50 rounded-2xl shadow-lg p-4 text-center">
                 <p class="text-sm font-semibold text-green-800">Клубника в наличии в Красноярске: мгновенная доставка за 24 ч — прямо с фермы к вашему столу! Сорта Клери и Черный принц в фасовках от 1 кг. Купите клубнику онлайн с удобной оплатой и гарантий качества каждой ягодки. 🍓🚀</p>
               </div>
@@ -165,7 +165,7 @@
         <div class="embla__viewport">
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($sellerProducts as $p): ?>
-              <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
+              <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -189,11 +189,11 @@
         <div class="embla__viewport">
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($preorderProducts as $p): ?>
-              <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
+              <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
-            <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
+            <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
               <div class="h-full flex items-center justify-center bg-blue-50 rounded-2xl shadow-lg p-4 text-center">
                 <p class="text-sm font-semibold text-blue-800">Клубника другие ягоды и фрукты под заказ с доставкой в Красноярске: эксклюзивные сорта и объёмы от 1 кг. Идеально для праздников, корпоративов и подарков! Заранее выберите свой идеальный набор — индивидуальная упаковка, свежесть гарантирована, доставка в удобное время. 🍓✨</p>
               </div>
@@ -219,7 +219,7 @@
         <div class="embla__viewport">
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($discountProducts as $p): ?>
-              <div class="embla__slide flex-none w-[52vw] sm:w-1/2 md:w-1/3">
+              <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>


### PR DESCRIPTION
### Motivation
- На экранах около 378px карточки выглядят слишком узкими и мелкими, поэтому нужно сделать их шире для лучшей читаемости и взаимодействия. 
- Хотелось упростить блок «количество + купить», сделав кнопку покупки компактной и более заметной через иконку корзины с плюсом.

### Description
- В `src/Views/client/home.php` увеличил мобильную ширину с `w-[52vw]` до `w-[64vw]` во всех секциях каруселей товаров (`saleProducts`, `regularProducts`, `sellerProducts`, `preorderProducts`, `discountProducts`).
- В `src/Views/client/_card.php` заменил текстовую кнопку «Купить сейчас» на круглую иконку-кнопку с `add_shopping_cart`, добавил `aria-label` и `title` для доступности и изменил классы на `w-10 h-10 rounded-full shrink-0` для компактного вида.
- Изменения направлены на улучшение визуального восприятия карточки на мобильных и упрощение CTA в блоке количества.

### Testing
- Запущен синтаксический чек PHP: `php -l src/Views/client/_card.php` и `php -l src/Views/client/home.php`, оба файла прошли без ошибок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c17cc35c832cb50c5448ef9747b8)