### PR TITLE
Add 'planned' purchase status, enforce allowed batch statuses, and update catalog/UI for preorder/sale

### DIFF
--- a/src/Controllers/PurchaseBatchesController.php
+++ b/src/Controllers/PurchaseBatchesController.php
@@ -214,7 +214,7 @@ ORDER BY pb.id DESC';
             'boxes_free' => (float)($_POST['boxes_free'] ?? 0),
             'purchase_price_per_box' => (float)($_POST['purchase_price_per_box'] ?? 0),
             'extra_cost_per_box' => (float)($_POST['extra_cost_per_box'] ?? 0),
-            'status' => (string)($_POST['status'] ?? 'purchased'),
+            'status' => (string)($_POST['status'] ?? 'planned'),
             'purchased_at' => (string)($_POST['purchased_at'] ?? ''),
             'comment' => trim((string)($_POST['comment'] ?? '')),
         ];

--- a/src/Services/ClientCatalogService.php
+++ b/src/Services/ClientCatalogService.php
@@ -19,13 +19,13 @@ class ClientCatalogService
     {
         return [
             'saleProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.sale_price > 0',
+                'p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.discount_stock_boxes > 0',
                 'p.id DESC',
                 [],
                 10
             ),
             'regularProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.delivery_date IS NOT NULL AND p.seller_id IS NULL',
+                "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.seller_id IS NULL AND (p.stock_status = 'in_stock' OR p.free_stock_boxes > 0)",
                 'p.id DESC',
                 [],
                 10
@@ -37,7 +37,7 @@ class ClientCatalogService
                 10
             ),
             'preorderProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.delivery_date IS NULL AND p.seller_id IS NULL',
+                "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL AND p.seller_id IS NULL AND p.stock_status = 'preorder'",
                 'p.id DESC',
                 [],
                 10

--- a/src/Services/PurchaseBatchService.php
+++ b/src/Services/PurchaseBatchService.php
@@ -7,6 +7,8 @@ use Throwable;
 
 class PurchaseBatchService
 {
+    private const ALLOWED_BATCH_STATUSES = ['planned', 'purchased', 'arrived'];
+
     private PDO $pdo;
     private PricingService $pricingService;
 
@@ -30,6 +32,7 @@ class PurchaseBatchService
         $buyerUserId = isset($data['buyer_user_id']) ? (int)$data['buyer_user_id'] : null;
         $comment = isset($data['comment']) ? (string)$data['comment'] : null;
         $purchasedAt = trim((string)($data['purchased_at'] ?? ''));
+        $status = (string)($data['status'] ?? 'planned');
 
         if ($productId <= 0) {
             throw new RuntimeException('Invalid product_id for purchase batch.');
@@ -42,6 +45,9 @@ class PurchaseBatchService
         }
         if (($boxesFree + $boxesReserved) > $boxesTotal) {
             throw new RuntimeException('Allocated boxes exceed boxes_total.');
+        }
+        if (!in_array($status, self::ALLOWED_BATCH_STATUSES, true)) {
+            throw new RuntimeException('Unsupported purchase batch status.');
         }
 
         $product = $this->loadProduct($productId);
@@ -129,7 +135,7 @@ class PurchaseBatchService
                 'preorder_unit_price' => $prices['preorder_unit_price'],
                 'instant_unit_price' => $prices['instant_unit_price'],
                 'discount_unit_price' => $prices['discount_unit_price'],
-                'status' => (string)($data['status'] ?? 'purchased'),
+                'status' => $status,
                 'purchased_at' => $purchasedAt !== '' ? $purchasedAt : date('Y-m-d'),
                 'comment' => $comment,
             ]);

