### PR TITLE
Introduce 'planned' purchase status, refine catalog visibility rules and update UI labels

### DIFF
--- a/src/Controllers/PurchaseBatchesController.php
+++ b/src/Controllers/PurchaseBatchesController.php
@@ -214,7 +214,7 @@ ORDER BY pb.id DESC';
             'boxes_free' => (float)($_POST['boxes_free'] ?? 0),
             'purchase_price_per_box' => (float)($_POST['purchase_price_per_box'] ?? 0),
             'extra_cost_per_box' => (float)($_POST['extra_cost_per_box'] ?? 0),
-            'status' => (string)($_POST['status'] ?? 'purchased'),
+            'status' => (string)($_POST['status'] ?? 'planned'),
             'purchased_at' => (string)($_POST['purchased_at'] ?? ''),
             'comment' => trim((string)($_POST['comment'] ?? '')),
         ];

--- a/src/Services/ClientCatalogService.php
+++ b/src/Services/ClientCatalogService.php
@@ -19,13 +19,13 @@ class ClientCatalogService
     {
         return [
             'saleProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.sale_price > 0',
+                'p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.discount_stock_boxes > 0',
                 'p.id DESC',
                 [],
                 10
             ),
             'regularProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.delivery_date IS NOT NULL AND p.seller_id IS NULL',
+                "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.seller_id IS NULL AND (p.stock_status = 'in_stock' OR p.free_stock_boxes > 0)",
                 'p.id DESC',
                 [],
                 10
@@ -37,7 +37,7 @@ class ClientCatalogService
                 10
             ),
             'preorderProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.delivery_date IS NULL AND p.seller_id IS NULL',
+                "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.seller_id IS NULL AND p.stock_status = 'preorder'",
                 'p.id DESC',
                 [],
                 10

