### PR TITLE
Перевести статусы закупок в админке на русский

### DIFF
--- a/src/Views/admin/purchases/create.php
+++ b/src/Views/admin/purchases/create.php
@@ -1,6 +1,11 @@
 <?php /** @var array<int,array<string,mixed>> $products */ ?>
 <?php $basePath = $basePath ?? '/admin'; ?>
 <?php $flash = $flash ?? null; ?>
+<?php $statusLabels = [
+  'purchased' => 'Закуплена',
+  'arrived' => 'Поступила',
+  'active' => 'В продаже',
+]; ?>
 <form action="<?= $basePath ?>/purchases/store" method="post" enctype="multipart/form-data" class="bg-white p-6 rounded shadow max-w-2xl mx-auto space-y-4">
   <?= csrf_field() ?>
   <?php if (is_array($flash) && !empty($flash['message'])): ?>
@@ -48,9 +53,9 @@
     <div>
       <label class="block mb-1">Статус</label>
       <select name="status" class="w-full border px-2 py-1 rounded">
-        <option value="purchased">purchased</option>
-        <option value="arrived">arrived</option>
-        <option value="active">active</option>
+        <option value="purchased"><?= $statusLabels['purchased'] ?></option>
+        <option value="arrived"><?= $statusLabels['arrived'] ?></option>
+        <option value="active"><?= $statusLabels['active'] ?></option>
       </select>
     </div>
   </div>

--- a/src/Views/admin/purchases/index.php
+++ b/src/Views/admin/purchases/index.php
@@ -4,6 +4,15 @@
 <?php $buyers = $buyers ?? []; ?>
 <?php $filters = $filters ?? ['status' => '', 'buyer_id' => 0]; ?>
 <?php $summary = $summary ?? []; ?>
+<?php $statusLabels = [
+  'planned' => 'Запланирована',
+  'purchased' => 'Закуплена',
+  'arrived' => 'Поступила',
+  'active' => 'В продаже',
+  'sold_out' => 'Распродана',
+  'closed' => 'Закрыта',
+  'cancelled' => 'Отменена',
+]; ?>
 <?php if (is_array($flash) && !empty($flash['message'])): ?>
   <div class="<?= ($flash['type'] ?? '') === 'error' ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700' ?> border p-3 rounded mb-4">
     <?= htmlspecialchars((string)$flash['message']) ?>
@@ -22,7 +31,7 @@
     <select name="status" class="w-full border rounded px-2 py-2 text-sm">
       <option value="">Все</option>
       <?php foreach (['planned','purchased','arrived','active','sold_out','closed','cancelled'] as $st): ?>
-        <option value="<?= $st ?>" <?= (($filters['status'] ?? '') === $st) ? 'selected' : '' ?>><?= $st ?></option>
+        <option value="<?= $st ?>" <?= (($filters['status'] ?? '') === $st) ? 'selected' : '' ?>><?= htmlspecialchars((string)($statusLabels[$st] ?? $st)) ?></option>
       <?php endforeach; ?>
     </select>
   </div>
@@ -74,7 +83,7 @@
         <td class="p-3"><?= (float)$batch['boxes_reserved'] ?></td>
         <td class="p-3"><?= number_format((float)$batch['purchase_price_per_box'], 2, '.', ' ') ?> ₽</td>
         <td class="p-3"><?= number_format((float)$batch['instant_price_per_box'], 2, '.', ' ') ?> ₽</td>
-        <td class="p-3"><?= htmlspecialchars((string)$batch['status']) ?></td>
+        <td class="p-3"><?= htmlspecialchars((string)($statusLabels[(string)$batch['status']] ?? (string)$batch['status'])) ?></td>
         <td class="p-3"><?= (int)($batch['age_days'] ?? 0) ?> дн.</td>
         <td class="p-3">
           <div class="flex flex-wrap gap-2">

--- a/src/Views/admin/purchases/show.php
+++ b/src/Views/admin/purchases/show.php
@@ -3,6 +3,15 @@
 <?php /** @var array<int,array<string,mixed>> $photos */ ?>
 <?php $basePath = $basePath ?? '/admin'; ?>
 <?php $flash = $flash ?? null; ?>
+<?php $statusLabels = [
+  'planned' => 'Запланирована',
+  'purchased' => 'Закуплена',
+  'arrived' => 'Поступила',
+  'active' => 'В продаже',
+  'sold_out' => 'Распродана',
+  'closed' => 'Закрыта',
+  'cancelled' => 'Отменена',
+]; ?>
 
 <div class="mb-4">
   <a href="<?= $basePath ?>/purchases" class="text-[#C86052] hover:underline">← К списку закупок</a>
@@ -19,7 +28,7 @@
   <p class="mb-2"><a class="text-sm text-[#C86052] hover:underline" href="<?= $basePath ?>/purchases/<?= (int)$batch['id'] ?>/pnl.csv">Скачать P&L CSV</a></p>
   <p><b>Товар:</b> <?= htmlspecialchars(trim(($batch['product_name'] ?? '') . ' ' . ($batch['variety'] ?? ''))) ?></p>
   <p><b>Закупщик:</b> <?= htmlspecialchars((string)($batch['buyer_name'] ?? '—')) ?></p>
-  <p><b>Статус:</b> <?= htmlspecialchars((string)$batch['status']) ?></p>
+  <p><b>Статус:</b> <?= htmlspecialchars((string)($statusLabels[(string)$batch['status']] ?? (string)$batch['status'])) ?></p>
   <p><b>Куплено:</b> <?= (float)$batch['boxes_total'] ?> | <b>Свободно:</b> <?= (float)$batch['boxes_free'] ?> | <b>Резерв:</b> <?= (float)$batch['boxes_reserved'] ?></p>
 </div>
 


### PR DESCRIPTION
### Motivation
- Улучшить удобство админки, показывая статусы закупок на русском языке в списках, форме и на странице партии.
- Сохранить поведение фильтра и логики, оставив внутренние значения статусов без изменений.

### Description
- Добавлен массив `$statusLabels` с соответствиями ключей статусов и их русских подписей в `src/Views/admin/purchases/index.php`, `src/Views/admin/purchases/create.php` и `src/Views/admin/purchases/show.php`.
- В списке закупок (`index.php`) фильтр и таблица теперь отображают русские подписи статусов, при этом `value` опций остаётся оригинальным ключом статуса для совместимости с фильтрацией.
- В форме создания закупки (`create.php`) опции `select[name="status"]` используют русские подписи из словаря, сохраняя технические значения опций.
- На странице просмотра партии (`show.php`) вывод поля «Статус» заменён на подписку из словаря, с защитой по умолчанию на случай неизвестного ключа.

### Testing
- Запущена проверка синтаксиса PHP: `php -l src/Views/admin/purchases/index.php`, `php -l src/Views/admin/purchases/create.php`, `php -l src/Views/admin/purchases/show.php`, все три файла прошли проверку без ошибок.
- Локальная проверка повторной валидации синтаксиса `php -l src/Views/admin/purchases/index.php` прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c4eca69c832cbc4eefd918fd6a56)