--- a/src/Views/admin/purchases/create.php
+++ b/src/Views/admin/purchases/create.php
@@ -2,9 +2,9 @@
 <?php $basePath = $basePath ?? '/admin'; ?>
 <?php $flash = $flash ?? null; ?>
 <?php $statusLabels = [
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
+  'planned' => 'Запланирована',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 <form action="<?= $basePath ?>/purchases/store" method="post" enctype="multipart/form-data" class="bg-white p-6 rounded shadow max-w-2xl mx-auto space-y-4">
   <?= csrf_field() ?>
@@ -27,8 +27,8 @@
 
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <label class="block mb-1">Дата закупки</label>
-      <input name="purchased_at" type="date" class="w-full border px-2 py-1 rounded" value="<?= date('Y-m-d') ?>" required>
+      <label class="block mb-1">Плановая дата поставки</label>
+      <input name="purchased_at" type="date" class="w-full border px-2 py-1 rounded" value="<?= date('Y-m-d') ?>">
     </div>
     <div>
       <label class="block mb-1">Количество ящиков</label>
@@ -53,9 +53,9 @@
     <div>
       <label class="block mb-1">Статус</label>
       <select name="status" class="w-full border px-2 py-1 rounded">
+        <option value="planned"><?= $statusLabels['planned'] ?></option>
         <option value="purchased"><?= $statusLabels['purchased'] ?></option>
         <option value="arrived"><?= $statusLabels['arrived'] ?></option>
-        <option value="active"><?= $statusLabels['active'] ?></option>
       </select>
     </div>
   </div>

--- a/src/Views/admin/purchases/index.php
+++ b/src/Views/admin/purchases/index.php
@@ -6,12 +6,8 @@
 <?php $summary = $summary ?? []; ?>
 <?php $statusLabels = [
   'planned' => 'Запланирована',
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
-  'sold_out' => 'Распродана',
-  'closed' => 'Закрыта',
-  'cancelled' => 'Отменена',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 <?php if (is_array($flash) && !empty($flash['message'])): ?>
   <div class="<?= ($flash['type'] ?? '') === 'error' ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700' ?> border p-3 rounded mb-4">
@@ -30,7 +26,7 @@
     <label class="text-xs text-gray-600">Статус</label>
     <select name="status" class="w-full border rounded px-2 py-2 text-sm">
       <option value="">Все</option>
-      <?php foreach (['planned','purchased','arrived','active','sold_out','closed','cancelled'] as $st): ?>
+      <?php foreach (['planned','purchased','arrived'] as $st): ?>
         <option value="<?= $st ?>" <?= (($filters['status'] ?? '') === $st) ? 'selected' : '' ?>><?= htmlspecialchars((string)($statusLabels[$st] ?? $st)) ?></option>
       <?php endforeach; ?>
     </select>

--- a/src/Views/admin/purchases/show.php
+++ b/src/Views/admin/purchases/show.php
@@ -5,12 +5,8 @@
 <?php $flash = $flash ?? null; ?>
 <?php $statusLabels = [
   'planned' => 'Запланирована',
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
-  'sold_out' => 'Распродана',
-  'closed' => 'Закрыта',
-  'cancelled' => 'Отменена',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 
 <div class="mb-4">

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -40,6 +40,10 @@ $hidePriceForPreorder = (!$showDate && $isRegularViewer);
 $basePath = $role === 'manager' ? '/manager' : '/admin';
 $regularKg  = round($price, 2);
 $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strtotime((string)$p['latest_purchase_date'])) : '';
+$cardSection = (string)($cardSection ?? '');
+$isPreorderSection = $cardSection === 'preorder';
+$isSaleSection = $cardSection === 'sale';
+$preorderDiscountBox = round($regularBox * 0.9, 0);
 ?>
 <div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 sm:h-full max-w-[350px]"
      data-search="<?= htmlspecialchars($search) ?>"
@@ -136,6 +140,17 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
       <?php if ($hidePriceForPreorder): ?>
         <p class="text-base font-semibold text-gray-400 mb-3">Цена уточняется</p>
 
+      <?php elseif ($isPreorderSection): ?>
+        <div class="flex items-end gap-2 mb-1">
+          <span class="text-base text-gray-400 line-through leading-none pb-0.5">
+            <?= number_format($regularBox, 0, '.', ' ') ?> ₽
+          </span>
+          <span class="text-xl sm:text-2xl font-bold text-gray-900 box-price leading-none">
+            <?= number_format($preorderDiscountBox, 0, '.', ' ') ?> ₽
+          </span>
+        </div>
+        <p class="text-[10px] leading-tight text-red-500 mb-3">Цена ориентировочная, точная цена будет после поступления</p>
+
       <?php elseif ($sale > 0): ?>
         <!-- Акционная цена -->
         <div class="flex items-end gap-2 mb-1">
@@ -214,7 +229,8 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
 
             <!-- Кнопка «В корзину» — растягивается на всю оставшуюся ширину -->
             <button type="submit"
-                    class="flex-1 h-10 flex items-center justify-center gap-1.5 bg-gradient-to-r from-red-500 to-pink-500 accent-gradient text-white font-semibold text-sm rounded-xl transition-opacity hover:opacity-90 active:opacity-80 shrink-0">
+                    <?= $isPreorderSection ? 'disabled' : '' ?>
+                    class="flex-1 h-10 flex items-center justify-center gap-1.5 <?= $isPreorderSection ? 'bg-gray-100 text-gray-400 cursor-not-allowed' : 'bg-gradient-to-r from-red-500 to-pink-500 accent-gradient text-white hover:opacity-90 active:opacity-80' ?> font-semibold text-sm rounded-xl transition-opacity shrink-0">
               <span class="material-icons-round text-base leading-none">add_shopping_cart</span>
               <span class="hidden sm:inline">В корзину</span>
             </button>
@@ -223,7 +239,8 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
 
         <!-- Предзаказ — вторичное действие: outline-стиль, меньше веса -->
         <button type="button"
-                class="w-full h-9 flex items-center justify-center gap-1.5 border border-emerald-500 text-emerald-700 hover:bg-emerald-50 active:bg-emerald-100 font-medium text-xs sm:text-sm rounded-xl transition-colors preorder-intent-btn"
+                <?= $isSaleSection ? 'disabled' : '' ?>
+                class="w-full h-9 flex items-center justify-center gap-1.5 border font-medium text-xs sm:text-sm rounded-xl transition-colors preorder-intent-btn <?= $isSaleSection ? 'border-gray-200 text-gray-400 bg-gray-50 cursor-not-allowed' : 'border-emerald-500 text-emerald-700 hover:bg-emerald-50 active:bg-emerald-100' ?>"
                 data-product-id="<?= (int)$p['id'] ?>">
           <span class="material-icons-round text-base leading-none">schedule</span>
           Предзаказ −10%

--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -68,7 +68,7 @@
 
   <?php if (!empty($saleProducts)): ?>
     <section class="px-4 mb-8 mt-6">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">💥 Наши спецпредложения</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">💥 Акции</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -80,6 +80,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($saleProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'sale'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -96,7 +97,7 @@
 
   <?php if (!empty($regularProducts)): ?>
     <section class="px-4 mb-8">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🚚 Регулярные поставки</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🚚 В наличии</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -108,6 +109,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($regularProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'in_stock'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -136,6 +138,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($sellerProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'seller'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -147,7 +150,7 @@
 
   <?php if (!empty($preorderProducts)): ?>
     <section class="px-4 mb-8">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🛒 Товары под заказ</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🛒 Предварительный заказ -10%</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -159,6 +162,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($preorderProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'preorder'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -187,6 +191,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($discountProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'sale'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>

--- a/tests/ClientCatalogServiceTest.php
+++ b/tests/ClientCatalogServiceTest.php
@@ -31,7 +31,11 @@ class ClientCatalogServiceTest extends TestCase
             sale_price REAL,
             is_active INTEGER,
             image_path TEXT,
-            delivery_date TEXT NULL
+            delivery_date TEXT NULL,
+            current_purchase_batch_id INTEGER NULL,
+            free_stock_boxes REAL DEFAULT 0,
+            discount_stock_boxes REAL DEFAULT 0,
+            stock_status TEXT DEFAULT "sold_out"
         )');
         $this->pdo->exec('CREATE TABLE content_categories (id INTEGER PRIMARY KEY, alias TEXT)');
         $this->pdo->exec('CREATE TABLE materials (
@@ -49,11 +53,11 @@ class ClientCatalogServiceTest extends TestCase
         $this->pdo->exec("INSERT INTO content_categories (id, alias) VALUES (1, 'news')");
 
         $this->pdo->exec(
-            "INSERT INTO products (id, alias, product_type_id, seller_id, variety, description, origin_country, box_size, box_unit, price, sale_price, is_active, image_path, delivery_date) VALUES
-            (1, 'sale-product', 1, NULL, 'Клери', 'sale', 'KG', 1, 'кг', 1000, 800, 1, '/sale.jpg', '2025-03-25'),
-            (2, 'regular-product', 1, NULL, 'Азия', 'regular', 'KG', 1, 'кг', 900, 0, 1, '/regular.jpg', '2025-03-24'),
-            (3, 'seller-product', 1, 1, 'Seller', 'seller', 'KG', 1, 'кг', 1200, 0, 1, '/seller.jpg', '2025-03-26'),
-            (4, 'preorder-product', 1, NULL, 'Pre', 'preorder', 'KG', 1, 'кг', 1100, 0, 1, '/pre.jpg', NULL)"
+            "INSERT INTO products (id, alias, product_type_id, seller_id, variety, description, origin_country, box_size, box_unit, price, sale_price, is_active, image_path, delivery_date, current_purchase_batch_id, free_stock_boxes, discount_stock_boxes, stock_status) VALUES
+            (1, 'sale-product', 1, NULL, 'Клери', 'sale', 'KG', 1, 'кг', 1000, 800, 1, '/sale.jpg', '2025-03-25', 11, 0, 3, 'in_stock'),
+            (2, 'regular-product', 1, NULL, 'Азия', 'regular', 'KG', 1, 'кг', 900, 0, 1, '/regular.jpg', '2025-03-24', 12, 5, 0, 'in_stock'),
+            (3, 'seller-product', 1, 1, 'Seller', 'seller', 'KG', 1, 'кг', 1200, 0, 1, '/seller.jpg', '2025-03-26', NULL, 0, 0, 'sold_out'),
+            (4, 'preorder-product', 1, NULL, 'Pre', 'preorder', 'KG', 1, 'кг', 1100, 0, 1, '/pre.jpg', NULL, 13, 0, 0, 'preorder')"
         );
         $this->pdo->exec(
             "INSERT INTO materials (id, alias, category_id, title, short_desc, image_path, created_at) VALUES

--- a/tests/PurchaseBatchServiceTest.php
+++ b/tests/PurchaseBatchServiceTest.php
@@ -87,6 +87,7 @@ class PurchaseBatchServiceTest extends TestCase
         $this->assertSame(1300.0, (float)$batch['preorder_price_per_box']);
         $this->assertSame(1500.0, (float)$batch['instant_price_per_box']);
         $this->assertSame(1100.0, (float)$batch['discount_price_per_box']);
+        $this->assertSame('planned', (string)$batch['status']);
 
         $product = $this->pdo->query('SELECT * FROM products WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame((float)$batchId, (float)$product['current_purchase_batch_id']);
@@ -105,6 +106,21 @@ class PurchaseBatchServiceTest extends TestCase
             'boxes_reserved' => 4,
             'boxes_free' => 3,
             'purchase_price_per_box' => 1000,
+        ]);
+    }
+
+    public function testCreateBatchRejectsLegacyStatus(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported purchase batch status.');
+
+        $this->service->createBatch([
+            'product_id' => 1,
+            'boxes_total' => 30,
+            'boxes_reserved' => 10,
+            'boxes_free' => 10,
+            'purchase_price_per_box' => 1000,
+            'status' => 'active',
         ]);
     }
 
@@ -139,4 +155,3 @@ class PurchaseBatchServiceTest extends TestCase
     }
 
 }
-


### PR DESCRIPTION
### Motivation
- Introduce an explicit `planned` status for purchase batches and stop using legacy `active` as a default to make lifecycle states clearer.
- Limit allowed purchase batch statuses to a small controlled set to prevent invalid states from being persisted.
- Adjust catalog grouping logic and product card UI to better reflect stock, preorder and sale scenarios so listings and prices are consistent.

### Description
- Added `ALLOWED_BATCH_STATUSES` and validation in `PurchaseBatchService::createBatch` to reject unsupported statuses and replaced legacy default status with `planned` when creating a batch via `PurchaseBatchesController` and the service.
- Updated `ClientCatalogService::getHomePageData` filters to require `current_purchase_batch_id`, `discount_stock_boxes`, `free_stock_boxes` and `stock_status` for correct grouping of `sale`, `regular` and `preorder` products.
- Modified client-facing views and product card (`_card.php`, `home.php`) to accept a `cardSection` context and render preorder discounted price presentation, disable cart/preorder actions for incompatible sections, and updated wording/labels across admin purchase views.
- Updated test fixtures and tests to reflect new product columns and behavior and added a test `testCreateBatchRejectsLegacyStatus` to verify rejection of legacy `active` status.

### Testing
- Ran `ClientCatalogServiceTest` which was updated to include the new product columns and assertions for product grouping, and it succeeded.
- Ran `PurchaseBatchServiceTest` which includes batch creation, product snapshot sync and the new `testCreateBatchRejectsLegacyStatus`, and it succeeded.
- Executed the full PHPUnit suite for modified tests to validate schema and logic changes, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f48e094c832ca63f49fc3554b2f5)