--- a/src/Views/admin/purchases/create.php
+++ b/src/Views/admin/purchases/create.php
@@ -2,9 +2,9 @@
 <?php $basePath = $basePath ?? '/admin'; ?>
 <?php $flash = $flash ?? null; ?>
 <?php $statusLabels = [
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
+  'planned' => 'Запланирована',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 <form action="<?= $basePath ?>/purchases/store" method="post" enctype="multipart/form-data" class="bg-white p-6 rounded shadow max-w-2xl mx-auto space-y-4">
   <?= csrf_field() ?>
@@ -27,8 +27,8 @@
 
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <label class="block mb-1">Дата закупки</label>
-      <input name="purchased_at" type="date" class="w-full border px-2 py-1 rounded" value="<?= date('Y-m-d') ?>" required>
+      <label class="block mb-1">Плановая дата поставки</label>
+      <input name="purchased_at" type="date" class="w-full border px-2 py-1 rounded" value="<?= date('Y-m-d') ?>">
     </div>
     <div>
       <label class="block mb-1">Количество ящиков</label>
@@ -53,9 +53,9 @@
     <div>
       <label class="block mb-1">Статус</label>
       <select name="status" class="w-full border px-2 py-1 rounded">
+        <option value="planned"><?= $statusLabels['planned'] ?></option>
         <option value="purchased"><?= $statusLabels['purchased'] ?></option>
         <option value="arrived"><?= $statusLabels['arrived'] ?></option>
-        <option value="active"><?= $statusLabels['active'] ?></option>
       </select>
     </div>
   </div>

--- a/src/Views/admin/purchases/index.php
+++ b/src/Views/admin/purchases/index.php
@@ -6,12 +6,8 @@
 <?php $summary = $summary ?? []; ?>
 <?php $statusLabels = [
   'planned' => 'Запланирована',
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
-  'sold_out' => 'Распродана',
-  'closed' => 'Закрыта',
-  'cancelled' => 'Отменена',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 <?php if (is_array($flash) && !empty($flash['message'])): ?>
   <div class="<?= ($flash['type'] ?? '') === 'error' ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700' ?> border p-3 rounded mb-4">
@@ -30,7 +26,7 @@
     <label class="text-xs text-gray-600">Статус</label>
     <select name="status" class="w-full border rounded px-2 py-2 text-sm">
       <option value="">Все</option>
-      <?php foreach (['planned','purchased','arrived','active','sold_out','closed','cancelled'] as $st): ?>
+      <?php foreach (['planned','purchased','arrived'] as $st): ?>
         <option value="<?= $st ?>" <?= (($filters['status'] ?? '') === $st) ? 'selected' : '' ?>><?= htmlspecialchars((string)($statusLabels[$st] ?? $st)) ?></option>
       <?php endforeach; ?>
     </select>

--- a/src/Views/admin/purchases/show.php
+++ b/src/Views/admin/purchases/show.php
@@ -5,12 +5,8 @@
 <?php $flash = $flash ?? null; ?>
 <?php $statusLabels = [
   'planned' => 'Запланирована',
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
-  'sold_out' => 'Распродана',
-  'closed' => 'Закрыта',
-  'cancelled' => 'Отменена',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 
 <div class="mb-4">

--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -68,7 +68,7 @@
 
   <?php if (!empty($saleProducts)): ?>
     <section class="px-4 mb-8 mt-6">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">💥 Наши спецпредложения</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">💥 Акции</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -96,7 +96,7 @@
 
   <?php if (!empty($regularProducts)): ?>
     <section class="px-4 mb-8">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🚚 Регулярные поставки</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🚚 В наличии</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -147,7 +147,7 @@
 
   <?php if (!empty($preorderProducts)): ?>
     <section class="px-4 mb-8">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🛒 Товары под заказ</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🛒 Предварительный заказ -10%</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>

--- a/tests/ClientCatalogServiceTest.php
+++ b/tests/ClientCatalogServiceTest.php
@@ -31,7 +31,11 @@ class ClientCatalogServiceTest extends TestCase
             sale_price REAL,
             is_active INTEGER,
             image_path TEXT,
-            delivery_date TEXT NULL
+            delivery_date TEXT NULL,
+            current_purchase_batch_id INTEGER NULL,
+            free_stock_boxes REAL DEFAULT 0,
+            discount_stock_boxes REAL DEFAULT 0,
+            stock_status TEXT DEFAULT "sold_out"
         )');
         $this->pdo->exec('CREATE TABLE content_categories (id INTEGER PRIMARY KEY, alias TEXT)');
         $this->pdo->exec('CREATE TABLE materials (
@@ -49,11 +53,11 @@ class ClientCatalogServiceTest extends TestCase
         $this->pdo->exec("INSERT INTO content_categories (id, alias) VALUES (1, 'news')");
 
         $this->pdo->exec(
-            "INSERT INTO products (id, alias, product_type_id, seller_id, variety, description, origin_country, box_size, box_unit, price, sale_price, is_active, image_path, delivery_date) VALUES
-            (1, 'sale-product', 1, NULL, 'Клери', 'sale', 'KG', 1, 'кг', 1000, 800, 1, '/sale.jpg', '2025-03-25'),
-            (2, 'regular-product', 1, NULL, 'Азия', 'regular', 'KG', 1, 'кг', 900, 0, 1, '/regular.jpg', '2025-03-24'),
-            (3, 'seller-product', 1, 1, 'Seller', 'seller', 'KG', 1, 'кг', 1200, 0, 1, '/seller.jpg', '2025-03-26'),
-            (4, 'preorder-product', 1, NULL, 'Pre', 'preorder', 'KG', 1, 'кг', 1100, 0, 1, '/pre.jpg', NULL)"
+            "INSERT INTO products (id, alias, product_type_id, seller_id, variety, description, origin_country, box_size, box_unit, price, sale_price, is_active, image_path, delivery_date, current_purchase_batch_id, free_stock_boxes, discount_stock_boxes, stock_status) VALUES
+            (1, 'sale-product', 1, NULL, 'Клери', 'sale', 'KG', 1, 'кг', 1000, 800, 1, '/sale.jpg', '2025-03-25', 11, 0, 3, 'in_stock'),
+            (2, 'regular-product', 1, NULL, 'Азия', 'regular', 'KG', 1, 'кг', 900, 0, 1, '/regular.jpg', '2025-03-24', 12, 5, 0, 'in_stock'),
+            (3, 'seller-product', 1, 1, 'Seller', 'seller', 'KG', 1, 'кг', 1200, 0, 1, '/seller.jpg', '2025-03-26', NULL, 0, 0, 'sold_out'),
+            (4, 'preorder-product', 1, NULL, 'Pre', 'preorder', 'KG', 1, 'кг', 1100, 0, 1, '/pre.jpg', NULL, 13, 0, 0, 'preorder')"
         );
         $this->pdo->exec(
             "INSERT INTO materials (id, alias, category_id, title, short_desc, image_path, created_at) VALUES


### PR DESCRIPTION
### Motivation
- Add a new `planned` status for purchase batches and make it the default when creating a new batch to better represent pre-arrival inventory. 
- Tighten client catalog grouping to rely on purchase-batch and stock fields so front-end listings reflect actual availability and promo/discount stock. 
- Update admin and client UI labels to match the new workflow and clearer customer-facing terminology.

### Description
- Change default status in `PurchaseBatchesController::store` from `purchased` to `planned` and ensure the create form includes the `planned` option. 
- Add `planned` to admin views and simplify available status filters in `src/Views/admin/purchases/*`, and update wording for `purchased`/`arrived` labels. 
- Modify `ClientCatalogService::getHomePageData` product filters to require `p.current_purchase_batch_id IS NOT NULL` and use `free_stock_boxes`, `discount_stock_boxes`, and `stock_status` to determine `saleProducts`, `regularProducts` and `preorderProducts`. 
- Update client-facing headings in `src/Views/client/home.php` for `saleProducts`, `regularProducts` and `preorderProducts`. 
- Update `tests/ClientCatalogServiceTest.php` to create the new product columns (`current_purchase_batch_id`, `free_stock_boxes`, `discount_stock_boxes`, `stock_status`) and adjust fixtures to validate the updated grouping logic.

### Testing
- Ran the catalog unit test file `tests/ClientCatalogServiceTest.php` under `phpunit` and the test for homepage grouping and catalog data completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f48e094c832ca63f49fc3554b2f5)