### PR TITLE
Разрешить администратору оформлять заказы через клиентский интерфейс

### DIFF
--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -176,7 +176,7 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
       <?php endif; ?>
 
       <!-- Кнопка «В корзину» или «Войдите» -->
-      <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller']) && $active): ?>
+      <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller','admin']) && $active): ?>
         <div class="space-y-2">
           <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $p['id'] ?>" data-name="<?= htmlspecialchars($p['product'] . ($p['variety'] ? ' ' . $p['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
             <input type="hidden" name="product_id" value="<?= $p['id'] ?>">

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -85,7 +85,7 @@
             <link itemprop="availability" href="<?= $active ? 'http://schema.org/InStock' : 'http://schema.org/OutOfStock' ?>">
           </div>
 
-          <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller']) && $active): ?>
+          <?php if (in_array((string)($_SESSION['role'] ?? ''), ['client','partner','seller','admin']) && $active): ?>
             <div class="space-y-2">
               <form action="/cart/add" method="post" class="flex items-center space-x-2 add-to-cart-form" data-id="<?= $product['id'] ?>" data-name="<?= htmlspecialchars($product['product'] . ($product['variety'] ? ' ' . $product['variety'] : '')) ?>" data-price="<?= $priceBox ?>">
                 <input type="hidden" name="product_id" value="<?= $product['id'] ?>">


### PR DESCRIPTION
### Motivation
- Администратор имел серверную авторизацию для `checkout`, но в клиентском интерфейсе не видел кнопку добавления товара в корзину и не мог начать оформление заказа.
- Нужно позволить админу инициировать оформление заказа из карточки товара и каталога так же, как другим клиентским ролям.

### Description
- Добавил роль `admin` в проверку показа кнопки добавления в корзину в `src/Views/client/product.php` (условие `in_array(..., ['client','partner','seller','admin'])`).
- Аналогичное изменение сделано в `src/Views/client/_card.php` чтобы админ видел кнопку на карточках в каталоге.
- Файлы отформатированы/проверены на синтаксис PHP после правок.

### Testing
- Выполнены синтаксические проверки: `php -l src/Views/client/product.php` — успешно.
- Выполнены синтаксические проверки: `php -l src/Views/client/_card.php` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c573a908832caa2579ea8de694c5)