### PR TITLE
Improve product availability filters and update homepage labels

### DIFF
--- a/src/Services/ClientCatalogService.php
+++ b/src/Services/ClientCatalogService.php
@@ -19,13 +19,13 @@ class ClientCatalogService
     {
         return [
             'saleProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.sale_price > 0',
+                'p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.discount_stock_boxes > 0',
                 'p.id DESC',
                 [],
                 10
             ),
             'regularProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.delivery_date IS NOT NULL AND p.seller_id IS NULL',
+                "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.seller_id IS NULL AND (p.stock_status = 'in_stock' OR p.free_stock_boxes > 0)",
                 'p.id DESC',
                 [],
                 10
@@ -37,7 +37,7 @@ class ClientCatalogService
                 10
             ),
             'preorderProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.delivery_date IS NULL AND p.seller_id IS NULL',
+                "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.seller_id IS NULL AND p.stock_status = 'preorder'",
                 'p.id DESC',
                 [],
                 10

--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -68,7 +68,7 @@
 
   <?php if (!empty($saleProducts)): ?>
     <section class="px-4 mb-8 mt-6">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">💥 Наши спецпредложения</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">💥 Акции</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -96,7 +96,7 @@
 
   <?php if (!empty($regularProducts)): ?>
     <section class="px-4 mb-8">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🚚 Регулярные поставки</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🚚 В наличии</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -147,7 +147,7 @@
 
   <?php if (!empty($preorderProducts)): ?>
     <section class="px-4 mb-8">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🛒 Товары под заказ</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🛒 Предварительный заказ -10%</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>

--- a/tests/ClientCatalogServiceTest.php
+++ b/tests/ClientCatalogServiceTest.php
@@ -31,7 +31,11 @@ class ClientCatalogServiceTest extends TestCase
             sale_price REAL,
             is_active INTEGER,
             image_path TEXT,
-            delivery_date TEXT NULL
+            delivery_date TEXT NULL,
+            current_purchase_batch_id INTEGER NULL,
+            free_stock_boxes REAL DEFAULT 0,
+            discount_stock_boxes REAL DEFAULT 0,
+            stock_status TEXT DEFAULT "sold_out"
         )');
         $this->pdo->exec('CREATE TABLE content_categories (id INTEGER PRIMARY KEY, alias TEXT)');
         $this->pdo->exec('CREATE TABLE materials (
@@ -49,11 +53,11 @@ class ClientCatalogServiceTest extends TestCase
         $this->pdo->exec("INSERT INTO content_categories (id, alias) VALUES (1, 'news')");
 
         $this->pdo->exec(
-            "INSERT INTO products (id, alias, product_type_id, seller_id, variety, description, origin_country, box_size, box_unit, price, sale_price, is_active, image_path, delivery_date) VALUES
-            (1, 'sale-product', 1, NULL, 'Клери', 'sale', 'KG', 1, 'кг', 1000, 800, 1, '/sale.jpg', '2025-03-25'),
-            (2, 'regular-product', 1, NULL, 'Азия', 'regular', 'KG', 1, 'кг', 900, 0, 1, '/regular.jpg', '2025-03-24'),
-            (3, 'seller-product', 1, 1, 'Seller', 'seller', 'KG', 1, 'кг', 1200, 0, 1, '/seller.jpg', '2025-03-26'),
-            (4, 'preorder-product', 1, NULL, 'Pre', 'preorder', 'KG', 1, 'кг', 1100, 0, 1, '/pre.jpg', NULL)"
+            "INSERT INTO products (id, alias, product_type_id, seller_id, variety, description, origin_country, box_size, box_unit, price, sale_price, is_active, image_path, delivery_date, current_purchase_batch_id, free_stock_boxes, discount_stock_boxes, stock_status) VALUES
+            (1, 'sale-product', 1, NULL, 'Клери', 'sale', 'KG', 1, 'кг', 1000, 800, 1, '/sale.jpg', '2025-03-25', 11, 0, 3, 'in_stock'),
+            (2, 'regular-product', 1, NULL, 'Азия', 'regular', 'KG', 1, 'кг', 900, 0, 1, '/regular.jpg', '2025-03-24', 12, 5, 0, 'in_stock'),
+            (3, 'seller-product', 1, 1, 'Seller', 'seller', 'KG', 1, 'кг', 1200, 0, 1, '/seller.jpg', '2025-03-26', NULL, 0, 0, 'sold_out'),
+            (4, 'preorder-product', 1, NULL, 'Pre', 'preorder', 'KG', 1, 'кг', 1100, 0, 1, '/pre.jpg', NULL, 13, 0, 0, 'preorder')"
         );
         $this->pdo->exec(
             "INSERT INTO materials (id, alias, category_id, title, short_desc, image_path, created_at) VALUES


### PR DESCRIPTION
### Motivation
- Categorize homepage products based on real stock and batch data instead of legacy flags to show accurate availability to users.

### Description
- Change `ClientCatalogService::getHomePageData` filters to require `current_purchase_batch_id IS NOT NULL` and to use `free_stock_boxes`, `discount_stock_boxes`, and `stock_status` when selecting `saleProducts`, `regularProducts`, and `preorderProducts`.
- Leave seller product selection unchanged and preserve ordering/limits used by `fetchProducts`.
- Update homepage view `src/Views/client/home.php` to adjust section headings and promotional copy for sale, regular (in-stock) and preorder sections.
- Extend the test SQLite schema in `tests/ClientCatalogServiceTest.php` with `current_purchase_batch_id`, `free_stock_boxes`, `discount_stock_boxes`, and `stock_status`, and update product fixtures to exercise the new filtering rules.

### Testing
- Ran unit tests in `tests/ClientCatalogServiceTest.php` with `phpunit`, which validate `getHomePageData` grouping and `getCatalogData` behavior, and all assertions passed.
- No other automated test suites were changed or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f48e094c832ca63f49fc3554b2f5)