### PR TITLE
Implement purchase batch lifecycle and preorder flows (planned→purchased→arrived) with admin UI and maintenance

### DIFF
--- a/docs/qa_smoke_preorder_staging.md
+++ b/docs/qa_smoke_preorder_staging.md
@@ -1,0 +1,166 @@
+# QA Smoke Run — Staging (Preorder + Purchase Batch Lifecycle)
+
+## Scope
+
+Проверить end-to-end сценарии по ТЗ:
+
+1. `planned -> purchased -> arrived`
+2. bounded offer wave
+3. confirm / decline / expire
+4. maintenance cancel for unconfirmed
+5. in-stock preorder ETA `+2 дня` / fallback `ближайшая возможная`
+
+---
+
+## Preconditions
+
+- Есть staging-база с таблицами:
+  - `purchase_batches`
+  - `preorder_intents`
+  - `preorder_intent_events`
+  - `notifications`
+- Есть роли:
+  - `admin` (или `manager` где указано)
+  - `client`
+- Создан активный товар `SKU-A` с `current_purchase_batch_id`.
+
+---
+
+## Scenario 1: `planned -> purchased -> arrived`
+
+### 1.1 Create planned batch
+
+1. Зайти под `admin` в `/admin/purchases/create`.
+2. Создать закупку для `SKU-A` со статусом `Запланирована`.
+
+**Expected**
+- В списке закупок статус отображается как `Запланирована`.
+
+### 1.2 Move to purchased
+
+1. В `/admin/purchases` нажать `Выкуплена` для созданной партии.
+
+**Expected**
+- Статус партии становится `Выкуплена`.
+- Запускается offer wave для `intent_created` (см. Scenario 2).
+
+### 1.3 Move to arrived
+
+1. В `/admin/purchases` нажать `Готова к выдаче`.
+
+**Expected**
+- Статус партии становится `Готова к выдаче`.
+- Просроченные `offer_sent` переходят в `expired`.
+- Подтвержденные `confirmed` переходят в `checkout_completed` (UI label: `Выполнен`).
+
+---
+
+## Scenario 2: bounded offer wave
+
+### Setup
+
+Создать 3 интента по `SKU-A`:
+- User1: `requested_boxes = 2`, `status = intent_created`
+- User2: `requested_boxes = 2`, `status = intent_created`
+- User3: `requested_boxes = 5`, `status = intent_created`
+
+Создать партию со `status = planned`, затем перевести в `purchased` с `boxes_free = 4`.
+
+### Expected
+
+- В `offer_sent` перейдут только интенты, которые укладываются в `boxes_free` (FIFO по `created_at`, `id`).
+- Сумма распределенных коробок не превышает `boxes_free`.
+- В `notifications` появляется запись с кодом `preorder_offer_sent`.
+
+---
+
+## Scenario 3: Confirm / Decline / Expire
+
+### 3.1 Confirm
+
+1. Клиент открывает страницу оффера `/preorder-offer/{id}`.
+2. Нажимает `Да, подтверждаю`.
+
+**Expected**
+- `offer_sent -> confirmed`
+- Возвращается `continue_url`.
+
+### 3.2 Decline
+
+1. Для другого оффера нажать `Нет, отказаться`.
+
+**Expected**
+- `offer_sent -> declined`
+- UI статус показывает `Отменен`.
+
+### 3.3 Expire
+
+1. Установить `offer_expires_at` в прошлое.
+2. Запустить maintenance (см. Scenario 4) или trigger arrived flow.
+
+**Expected**
+- `offer_sent -> expired`
+- В UI показывается `Просрочен`.
+
+---
+
+## Scenario 4: Maintenance cancel for unconfirmed
+
+### 4.1 Admin trigger
+
+1. В `/admin/purchases` нажать `Обновить статусы предзаказов`.
+
+**Expected**
+- Старые `intent_created` (старше `preorder_unconfirmed_cancel_hours`) переходят в `declined`.
+- Просроченные `offer_sent` переходят в `expired`.
+- Показывается flash: сколько `истекло` и сколько `отменено неподтвержденных`.
+- В `preorder_intent_events` появляются `auto_cancel_unconfirmed`.
+
+---
+
+## Scenario 5: In-stock preorder ETA `+2 дня`
+
+### 5.1 With source date
+
+1. На главной в секции `В наличии` нажать `Предзаказ` у карточки с `delivery_date`.
+
+**Expected**
+- В API-ответе на `/preorder-intents` есть `eta_delivery_date = source_delivery_date + 2 days`.
+- Сообщение клиенту: `Предзаказ сохранён: на DD.MM.YYYY`.
+- В `preorder_intent_events.meta_json` записаны:
+  - `source_section = in_stock`
+  - `source_delivery_date`
+  - `eta_delivery_date`
+
+### 5.2 Without source date
+
+1. Нажать `Предзаказ` для in-stock карточки без даты.
+
+**Expected**
+- ETA дата не вычисляется (`null`).
+- Сообщение клиенту: `на ближайшую возможную дату`.
+
+---
+
+## Evidence to collect (required)
+
+- Скриншоты:
+  - `/admin/purchases` (статусы до/после переходов)
+  - `/preorder-offer/{id}` (confirm/decline)
+  - главная карточка in-stock с кнопкой `Предзаказ`
+- SQL выборки:
+  - `preorder_intents` по `product_id`
+  - `preorder_intent_events` по `preorder_intent_id`
+  - `notifications` по кодам `preorder_offer_sent`, `preorder_ready_for_pickup`
+
+---
+
+## Pass criteria
+
+Smoke-run считается пройденным, если:
+
+1. Все 5 сценариев завершились ожидаемыми переходами статусов.
+2. Нет переходов, нарушающих lifecycle (`planned -> purchased -> arrived`).
+3. Нет oversell в offer wave (allocated <= free).
+4. ETA `+2 дня` корректно рассчитывается для in-stock source.
+5. События и уведомления пишутся в БД.

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -78,6 +78,10 @@ return [
         requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->markArrived(); return true;
     },
     static function (string $method, string $uri, array $c): bool {
+        if (!routeExact('POST', '/admin/purchases/purchased', $method, $uri)) return false;
+        requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->markPurchased(); return true;
+    },
+    static function (string $method, string $uri, array $c): bool {
         if (!routeExact('POST', '/admin/purchases/move-to-discount', $method, $uri)) return false;
         requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->moveToDiscount(); return true;
     },
@@ -86,8 +90,12 @@ return [
         requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->writeOff(); return true;
     },
     static function (string $method, string $uri, array $c): bool {
-        if (!routeExact('POST', '/admin/purchases/close', $method, $uri)) return false;
-        requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->close(); return true;
+        if (!routeExact('POST', '/admin/purchases/cancel-reservations', $method, $uri)) return false;
+        requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->cancelReservations(); return true;
+    },
+    static function (string $method, string $uri, array $c): bool {
+        if (!routeExact('POST', '/admin/purchases/preorders/maintenance', $method, $uri)) return false;
+        requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->maintenancePreorders(); return true;
     },
     static function (string $method, string $uri, array $c): bool {
         if (!routeExact('POST', '/admin/purchases/photos/delete', $method, $uri)) return false;

--- a/routes/manager.php
+++ b/routes/manager.php
@@ -39,10 +39,12 @@ return [
             'GET /manager/purchases' => ['App\\Controllers\\PurchaseBatchesController', 'index'],
             'GET /manager/purchases/create' => ['App\\Controllers\\PurchaseBatchesController', 'create'],
             'POST /manager/purchases/store' => ['App\\Controllers\\PurchaseBatchesController', 'store'],
+            'POST /manager/purchases/purchased' => ['App\\Controllers\\PurchaseBatchesController', 'markPurchased'],
             'POST /manager/purchases/arrived' => ['App\\Controllers\\PurchaseBatchesController', 'markArrived'],
             'POST /manager/purchases/move-to-discount' => ['App\\Controllers\\PurchaseBatchesController', 'moveToDiscount'],
+            'POST /manager/purchases/cancel-reservations' => ['App\\Controllers\\PurchaseBatchesController', 'cancelReservations'],
+            'POST /manager/purchases/preorders/maintenance' => ['App\\Controllers\\PurchaseBatchesController', 'maintenancePreorders'],
             'POST /manager/purchases/write-off' => ['App\\Controllers\\PurchaseBatchesController', 'writeOff'],
-            'POST /manager/purchases/close' => ['App\\Controllers\\PurchaseBatchesController', 'close'],
             'POST /manager/purchases/photos/delete' => ['App\\Controllers\\PurchaseBatchesController', 'deletePhoto'],
         ];
 

--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -157,6 +157,17 @@ public function cart(): void
         }
 
         if ($productId && $quantity > 0) {
+            if ($stockMode !== 'preorder') {
+                $stockService = new StockService($this->pdo);
+                $available = $stockService->getAvailableBoxes($productId, $stockMode);
+                if ($quantity > $available) {
+                    $_SESSION['cart_error'] = 'Недостаточно товара в наличии.';
+                    $referer = $_SERVER['HTTP_REFERER'] ?? '/';
+                    header('Location: ' . $referer);
+                    exit;
+                }
+            }
+
             $priceStmt = $this->pdo->prepare(
                 "SELECT price, sale_price, box_size, preorder_unit_price, instant_unit_price, discount_unit_price, current_purchase_batch_id
                  FROM products WHERE id = ?"
@@ -1225,9 +1236,13 @@ public function cancelReservedOrder(int $orderId): void
         $stmt->execute([$userId]);
         $phone = $stmt->fetchColumn();
         $tgStart = $phone ? $phone : null;
+        $notificationRows = $this->pdo->query(
+            "SELECT id, code, description FROM notifications ORDER BY id DESC"
+        )->fetchAll(PDO::FETCH_ASSOC);
         view('client/notifications', [
             'userName' => $_SESSION['name'] ?? null,
             'tgStart'  => $tgStart,
+            'notifications' => $notificationRows,
         ]);
     }
 
@@ -1374,6 +1389,8 @@ public function cancelReservedOrder(int $orderId): void
         $userId = (int)($_SESSION['user_id'] ?? 0);
         $productId = (int)($_POST['product_id'] ?? 0);
         $requestedBoxes = round((float)($_POST['requested_boxes'] ?? 0), 2);
+        $sourceSection = trim((string)($_POST['source_section'] ?? ''));
+        $sourceDeliveryDate = trim((string)($_POST['source_delivery_date'] ?? ''));
 
         if ($userId <= 0 || $productId <= 0 || $requestedBoxes <= 0) {
             http_response_code(422);
@@ -1397,18 +1414,44 @@ public function cancelReservedOrder(int $orderId): void
         $existingStmt->execute([$userId, $productId]);
         $existingId = $existingStmt->fetchColumn();
 
+        $etaDateValue = null;
+        if ($sourceSection === 'in_stock' && $sourceDeliveryDate !== '') {
+            $ts = strtotime($sourceDeliveryDate);
+            if ($ts !== false) {
+                $etaDateValue = date('Y-m-d', strtotime('+2 day', $ts));
+            }
+        }
+
         if ($existingId) {
             $this->pdo->prepare(
                 "UPDATE preorder_intents SET requested_boxes = ?, status = 'intent_created', offered_price_per_box = NULL, offer_expires_at = NULL, checkout_token = NULL WHERE id = ?"
             )->execute([$requestedBoxes, (int)$existingId]);
             $intentId = (int)$existingId;
-            $this->logPreorderEvent($intentId, 'intent_updated', null, 'intent_created', ['requested_boxes' => $requestedBoxes]);
+            $this->logPreorderEvent($intentId, 'intent_updated', null, 'intent_created', [
+                'requested_boxes' => $requestedBoxes,
+                'source_section' => $sourceSection,
+                'source_delivery_date' => $sourceDeliveryDate,
+                'eta_delivery_date' => $etaDateValue,
+            ]);
         } else {
             $this->pdo->prepare(
                 "INSERT INTO preorder_intents (user_id, product_id, requested_boxes, status, created_at, updated_at) VALUES (?, ?, ?, 'intent_created', NOW(), NOW())"
             )->execute([$userId, $productId, $requestedBoxes]);
             $intentId = (int)$this->pdo->lastInsertId();
-            $this->logPreorderEvent($intentId, 'intent_created', null, 'intent_created', ['requested_boxes' => $requestedBoxes]);
+            $this->logPreorderEvent($intentId, 'intent_created', null, 'intent_created', [
+                'requested_boxes' => $requestedBoxes,
+                'source_section' => $sourceSection,
+                'source_delivery_date' => $sourceDeliveryDate,
+                'eta_delivery_date' => $etaDateValue,
+            ]);
+        }
+
+        $etaText = 'на ближайшую возможную дату';
+        if ($sourceSection === 'in_stock' && $sourceDeliveryDate !== '') {
+            $ts = strtotime($sourceDeliveryDate);
+            if ($ts !== false) {
+                $etaText = 'на ' . date('d.m.Y', strtotime('+2 day', $ts));
+            }
         }
 
         header('Content-Type: application/json; charset=utf-8');
@@ -1416,7 +1459,9 @@ public function cancelReservedOrder(int $orderId): void
             'ok' => true,
             'intent_id' => $intentId,
             'status' => 'intent_created',
-            'message' => 'Предзаказ сохранён. Мы уведомим вас после поступления партии.',
+            'status_label' => $this->preorderIntentStatusLabel('intent_created'),
+            'eta_delivery_date' => $etaDateValue,
+            'message' => 'Предзаказ сохранён: ' . $etaText . '. Мы уведомим вас после поступления партии.',
         ], JSON_UNESCAPED_UNICODE);
     }
 
@@ -1463,6 +1508,7 @@ public function cancelReservedOrder(int $orderId): void
         echo json_encode([
             'ok' => true,
             'status' => 'confirmed',
+            'status_label' => $this->preorderIntentStatusLabel('confirmed'),
             'continue_url' => '/preorder/continue/' . $token,
         ], JSON_UNESCAPED_UNICODE);
     }
@@ -1494,7 +1540,11 @@ public function cancelReservedOrder(int $orderId): void
         $this->logPreorderEvent($intentId, 'offer_declined', 'offer_sent', 'declined');
 
         header('Content-Type: application/json; charset=utf-8');
-        echo json_encode(['ok' => true, 'status' => 'declined'], JSON_UNESCAPED_UNICODE);
+        echo json_encode([
+            'ok' => true,
+            'status' => 'declined',
+            'status_label' => $this->preorderIntentStatusLabel('declined'),
+        ], JSON_UNESCAPED_UNICODE);
     }
 
     public function continuePreorderCheckout(string $token): void
@@ -1541,7 +1591,21 @@ public function cancelReservedOrder(int $orderId): void
             echo 'Оффер не найден';
             return;
         }
+        $offer['status_label'] = $this->preorderIntentStatusLabel((string)($offer['status'] ?? ''));
         view('client/preorder_offer', ['offer' => $offer]);
+    }
+
+    private function preorderIntentStatusLabel(string $status): string
+    {
+        return match ($status) {
+            'intent_created' => 'Новый',
+            'offer_sent' => 'Ожидает подтверждения',
+            'confirmed' => 'Подтвержден',
+            'checkout_completed' => 'Выполнен',
+            'declined' => 'Отменен',
+            'expired' => 'Просрочен',
+            default => $status,
+        };
     }
 
     private function logPreorderEvent(int $intentId, string $eventType, ?string $fromStatus, ?string $toStatus, ?array $meta = null): void

--- a/src/Controllers/PurchaseBatchesController.php
+++ b/src/Controllers/PurchaseBatchesController.php
@@ -2,6 +2,7 @@
 namespace App\Controllers;
 
 use App\Services\PurchaseBatchService;
+use App\Services\PreorderIntentService;
 use PDO;
 use RuntimeException;
 
@@ -9,11 +10,13 @@ class PurchaseBatchesController
 {
     private PDO $pdo;
     private PurchaseBatchService $purchaseBatchService;
+    private PreorderIntentService $preorderIntentService;
 
     public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
         $this->purchaseBatchService = new PurchaseBatchService($pdo);
+        $this->preorderIntentService = new PreorderIntentService($pdo);
     }
 
     public function index(): void
@@ -214,8 +217,8 @@ ORDER BY pb.id DESC';
             'boxes_free' => (float)($_POST['boxes_free'] ?? 0),
             'purchase_price_per_box' => (float)($_POST['purchase_price_per_box'] ?? 0),
             'extra_cost_per_box' => (float)($_POST['extra_cost_per_box'] ?? 0),
-            'status' => (string)($_POST['status'] ?? 'purchased'),
-            'purchased_at' => (string)($_POST['purchased_at'] ?? ''),
+            'status' => (string)($_POST['status'] ?? 'planned'),
+            'purchased_at' => (string)($_POST['planned_supply_date'] ?? ''),
             'comment' => trim((string)($_POST['comment'] ?? '')),
         ];
 
@@ -238,8 +241,33 @@ ORDER BY pb.id DESC';
         $this->ensureCsrfOrRedirect();
         $batchId = (int)($_POST['batch_id'] ?? 0);
         if ($batchId > 0) {
-            $this->purchaseBatchService->markArrived($batchId);
-            $this->setFlash('success', 'Партия отмечена как поступившая.');
+            try {
+                $this->purchaseBatchService->markArrived($batchId);
+                $movedBoxes = 0.0;
+                if (isset($_POST['move_leftovers_to_discount'])) {
+                    $movedBoxes = $this->purchaseBatchService->moveAllFreeToDiscountStock($batchId);
+                }
+                $suffix = $movedBoxes > 0 ? ' Остаток в уценку: ' . number_format($movedBoxes, 2, '.', ' ') . ' ящ.' : '';
+                $this->setFlash('success', 'Партия отмечена как готовая к выдаче.' . $suffix);
+            } catch (RuntimeException $e) {
+                $this->setFlash('error', $e->getMessage());
+            }
+        }
+        header('Location: ' . $this->basePath() . '/purchases');
+        exit;
+    }
+
+    public function markPurchased(): void
+    {
+        $this->ensureCsrfOrRedirect();
+        $batchId = (int)($_POST['batch_id'] ?? 0);
+        if ($batchId > 0) {
+            try {
+                $this->purchaseBatchService->markPurchased($batchId);
+                $this->setFlash('success', 'Партия отмечена как выкупленная.');
+            } catch (RuntimeException $e) {
+                $this->setFlash('error', $e->getMessage());
+            }
         }
         header('Location: ' . $this->basePath() . '/purchases');
         exit;
@@ -248,9 +276,20 @@ ORDER BY pb.id DESC';
     public function moveToDiscount(): void
     {
         $this->ensureCsrfOrRedirect();
+        if (($_SESSION['role'] ?? '') !== 'admin') {
+            $this->setFlash('error', 'Операция доступна только администратору.');
+            header('Location: ' . $this->basePath() . '/purchases');
+            exit;
+        }
         $batchId = (int)($_POST['batch_id'] ?? 0);
         $boxes = (float)($_POST['boxes'] ?? 0);
+        $reason = trim((string)($_POST['reason'] ?? ''));
         if ($batchId > 0 && $boxes > 0) {
+            if ($reason === '') {
+                $this->setFlash('error', 'Укажите причину перевода в уценку.');
+                header('Location: ' . $this->basePath() . '/purchases');
+                exit;
+            }
             $this->purchaseBatchService->moveToDiscountStock($batchId, $boxes);
             $this->setFlash('success', 'Часть партии переведена в выгодный остаток.');
         }
@@ -258,27 +297,47 @@ ORDER BY pb.id DESC';
         exit;
     }
 
+    public function cancelReservations(): void
+    {
+        $this->ensureCsrfOrRedirect();
+        $batchId = (int)($_POST['batch_id'] ?? 0);
+        if ($batchId > 0) {
+            try {
+                $count = $this->purchaseBatchService->cancelPendingReservations($batchId);
+                $this->setFlash('success', 'Отменено броней: ' . $count);
+            } catch (RuntimeException $e) {
+                $this->setFlash('error', $e->getMessage());
+            }
+        }
+        header('Location: ' . $this->basePath() . '/purchases');
+        exit;
+    }
+
+    public function maintenancePreorders(): void
+    {
+        $this->ensureCsrfOrRedirect();
+        $ttlHours = max(1, (int)(get_setting('preorder_unconfirmed_cancel_hours', '48') ?? '48'));
+        $expired = $this->preorderIntentService->expireOffers();
+        $cancelled = $this->preorderIntentService->cancelUnconfirmedByDeadline($ttlHours);
+        $this->setFlash('success', 'Обновлено предзаказов: истекло ' . $expired . ', отменено неподтвержденных ' . $cancelled . '.');
+        header('Location: ' . $this->basePath() . '/purchases');
+        exit;
+    }
+
     public function writeOff(): void
     {
         $this->ensureCsrfOrRedirect();
+        if (($_SESSION['role'] ?? '') !== 'admin') {
+            $this->setFlash('error', 'Операция доступна только администратору.');
+            header('Location: ' . $this->basePath() . '/purchases');
+            exit;
+        }
         $batchId = (int)($_POST['batch_id'] ?? 0);
         $boxes = (float)($_POST['boxes'] ?? 0);
         $comment = trim((string)($_POST['comment'] ?? 'Write-off'));
         if ($batchId > 0 && $boxes > 0) {
             $this->purchaseBatchService->writeOff($batchId, $boxes, $comment);
             $this->setFlash('success', 'Списание выполнено.');
-        }
-        header('Location: ' . $this->basePath() . '/purchases');
-        exit;
-    }
-
-    public function close(): void
-    {
-        $this->ensureCsrfOrRedirect();
-        $batchId = (int)($_POST['batch_id'] ?? 0);
-        if ($batchId > 0) {
-            $this->purchaseBatchService->closeBatch($batchId);
-            $this->setFlash('success', 'Партия закрыта.');
         }
         header('Location: ' . $this->basePath() . '/purchases');
         exit;

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -25,6 +25,15 @@ class SettingsController
     // Сохранение
     public function save(): void
     {
+        $discount = isset($_POST['ui_preorder_discount_percent']) ? (float)$_POST['ui_preorder_discount_percent'] : 10.0;
+        $_POST['ui_preorder_discount_percent'] = (string)max(0.0, min(99.0, $discount));
+
+        $hint = trim((string)($_POST['ui_preorder_price_hint'] ?? ''));
+        if ($hint === '') {
+            $hint = 'Цена ориентировочная, точная цена будет после поступления';
+        }
+        $_POST['ui_preorder_price_hint'] = $hint;
+
         foreach ($_POST as $key => $value) {
             $stmt = $this->pdo->prepare(
               "REPLACE INTO settings (setting_key, setting_value) VALUES (?, ?)"

--- a/src/Services/ClientCatalogService.php
+++ b/src/Services/ClientCatalogService.php
@@ -5,6 +5,14 @@ use PDO;
 
 class ClientCatalogService
 {
+    private const HOME_SALE_WHERE = "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL
+                 AND pb.status = 'arrived' AND p.discount_stock_boxes > 0";
+    private const HOME_IN_STOCK_WHERE = "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL
+                 AND p.seller_id IS NULL AND pb.status = 'purchased'
+                 AND p.free_stock_boxes > 0";
+    private const HOME_PREORDER_WHERE = "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL
+                 AND p.seller_id IS NULL AND pb.status = 'planned'";
+
     private PDO $pdo;
 
     public function __construct(PDO $pdo)
@@ -19,13 +27,13 @@ class ClientCatalogService
     {
         return [
             'saleProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.sale_price > 0',
+                self::HOME_SALE_WHERE,
                 'p.id DESC',
                 [],
                 10
             ),
             'regularProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.delivery_date IS NOT NULL AND p.seller_id IS NULL',
+                self::HOME_IN_STOCK_WHERE,
                 'p.id DESC',
                 [],
                 10
@@ -37,7 +45,7 @@ class ClientCatalogService
                 10
             ),
             'preorderProducts' => $this->fetchProducts(
-                'p.is_active = 1 AND p.delivery_date IS NULL AND p.seller_id IS NULL',
+                self::HOME_PREORDER_WHERE,
                 'p.id DESC',
                 [],
                 10
@@ -106,6 +114,7 @@ class ClientCatalogService
             "FROM products p\n" .
             "JOIN product_types t ON t.id = p.product_type_id\n" .
             "LEFT JOIN users u ON u.id = p.seller_id\n" .
+            "LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id\n" .
             "WHERE {$where}\n" .
             "ORDER BY {$orderBy}";
 

--- a/src/Services/PreorderIntentService.php
+++ b/src/Services/PreorderIntentService.php
@@ -97,6 +97,32 @@ class PreorderIntentService
         return $affected;
     }
 
+    public function cancelUnconfirmedByDeadline(int $ttlHours = 48): int
+    {
+        $ttlHours = max(1, $ttlHours);
+        $idsStmt = $this->pdo->prepare(
+            "SELECT id
+             FROM preorder_intents
+             WHERE status = 'intent_created'
+               AND created_at < DATE_SUB(CURRENT_TIMESTAMP, INTERVAL ? HOUR)"
+        );
+        $idsStmt->execute([$ttlHours]);
+        $ids = $idsStmt->fetchAll(PDO::FETCH_COLUMN);
+
+        $stmt = $this->pdo->prepare(
+            "UPDATE preorder_intents
+             SET status = 'declined', updated_at = CURRENT_TIMESTAMP
+             WHERE status = 'intent_created'
+               AND created_at < DATE_SUB(CURRENT_TIMESTAMP, INTERVAL ? HOUR)"
+        );
+        $stmt->execute([$ttlHours]);
+        $affected = $stmt->rowCount();
+        foreach ($ids as $id) {
+            $this->logEvent((int)$id, 'auto_cancel_unconfirmed', 'intent_created', 'declined');
+        }
+        return $affected;
+    }
+
     /** @return array{offered_count:int,allocated_boxes:float} */
     public function reallocateForProduct(int $productId, float $freedBoxes, float $pricePerBox, int $ttlHours = 4): array
     {

--- a/src/Services/PurchaseBatchService.php
+++ b/src/Services/PurchaseBatchService.php
@@ -7,13 +7,24 @@ use Throwable;
 
 class PurchaseBatchService
 {
+    private const ALLOWED_BATCH_STATUSES = ['planned', 'purchased', 'arrived'];
+    private const ALLOWED_STATUS_TRANSITIONS = [
+        'planned' => ['purchased'],
+        'purchased' => ['arrived'],
+        'arrived' => [],
+    ];
+
     private PDO $pdo;
     private PricingService $pricingService;
+    private StockService $stockService;
+    private PreorderIntentService $preorderIntentService;
 
     public function __construct(PDO $pdo, ?PricingService $pricingService = null)
     {
         $this->pdo = $pdo;
         $this->pricingService = $pricingService ?? new PricingService($pdo);
+        $this->stockService = new StockService($pdo);
+        $this->preorderIntentService = new PreorderIntentService($pdo);
     }
 
     /**
@@ -30,6 +41,7 @@ class PurchaseBatchService
         $buyerUserId = isset($data['buyer_user_id']) ? (int)$data['buyer_user_id'] : null;
         $comment = isset($data['comment']) ? (string)$data['comment'] : null;
         $purchasedAt = trim((string)($data['purchased_at'] ?? ''));
+        $status = (string)($data['status'] ?? 'planned');
 
         if ($productId <= 0) {
             throw new RuntimeException('Invalid product_id for purchase batch.');
@@ -42,6 +54,9 @@ class PurchaseBatchService
         }
         if (($boxesFree + $boxesReserved) > $boxesTotal) {
             throw new RuntimeException('Allocated boxes exceed boxes_total.');
+        }
+        if (!in_array($status, self::ALLOWED_BATCH_STATUSES, true)) {
+            throw new RuntimeException('Unsupported purchase batch status.');
         }
 
         $product = $this->loadProduct($productId);
@@ -129,7 +144,7 @@ class PurchaseBatchService
                 'preorder_unit_price' => $prices['preorder_unit_price'],
                 'instant_unit_price' => $prices['instant_unit_price'],
                 'discount_unit_price' => $prices['discount_unit_price'],
-                'status' => (string)($data['status'] ?? 'purchased'),
+                'status' => $status,
                 'purchased_at' => $purchasedAt !== '' ? $purchasedAt : date('Y-m-d'),
                 'comment' => $comment,
             ]);
@@ -204,6 +219,13 @@ class PurchaseBatchService
     public function markArrived(int $batchId): void
     {
         $this->updateBatchStatus($batchId, 'arrived');
+        $this->processIntentsForArrivedBatch($batchId);
+    }
+
+    public function markPurchased(int $batchId): void
+    {
+        $this->updateBatchStatus($batchId, 'purchased');
+        $this->promoteIntentsToOfferSent($batchId);
     }
 
     public function moveToDiscountStock(int $batchId, float $boxes): void
@@ -224,6 +246,18 @@ class PurchaseBatchService
              WHERE id = :id'
         );
         $stmt->execute(['boxes' => $boxes, 'id' => $batchId]);
+    }
+
+    public function moveAllFreeToDiscountStock(int $batchId): float
+    {
+        $batch = $this->loadBatch($batchId);
+        $boxes = (float)($batch['boxes_free'] ?? 0);
+        if ($boxes <= 0) {
+            return 0.0;
+        }
+
+        $this->moveToDiscountStock($batchId, $boxes);
+        return $boxes;
     }
 
     public function writeOff(int $batchId, float $boxes, string $comment): void
@@ -250,6 +284,49 @@ class PurchaseBatchService
     public function closeBatch(int $batchId): void
     {
         $this->updateBatchStatus($batchId, 'closed');
+    }
+
+    public function cancelPendingReservations(int $batchId): int
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT oi.order_id, oi.product_id, oi.purchase_batch_id, oi.boxes, oi.stock_mode
+             FROM order_items oi
+             JOIN orders o ON o.id = oi.order_id
+             WHERE oi.purchase_batch_id = ?
+               AND oi.stock_mode = 'preorder'
+               AND o.status = 'reserved'"
+        );
+        $stmt->execute([$batchId]);
+        $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        if ($items === []) {
+            return 0;
+        }
+
+        $affectedOrderIds = [];
+        foreach ($items as $item) {
+            $orderId = (int)$item['order_id'];
+            $productId = (int)$item['product_id'];
+            $itemBatchId = (int)$item['purchase_batch_id'];
+            $boxes = (float)$item['boxes'];
+            if ($boxes <= 0 || $itemBatchId <= 0 || $productId <= 0 || $orderId <= 0) {
+                continue;
+            }
+
+            $this->stockService->unreserve($productId, $itemBatchId, $boxes, $orderId, 'preorder');
+            $affectedOrderIds[$orderId] = true;
+        }
+
+        if ($affectedOrderIds === []) {
+            return 0;
+        }
+
+        $ids = array_keys($affectedOrderIds);
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $params = array_merge(['cancelled'], $ids);
+        $upd = $this->pdo->prepare("UPDATE orders SET status = ?, updated_at = NOW() WHERE id IN ({$placeholders}) AND status = 'reserved'");
+        $upd->execute($params);
+
+        return count($ids);
     }
 
     /**
@@ -312,6 +389,24 @@ class PurchaseBatchService
 
     private function updateBatchStatus(int $batchId, string $status): void
     {
+        if (!in_array($status, self::ALLOWED_BATCH_STATUSES, true)) {
+            throw new RuntimeException('Unsupported purchase batch status.');
+        }
+
+        $batch = $this->loadBatch($batchId);
+        $currentStatus = (string)($batch['status'] ?? '');
+        if (!isset(self::ALLOWED_STATUS_TRANSITIONS[$currentStatus])) {
+            throw new RuntimeException('Current purchase batch status is unsupported.');
+        }
+
+        if ($currentStatus === $status) {
+            return;
+        }
+
+        if (!in_array($status, self::ALLOWED_STATUS_TRANSITIONS[$currentStatus], true)) {
+            throw new RuntimeException('Invalid purchase batch status transition.');
+        }
+
         $stmt = $this->pdo->prepare('UPDATE purchase_batches SET status = ? WHERE id = ?');
         $stmt->execute([$status, $batchId]);
     }
@@ -353,5 +448,89 @@ class PurchaseBatchService
             'stock_status' => $stockStatus,
             'product_id' => $productId,
         ]);
+    }
+
+    private function promoteIntentsToOfferSent(int $batchId): void
+    {
+        $batch = $this->loadBatch($batchId);
+        $productId = (int)($batch['product_id'] ?? 0);
+        if ($productId <= 0) {
+            return;
+        }
+
+        $offerHours = max(1, (int)($this->pricingService->getSettings()['preorder_offer_expiration_hours'] ?? 48));
+        $availableBoxes = max(0.0, (float)($batch['boxes_free'] ?? 0));
+        $pricePerBox = max(0.0, (float)($batch['preorder_price_per_box'] ?? 0));
+        if ($availableBoxes <= 0 || $pricePerBox <= 0) {
+            return;
+        }
+
+        $wave = $this->preorderIntentService->allocateOfferWave(
+            $productId,
+            $availableBoxes,
+            $pricePerBox,
+            $offerHours
+        );
+
+        if (($wave['offered_count'] ?? 0) > 0) {
+            $this->pdo->prepare(
+                "INSERT INTO notifications (code, description)
+                 VALUES (?, ?)"
+            )->execute([
+                'preorder_offer_sent',
+                'По товару #' . $productId . ' отправлены офферы предзаказа: ' . (int)$wave['offered_count'],
+            ]);
+        }
+    }
+
+    private function processIntentsForArrivedBatch(int $batchId): void
+    {
+        $batch = $this->loadBatch($batchId);
+        $productId = (int)($batch['product_id'] ?? 0);
+        if ($productId <= 0) {
+            return;
+        }
+
+        $this->pdo->prepare(
+            "UPDATE preorder_intents
+             SET status = 'expired', updated_at = NOW()
+             WHERE product_id = ?
+               AND status = 'offer_sent'
+               AND offer_expires_at IS NOT NULL
+               AND offer_expires_at < NOW()"
+        )->execute([$productId]);
+
+        $readyIdsStmt = $this->pdo->prepare(
+            "SELECT id FROM preorder_intents
+             WHERE product_id = ?
+               AND status = 'confirmed'"
+        );
+        $readyIdsStmt->execute([$productId]);
+        $readyIds = $readyIdsStmt->fetchAll(PDO::FETCH_COLUMN);
+        if ($readyIds !== []) {
+            $this->pdo->prepare(
+                "UPDATE preorder_intents
+                 SET status = 'checkout_completed',
+                     updated_at = NOW()
+                 WHERE product_id = ?
+                   AND status = 'confirmed'"
+            )->execute([$productId]);
+
+            $eventStmt = $this->pdo->prepare(
+                "INSERT INTO preorder_intent_events (preorder_intent_id, event_type, from_status, to_status, meta_json, created_at)
+                 VALUES (?, 'ready_for_pickup', 'confirmed', 'checkout_completed', NULL, NOW())"
+            );
+            foreach ($readyIds as $intentId) {
+                $eventStmt->execute([(int)$intentId]);
+            }
+
+            $this->pdo->prepare(
+                "INSERT INTO notifications (code, description)
+                 VALUES (?, ?)"
+            )->execute([
+                'preorder_ready_for_pickup',
+                'По товару #' . $productId . ' предзаказов готово к выдаче: ' . count($readyIds),
+            ]);
+        }
     }
 }

--- a/src/Views/admin/purchases/create.php
+++ b/src/Views/admin/purchases/create.php
@@ -2,9 +2,9 @@
 <?php $basePath = $basePath ?? '/admin'; ?>
 <?php $flash = $flash ?? null; ?>
 <?php $statusLabels = [
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
+  'planned' => 'Запланирована',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 <form action="<?= $basePath ?>/purchases/store" method="post" enctype="multipart/form-data" class="bg-white p-6 rounded shadow max-w-2xl mx-auto space-y-4">
   <?= csrf_field() ?>
@@ -27,8 +27,8 @@
 
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <label class="block mb-1">Дата закупки</label>
-      <input name="purchased_at" type="date" class="w-full border px-2 py-1 rounded" value="<?= date('Y-m-d') ?>" required>
+      <label class="block mb-1">Плановая дата поставки</label>
+      <input name="planned_supply_date" type="date" class="w-full border px-2 py-1 rounded" value="<?= date('Y-m-d') ?>">
     </div>
     <div>
       <label class="block mb-1">Количество ящиков</label>
@@ -53,9 +53,9 @@
     <div>
       <label class="block mb-1">Статус</label>
       <select name="status" class="w-full border px-2 py-1 rounded">
+        <option value="planned"><?= $statusLabels['planned'] ?></option>
         <option value="purchased"><?= $statusLabels['purchased'] ?></option>
         <option value="arrived"><?= $statusLabels['arrived'] ?></option>
-        <option value="active"><?= $statusLabels['active'] ?></option>
       </select>
     </div>
   </div>

--- a/src/Views/admin/purchases/index.php
+++ b/src/Views/admin/purchases/index.php
@@ -6,12 +6,8 @@
 <?php $summary = $summary ?? []; ?>
 <?php $statusLabels = [
   'planned' => 'Запланирована',
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
-  'sold_out' => 'Распродана',
-  'closed' => 'Закрыта',
-  'cancelled' => 'Отменена',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 <?php if (is_array($flash) && !empty($flash['message'])): ?>
   <div class="<?= ($flash['type'] ?? '') === 'error' ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700' ?> border p-3 rounded mb-4">
@@ -30,7 +26,7 @@
     <label class="text-xs text-gray-600">Статус</label>
     <select name="status" class="w-full border rounded px-2 py-2 text-sm">
       <option value="">Все</option>
-      <?php foreach (['planned','purchased','arrived','active','sold_out','closed','cancelled'] as $st): ?>
+      <?php foreach (['planned','purchased','arrived'] as $st): ?>
         <option value="<?= $st ?>" <?= (($filters['status'] ?? '') === $st) ? 'selected' : '' ?>><?= htmlspecialchars((string)($statusLabels[$st] ?? $st)) ?></option>
       <?php endforeach; ?>
     </select>
@@ -54,6 +50,10 @@
   <a href="<?= $basePath ?>/purchases/create" class="bg-[#C86052] text-white px-4 py-2 rounded inline-flex items-center">
     <span class="material-icons-round text-base mr-1">add</span> Добавить закупку
   </a>
+  <form method="post" action="<?= $basePath ?>/purchases/preorders/maintenance" class="ml-2">
+    <?= csrf_field() ?>
+    <button class="bg-gray-100 text-gray-700 px-3 py-2 rounded text-sm" type="submit">Обновить статусы предзаказов</button>
+  </form>
 </div>
 
 <table class="min-w-full bg-white rounded shadow overflow-hidden">
@@ -88,29 +88,46 @@
         <td class="p-3">
           <div class="flex flex-wrap gap-2">
             <a class="text-xs bg-green-100 px-2 py-1 rounded" href="<?= $basePath ?>/purchases/<?= (int)$batch['id'] ?>">Открыть</a>
-            <form method="post" action="<?= $basePath ?>/purchases/arrived">
+            <?php if (($batch['status'] ?? '') === 'planned'): ?>
+              <form method="post" action="<?= $basePath ?>/purchases/purchased">
+                <?= csrf_field() ?>
+                <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
+                <button class="text-xs bg-indigo-100 px-2 py-1 rounded" type="submit">Выкуплена</button>
+              </form>
+            <?php elseif (($batch['status'] ?? '') === 'purchased'): ?>
+              <form method="post" action="<?= $basePath ?>/purchases/arrived">
+                <?= csrf_field() ?>
+                <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
+                <label class="inline-flex items-center gap-1 text-[11px] text-gray-600 mr-1">
+                  <input type="checkbox" name="move_leftovers_to_discount" value="1">
+                  В уценку
+                </label>
+                <button class="text-xs bg-blue-100 px-2 py-1 rounded" type="submit">Готова к выдаче</button>
+              </form>
+            <?php endif; ?>
+            <?php if (($_SESSION['role'] ?? '') === 'admin'): ?>
+              <form method="post" action="<?= $basePath ?>/purchases/move-to-discount" class="flex items-center gap-1">
+                <?= csrf_field() ?>
+                <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
+                <input name="boxes" type="number" step="0.01" min="0.01" placeholder="ящ." class="w-16 border rounded px-1 py-1 text-xs">
+                <input name="reason" type="text" required placeholder="причина" class="w-24 border rounded px-1 py-1 text-xs">
+                <button class="text-xs bg-yellow-100 px-2 py-1 rounded" type="submit">Уценить</button>
+              </form>
+            <?php endif; ?>
+            <form method="post" action="<?= $basePath ?>/purchases/cancel-reservations">
               <?= csrf_field() ?>
               <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
-              <button class="text-xs bg-blue-100 px-2 py-1 rounded" type="submit">Поступила</button>
+              <button class="text-xs bg-orange-100 px-2 py-1 rounded" type="submit">Отменить бронь</button>
             </form>
-            <form method="post" action="<?= $basePath ?>/purchases/move-to-discount" class="flex items-center gap-1">
-              <?= csrf_field() ?>
-              <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
-              <input name="boxes" type="number" step="0.01" min="0.01" placeholder="ящ." class="w-16 border rounded px-1 py-1 text-xs">
-              <button class="text-xs bg-yellow-100 px-2 py-1 rounded" type="submit">Уценить</button>
-            </form>
-            <form method="post" action="<?= $basePath ?>/purchases/write-off" class="flex items-center gap-1">
-              <?= csrf_field() ?>
-              <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
-              <input name="boxes" type="number" step="0.01" min="0.01" placeholder="ящ." class="w-16 border rounded px-1 py-1 text-xs">
-              <input name="comment" type="text" placeholder="комм." class="w-24 border rounded px-1 py-1 text-xs">
-              <button class="text-xs bg-red-100 px-2 py-1 rounded" type="submit">Списать</button>
-            </form>
-            <form method="post" action="<?= $basePath ?>/purchases/close">
-              <?= csrf_field() ?>
-              <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
-              <button class="text-xs bg-gray-100 px-2 py-1 rounded" type="submit">Закрыть</button>
-            </form>
+            <?php if (($_SESSION['role'] ?? '') === 'admin'): ?>
+              <form method="post" action="<?= $basePath ?>/purchases/write-off" class="flex items-center gap-1">
+                <?= csrf_field() ?>
+                <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
+                <input name="boxes" type="number" step="0.01" min="0.01" placeholder="ящ." class="w-16 border rounded px-1 py-1 text-xs">
+                <input name="comment" type="text" required placeholder="причина" class="w-24 border rounded px-1 py-1 text-xs">
+                <button class="text-xs bg-red-100 px-2 py-1 rounded" type="submit">Списать</button>
+              </form>
+            <?php endif; ?>
           </div>
         </td>
       </tr>

--- a/src/Views/admin/purchases/show.php
+++ b/src/Views/admin/purchases/show.php
@@ -5,12 +5,8 @@
 <?php $flash = $flash ?? null; ?>
 <?php $statusLabels = [
   'planned' => 'Запланирована',
-  'purchased' => 'Закуплена',
-  'arrived' => 'Поступила',
-  'active' => 'В продаже',
-  'sold_out' => 'Распродана',
-  'closed' => 'Закрыта',
-  'cancelled' => 'Отменена',
+  'purchased' => 'Выкуплена',
+  'arrived' => 'Готова к выдаче',
 ]; ?>
 
 <div class="mb-4">

--- a/src/Views/admin/settings.php
+++ b/src/Views/admin/settings.php
@@ -16,6 +16,21 @@ $themeColors = $themeColors ?? [];
            value="<?= htmlspecialchars($settings['contact_phone'] ?? '') ?>"
            class="w-full border px-2 py-1 rounded">
   </div>
+  <fieldset class="border border-gray-200 rounded-lg p-4 space-y-3">
+    <legend class="px-2 text-sm font-semibold text-gray-600">Предзаказ (витрина)</legend>
+    <div>
+      <label class="block mb-1">Скидка предзаказа, %</label>
+      <input name="ui_preorder_discount_percent" type="number" min="0" max="99" step="0.1"
+             value="<?= htmlspecialchars($settings['ui_preorder_discount_percent'] ?? '10') ?>"
+             class="w-full border px-2 py-1 rounded">
+    </div>
+    <div>
+      <label class="block mb-1">Подсказка о цене</label>
+      <input name="ui_preorder_price_hint" type="text"
+             value="<?= htmlspecialchars($settings['ui_preorder_price_hint'] ?? 'Цена ориентировочная, точная цена будет после поступления') ?>"
+             class="w-full border px-2 py-1 rounded">
+    </div>
+  </fieldset>
   <?php if (!empty($themeColors)): ?>
     <fieldset class="border border-gray-200 rounded-lg p-4 space-y-3">
       <legend class="px-2 text-sm font-semibold text-gray-600">Цветовая тема</legend>

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -40,6 +40,15 @@ $hidePriceForPreorder = (!$showDate && $isRegularViewer);
 $basePath = $role === 'manager' ? '/manager' : '/admin';
 $regularKg  = round($price, 2);
 $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strtotime((string)$p['latest_purchase_date'])) : '';
+$cardSection = (string)($cardSection ?? '');
+$isPreorderSection = $cardSection === 'preorder';
+$isSaleSection = $cardSection === 'sale';
+$isInStockSection = $cardSection === 'in_stock';
+$preorderDiscountPercent = (float)(get_setting('ui_preorder_discount_percent', '10') ?? '10');
+$preorderDiscountPercent = max(0.0, min(99.0, $preorderDiscountPercent));
+$discountFactor = (100 - $preorderDiscountPercent) / 100;
+$preorderDiscountBox = round($regularBox * $discountFactor, 0);
+$preorderPriceHint = (string)(get_setting('ui_preorder_price_hint', 'Цена ориентировочная, точная цена будет после поступления') ?? '');
 ?>
 <div class="product-card bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col hover:shadow-2xl transition-shadow duration-200 sm:h-full max-w-[350px]"
      data-search="<?= htmlspecialchars($search) ?>"
@@ -136,6 +145,17 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
       <?php if ($hidePriceForPreorder): ?>
         <p class="text-base font-semibold text-gray-400 mb-3">Цена уточняется</p>
 
+      <?php elseif ($isPreorderSection): ?>
+        <div class="flex items-end gap-2 mb-1">
+          <span class="text-base text-gray-400 line-through leading-none pb-0.5">
+            <?= number_format($regularBox, 0, '.', ' ') ?> ₽
+          </span>
+          <span class="text-xl sm:text-2xl font-bold text-gray-900 box-price leading-none">
+            <?= number_format($preorderDiscountBox, 0, '.', ' ') ?> ₽
+          </span>
+        </div>
+        <p class="text-[10px] leading-tight text-red-500 mb-3"><?= htmlspecialchars($preorderPriceHint) ?></p>
+
       <?php elseif ($sale > 0): ?>
         <!-- Акционная цена -->
         <div class="flex items-end gap-2 mb-1">
@@ -214,7 +234,8 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
 
             <!-- Кнопка «В корзину» — растягивается на всю оставшуюся ширину -->
             <button type="submit"
-                    class="flex-1 h-10 flex items-center justify-center gap-1.5 bg-gradient-to-r from-red-500 to-pink-500 accent-gradient text-white font-semibold text-sm rounded-xl transition-opacity hover:opacity-90 active:opacity-80 shrink-0">
+                    <?= $isPreorderSection ? 'disabled' : '' ?>
+                    class="flex-1 h-10 flex items-center justify-center gap-1.5 <?= $isPreorderSection ? 'bg-gray-100 text-gray-400 cursor-not-allowed' : 'bg-gradient-to-r from-red-500 to-pink-500 accent-gradient text-white hover:opacity-90 active:opacity-80' ?> font-semibold text-sm rounded-xl transition-opacity shrink-0">
               <span class="material-icons-round text-base leading-none">add_shopping_cart</span>
               <span class="hidden sm:inline">В корзину</span>
             </button>
@@ -223,14 +244,19 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
 
         <!-- Предзаказ — вторичное действие: outline-стиль, меньше веса -->
         <button type="button"
-                class="w-full h-9 flex items-center justify-center gap-1.5 border border-emerald-500 text-emerald-700 hover:bg-emerald-50 active:bg-emerald-100 font-medium text-xs sm:text-sm rounded-xl transition-colors preorder-intent-btn"
-                data-product-id="<?= (int)$p['id'] ?>">
+                <?= $isSaleSection ? 'disabled' : '' ?>
+                class="w-full h-9 flex items-center justify-center gap-1.5 border font-medium text-xs sm:text-sm rounded-xl transition-colors preorder-intent-btn <?= $isSaleSection ? 'border-gray-200 text-gray-400 bg-gray-50 cursor-not-allowed' : 'border-emerald-500 text-emerald-700 hover:bg-emerald-50 active:bg-emerald-100' ?>"
+                data-product-id="<?= (int)$p['id'] ?>"
+                data-source-section="<?= htmlspecialchars($cardSection) ?>"
+                data-delivery-date="<?= htmlspecialchars((string)($d ?? '')) ?>">
           <span class="material-icons-round text-base leading-none">schedule</span>
-          Предзаказ −10%
+          <?= $isInStockSection ? 'Предзаказ' : 'Предзаказ −10%' ?>
         </button>
 
         <?php if ($preorderPurchaseDate !== ''): ?>
           <p class="mt-1.5 text-[11px] text-gray-400 text-center">Дата закупки: <?= htmlspecialchars($preorderPurchaseDate) ?></p>
+        <?php elseif ($isInStockSection): ?>
+          <p class="mt-1.5 text-[11px] text-gray-400 text-center">Предзаказ оформляется на ближайшую возможную дату</p>
         <?php endif; ?>
 
         <p class="mt-1.5 text-[11px] text-gray-400 hidden preorder-intent-hint"></p>
@@ -269,6 +295,8 @@ $preorderPurchaseDate = !empty($p['latest_purchase_date']) ? date('d.m.Y', strto
       const payload = new URLSearchParams();
       payload.set('product_id', btn.dataset.productId || '0');
       payload.set('requested_boxes', String(qty > 0 ? qty : 1));
+      payload.set('source_section', btn.dataset.sourceSection || '');
+      payload.set('source_delivery_date', btn.dataset.deliveryDate || '');
       const res = await fetch('/preorder-intents', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},

--- a/src/Views/client/home.php
+++ b/src/Views/client/home.php
@@ -68,7 +68,7 @@
 
   <?php if (!empty($saleProducts)): ?>
     <section class="px-4 mb-8 mt-6">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">💥 Наши спецпредложения</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">💥 Акции</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -80,6 +80,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($saleProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'sale'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -96,7 +97,7 @@
 
   <?php if (!empty($regularProducts)): ?>
     <section class="px-4 mb-8">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🚚 Регулярные поставки</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🚚 В наличии</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -108,6 +109,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($regularProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'in_stock'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -136,6 +138,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($sellerProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'seller'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -147,7 +150,7 @@
 
   <?php if (!empty($preorderProducts)): ?>
     <section class="px-4 mb-8">
-      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🛒 Товары под заказ</h2>
+      <h2 class="text-xl md:text-2xl font-bold text-gray-800 mb-4">🛒 Предварительный заказ -10%</h2>
       <div class="embla drag-free has-arrows relative">
         <button data-dir="left" class="hidden md:flex items-center justify-center w-8 h-8 absolute left-0 top-1/2 -translate-y-1/2 bg-white shadow rounded-full z-10 hover:bg-gray-100">
           <span class="material-icons-round text-gray-600">chevron_left</span>
@@ -159,6 +162,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($preorderProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'preorder'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>
@@ -187,6 +191,7 @@
           <div class="embla__container space-x-4 pb-2 no-scrollbar eq-row">
             <?php foreach ($discountProducts as $p): ?>
               <div class="embla__slide flex-none w-[64vw] sm:w-1/2 md:w-1/3">
+                <?php $cardSection = 'sale'; ?>
                 <?php include __DIR__ . '/_card.php'; ?>
               </div>
             <?php endforeach; ?>

--- a/src/Views/client/notifications.php
+++ b/src/Views/client/notifications.php
@@ -1,5 +1,6 @@
 <?php /** @var string|null $userName */ ?>
 <?php /** @var string|null $tgStart */ ?>
+<?php /** @var array<int,array<string,mixed>> $notifications */ ?>
 <main class="bg-gradient-to-br from-orange-50 via-white to-pink-50 min-h-screen pb-24">
   <div class="px-4 pt-6 space-y-6">
     <a href="https://t.me/YagodgoBot<?= $tgStart ? '?start=' . $tgStart : '' ?>" class="flex items-center justify-center space-x-2 bg-blue-500 text-white rounded-2xl py-3 shadow-lg hover:bg-blue-600 transition">
@@ -10,26 +11,85 @@
       После перехода нажмите <strong>Start</strong> в Telegram.
     </p>
 
-    <div class="bg-white rounded-3xl shadow divide-y divide-gray-100">
-      <?php
-        $items = [
-          'Уведомления об изменении статуса моих заказов',
-          'Сообщения об акциях и спецпредложениях',
-          'Информационные сообщения',
-          'Поступление клубники',
-          'Поступление черешни',
-          'Поступление ежевики'
-        ];
-      ?>
-      <?php foreach ($items as $label): ?>
-        <div class="flex items-center justify-between p-4">
-          <span class="text-gray-800 text-sm flex-1 pr-3"><?= $label ?></span>
-          <label class="relative inline-flex items-center cursor-pointer">
-            <input type="checkbox" class="sr-only peer">
-            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-red-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red-600"></div>
-          </label>
-        </div>
-      <?php endforeach; ?>
+    <button type="button"
+            data-open-notify-settings
+            class="w-full bg-white border border-gray-200 rounded-2xl py-3 text-gray-800 font-semibold shadow-sm hover:bg-gray-50 transition">
+      Настройка уведомлений
+    </button>
+
+    <section class="bg-white rounded-3xl shadow divide-y divide-gray-100 overflow-hidden">
+      <div class="px-4 py-3 bg-gray-50">
+        <h2 class="text-sm font-semibold text-gray-700">Уведомления от приложения</h2>
+      </div>
+      <?php if (!empty($notifications)): ?>
+        <?php foreach ($notifications as $n): ?>
+          <div class="p-4">
+            <p class="text-sm font-medium text-gray-800"><?= htmlspecialchars((string)($n['description'] ?? 'Уведомление')) ?></p>
+            <?php if (!empty($n['code'])): ?>
+              <p class="text-xs text-gray-400 mt-1">Код: <?= htmlspecialchars((string)$n['code']) ?></p>
+            <?php endif; ?>
+          </div>
+        <?php endforeach; ?>
+      <?php else: ?>
+        <div class="p-4 text-sm text-gray-500">Пока нет новых уведомлений.</div>
+      <?php endif; ?>
+    </section>
+  </div>
+
+  <div data-notify-modal class="fixed inset-0 bg-black/40 z-50 hidden items-end sm:items-center justify-center">
+    <div class="bg-white w-full sm:max-w-xl sm:rounded-2xl rounded-t-2xl p-4 sm:p-6 max-h-[85vh] overflow-y-auto">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-base sm:text-lg font-semibold text-gray-800">Настройка уведомлений</h3>
+        <button type="button" data-close-notify-settings class="text-gray-500 hover:text-gray-700">
+          <span class="material-icons-round">close</span>
+        </button>
+      </div>
+
+      <div class="bg-white rounded-2xl border divide-y divide-gray-100">
+        <?php
+          $items = [
+            'Уведомления об изменении статуса моих заказов',
+            'Сообщения об акциях и спецпредложениях',
+            'Информационные сообщения',
+            'Поступление клубники',
+            'Поступление черешни',
+            'Поступление ежевики'
+          ];
+        ?>
+        <?php foreach ($items as $label): ?>
+          <div class="flex items-center justify-between p-4">
+            <span class="text-gray-800 text-sm flex-1 pr-3"><?= $label ?></span>
+            <label class="relative inline-flex items-center cursor-pointer">
+              <input type="checkbox" class="sr-only peer">
+              <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-red-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red-600"></div>
+            </label>
+          </div>
+        <?php endforeach; ?>
+      </div>
     </div>
   </div>
 </main>
+
+<script>
+  (() => {
+    const openBtn = document.querySelector('[data-open-notify-settings]');
+    const closeBtn = document.querySelector('[data-close-notify-settings]');
+    const modal = document.querySelector('[data-notify-modal]');
+    if (!openBtn || !closeBtn || !modal) return;
+
+    const open = () => {
+      modal.classList.remove('hidden');
+      modal.classList.add('flex');
+    };
+    const close = () => {
+      modal.classList.add('hidden');
+      modal.classList.remove('flex');
+    };
+
+    openBtn.addEventListener('click', open);
+    closeBtn.addEventListener('click', close);
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) close();
+    });
+  })();
+</script>

--- a/src/Views/client/preorder_offer.php
+++ b/src/Views/client/preorder_offer.php
@@ -31,7 +31,7 @@
           document.getElementById('offerDeclineBtn')?.addEventListener('click', () => postOffer('decline'));
         </script>
       <?php else: ?>
-        <div class="p-3 rounded-xl bg-gray-100 text-gray-700 text-sm">Статус оффера: <?= htmlspecialchars((string)$offer['status']) ?></div>
+        <div class="p-3 rounded-xl bg-gray-100 text-gray-700 text-sm">Статус оффера: <?= htmlspecialchars((string)($offer['status_label'] ?? $offer['status'])) ?></div>
       <?php endif; ?>
 
       <a href="/catalog/<?= urlencode((string)$offer['type_alias']) ?>/<?= urlencode((string)$offer['product_alias']) ?>" class="inline-block text-red-600">Вернуться к товару</a>

--- a/tests/ClientCatalogServiceTest.php
+++ b/tests/ClientCatalogServiceTest.php
@@ -31,7 +31,11 @@ class ClientCatalogServiceTest extends TestCase
             sale_price REAL,
             is_active INTEGER,
             image_path TEXT,
-            delivery_date TEXT NULL
+            delivery_date TEXT NULL,
+            current_purchase_batch_id INTEGER NULL,
+            free_stock_boxes REAL DEFAULT 0,
+            discount_stock_boxes REAL DEFAULT 0,
+            stock_status TEXT DEFAULT "sold_out"
         )');
         $this->pdo->exec('CREATE TABLE content_categories (id INTEGER PRIMARY KEY, alias TEXT)');
         $this->pdo->exec('CREATE TABLE materials (
@@ -49,11 +53,11 @@ class ClientCatalogServiceTest extends TestCase
         $this->pdo->exec("INSERT INTO content_categories (id, alias) VALUES (1, 'news')");
 
         $this->pdo->exec(
-            "INSERT INTO products (id, alias, product_type_id, seller_id, variety, description, origin_country, box_size, box_unit, price, sale_price, is_active, image_path, delivery_date) VALUES
-            (1, 'sale-product', 1, NULL, 'Клери', 'sale', 'KG', 1, 'кг', 1000, 800, 1, '/sale.jpg', '2025-03-25'),
-            (2, 'regular-product', 1, NULL, 'Азия', 'regular', 'KG', 1, 'кг', 900, 0, 1, '/regular.jpg', '2025-03-24'),
-            (3, 'seller-product', 1, 1, 'Seller', 'seller', 'KG', 1, 'кг', 1200, 0, 1, '/seller.jpg', '2025-03-26'),
-            (4, 'preorder-product', 1, NULL, 'Pre', 'preorder', 'KG', 1, 'кг', 1100, 0, 1, '/pre.jpg', NULL)"
+            "INSERT INTO products (id, alias, product_type_id, seller_id, variety, description, origin_country, box_size, box_unit, price, sale_price, is_active, image_path, delivery_date, current_purchase_batch_id, free_stock_boxes, discount_stock_boxes, stock_status) VALUES
+            (1, 'sale-product', 1, NULL, 'Клери', 'sale', 'KG', 1, 'кг', 1000, 800, 1, '/sale.jpg', '2025-03-25', 11, 0, 3, 'in_stock'),
+            (2, 'regular-product', 1, NULL, 'Азия', 'regular', 'KG', 1, 'кг', 900, 0, 1, '/regular.jpg', '2025-03-24', 12, 5, 0, 'in_stock'),
+            (3, 'seller-product', 1, 1, 'Seller', 'seller', 'KG', 1, 'кг', 1200, 0, 1, '/seller.jpg', '2025-03-26', NULL, 0, 0, 'sold_out'),
+            (4, 'preorder-product', 1, NULL, 'Pre', 'preorder', 'KG', 1, 'кг', 1100, 0, 1, '/pre.jpg', NULL, 13, 0, 0, 'preorder')"
         );
         $this->pdo->exec(
             "INSERT INTO materials (id, alias, category_id, title, short_desc, image_path, created_at) VALUES

--- a/tests/PurchaseBatchServiceTest.php
+++ b/tests/PurchaseBatchServiceTest.php
@@ -59,6 +59,56 @@ class PurchaseBatchServiceTest extends TestCase
             status TEXT,
             comment TEXT
         )');
+        $this->pdo->exec('CREATE TABLE orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            status TEXT,
+            updated_at TEXT
+        )');
+        $this->pdo->exec('CREATE TABLE order_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            order_id INTEGER,
+            product_id INTEGER,
+            purchase_batch_id INTEGER,
+            boxes REAL DEFAULT 0,
+            stock_mode TEXT DEFAULT "instant"
+        )');
+        $this->pdo->exec('CREATE TABLE stock_movements (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            purchase_batch_id INTEGER,
+            product_id INTEGER,
+            order_id INTEGER NULL,
+            user_id INTEGER NULL,
+            movement_type TEXT,
+            stock_mode TEXT,
+            boxes_delta REAL,
+            comment TEXT NULL
+        )');
+        $this->pdo->exec('CREATE TABLE preorder_intents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            product_id INTEGER,
+            requested_boxes REAL,
+            status TEXT,
+            offered_price_per_box REAL NULL,
+            offer_expires_at TEXT NULL,
+            checkout_token TEXT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+        $this->pdo->exec('CREATE TABLE preorder_intent_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            preorder_intent_id INTEGER,
+            event_type TEXT,
+            from_status TEXT NULL,
+            to_status TEXT NULL,
+            meta_json TEXT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+        $this->pdo->exec('CREATE TABLE notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT,
+            description TEXT
+        )');
 
         $this->pdo->exec("INSERT INTO products (id, box_size, box_unit, price) VALUES (1, 2.0, 'кг', 0)");
 
@@ -87,6 +137,7 @@ class PurchaseBatchServiceTest extends TestCase
         $this->assertSame(1300.0, (float)$batch['preorder_price_per_box']);
         $this->assertSame(1500.0, (float)$batch['instant_price_per_box']);
         $this->assertSame(1100.0, (float)$batch['discount_price_per_box']);
+        $this->assertSame('planned', (string)$batch['status']);
 
         $product = $this->pdo->query('SELECT * FROM products WHERE id = 1')->fetch(PDO::FETCH_ASSOC);
         $this->assertSame((float)$batchId, (float)$product['current_purchase_batch_id']);
@@ -105,6 +156,21 @@ class PurchaseBatchServiceTest extends TestCase
             'boxes_reserved' => 4,
             'boxes_free' => 3,
             'purchase_price_per_box' => 1000,
+        ]);
+    }
+
+    public function testCreateBatchRejectsLegacyStatus(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported purchase batch status.');
+
+        $this->service->createBatch([
+            'product_id' => 1,
+            'boxes_total' => 30,
+            'boxes_reserved' => 10,
+            'boxes_free' => 10,
+            'purchase_price_per_box' => 1000,
+            'status' => 'active',
         ]);
     }
 
@@ -138,5 +204,120 @@ class PurchaseBatchServiceTest extends TestCase
         $this->assertSame(20400.0, $pnl['inventory_value_remaining']);
     }
 
-}
+    public function testMarkArrivedRequiresPurchasedStatus(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_batches (
+            id, product_id, box_size_snapshot, box_unit_snapshot, boxes_total, boxes_reserved, boxes_free, boxes_remaining,
+            purchase_price_per_box, extra_cost_per_box, cost_price_per_box, preorder_margin_percent, instant_margin_percent,
+            discount_markup_fixed, preorder_price_per_box, instant_price_per_box, discount_price_per_box,
+            preorder_unit_price, instant_unit_price, discount_unit_price, status
+        ) VALUES (
+            200, 1, 2.0, 'кг', 10, 0, 10, 10,
+            1000, 0, 1000, 30, 50,
+            100, 1300, 1500, 1100,
+            650, 750, 550, 'planned'
+        )");
 
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid purchase batch status transition.');
+        $this->service->markArrived(200);
+    }
+
+    public function testCancelPendingReservationsCancelsOrdersAndReturnsStock(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_batches (
+            id, product_id, box_size_snapshot, box_unit_snapshot, boxes_total, boxes_reserved, boxes_free, boxes_remaining,
+            purchase_price_per_box, extra_cost_per_box, cost_price_per_box, preorder_margin_percent, instant_margin_percent,
+            discount_markup_fixed, preorder_price_per_box, instant_price_per_box, discount_price_per_box,
+            preorder_unit_price, instant_unit_price, discount_unit_price, status
+        ) VALUES (
+            300, 1, 2.0, 'кг', 20, 5, 2, 20,
+            1000, 0, 1000, 30, 50,
+            100, 1300, 1500, 1100,
+            650, 750, 550, 'purchased'
+        )");
+        $this->pdo->exec("INSERT INTO orders (id, status) VALUES (10, 'reserved')");
+        $this->pdo->exec("INSERT INTO order_items (order_id, product_id, purchase_batch_id, boxes, stock_mode) VALUES (10, 1, 300, 2, 'preorder')");
+
+        $affected = $this->service->cancelPendingReservations(300);
+        $this->assertSame(1, $affected);
+
+        $orderStatus = $this->pdo->query("SELECT status FROM orders WHERE id = 10")->fetchColumn();
+        $this->assertSame('cancelled', $orderStatus);
+
+        $batch = $this->pdo->query("SELECT boxes_reserved, boxes_free FROM purchase_batches WHERE id = 300")->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(3.0, (float)$batch['boxes_reserved']);
+        $this->assertSame(4.0, (float)$batch['boxes_free']);
+    }
+
+    public function testMarkPurchasedRequiresPlannedStatus(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_batches (
+            id, product_id, box_size_snapshot, box_unit_snapshot, boxes_total, boxes_reserved, boxes_free, boxes_remaining,
+            purchase_price_per_box, extra_cost_per_box, cost_price_per_box, preorder_margin_percent, instant_margin_percent,
+            discount_markup_fixed, preorder_price_per_box, instant_price_per_box, discount_price_per_box,
+            preorder_unit_price, instant_unit_price, discount_unit_price, status
+        ) VALUES (
+            400, 1, 2.0, 'кг', 10, 0, 10, 10,
+            1000, 0, 1000, 30, 50,
+            100, 1300, 1500, 1100,
+            650, 750, 550, 'arrived'
+        )");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid purchase batch status transition.');
+        $this->service->markPurchased(400);
+    }
+
+    public function testMoveAllFreeToDiscountStockMovesEntireFreeBalance(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_batches (
+            id, product_id, box_size_snapshot, box_unit_snapshot, boxes_total, boxes_reserved, boxes_free, boxes_remaining,
+            purchase_price_per_box, extra_cost_per_box, cost_price_per_box, preorder_margin_percent, instant_margin_percent,
+            discount_markup_fixed, preorder_price_per_box, instant_price_per_box, discount_price_per_box,
+            preorder_unit_price, instant_unit_price, discount_unit_price, boxes_discount, status
+        ) VALUES (
+            401, 1, 2.0, 'кг', 10, 0, 3, 10,
+            1000, 0, 1000, 30, 50,
+            100, 1300, 1500, 1100,
+            650, 750, 550, 1, 'purchased'
+        )");
+
+        $moved = $this->service->moveAllFreeToDiscountStock(401);
+        $this->assertSame(3.0, $moved);
+
+        $batch = $this->pdo->query("SELECT boxes_free, boxes_discount FROM purchase_batches WHERE id = 401")->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(0.0, (float)$batch['boxes_free']);
+        $this->assertSame(4.0, (float)$batch['boxes_discount']);
+    }
+
+    public function testHappyPathTransitionsFromPlannedToArrivedAndUpdatesIntents(): void
+    {
+        $batchId = $this->service->createBatch([
+            'product_id' => 1,
+            'boxes_total' => 20,
+            'boxes_reserved' => 0,
+            'boxes_free' => 6,
+            'purchase_price_per_box' => 1000,
+            'status' => 'planned',
+        ]);
+
+        $this->pdo->exec("INSERT INTO preorder_intents (user_id, product_id, requested_boxes, status) VALUES
+            (101, 1, 2, 'intent_created'),
+            (102, 1, 2, 'intent_created'),
+            (103, 1, 1, 'confirmed')
+        ");
+
+        $this->service->markPurchased($batchId);
+        $afterPurchased = $this->pdo->query("SELECT status FROM preorder_intents WHERE product_id = 1 ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['offer_sent', 'offer_sent', 'confirmed'], $afterPurchased);
+
+        $this->service->markArrived($batchId);
+        $afterArrived = $this->pdo->query("SELECT status FROM preorder_intents WHERE product_id = 1 ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['offer_sent', 'offer_sent', 'checkout_completed'], $afterArrived);
+
+        $batchStatus = $this->pdo->query("SELECT status FROM purchase_batches WHERE id = " . (int)$batchId)->fetchColumn();
+        $this->assertSame('arrived', $batchStatus);
+    }
+
+}


### PR DESCRIPTION
### Motivation

- Introduce a full purchase batch lifecycle and end-to-end preorder handling so admin/manager can create planned batches, mark them purchased/arrived, notify clients and handle offer waves and unconfirmed expirations. 
- Provide client-facing preorder UX improvements: in-stock ETA (+2 days), preorder pricing hint/discount and clearer status labels. 

### Description

- Routes: added admin/manager endpoints for `purchases/purchased`, `purchases/cancel-reservations` and `purchases/preorders/maintenance` and wired them to controller actions. 
- PurchaseBatchService: added allowed statuses/transitions, support for `planned` default, `markPurchased`/`markArrived` flows, promotion of intents to `offer_sent`, processing of confirmed intents into `checkout_completed`, moving free boxes to discount, cancelling pending preorder reservations, and related DB notifications/events. 
- PreorderIntentService: added `cancelUnconfirmedByDeadline` to auto-cancel old intents and reused `expireOffers` for expiring offers. 
- ClientController: added availability checks for non-preorder adds-to-cart, exposed notifications list, implemented `createPreorderIntent` accepting `source_section` and `source_delivery_date`, computing `eta_delivery_date` (+2 days for in-stock source), returning `eta_delivery_date` and `status_label`; added `preorderIntentStatusLabel` helper and added status labels to confirm/decline/offer views. 
- Views/UI: updated admin purchases pages to support planned/purchased/arrived flow and new actions (purchase, arrived with optional leftovers→discount, cancel reservations, write-off, maintenance button); added settings UI for preorder discount and hint; updated client home & card components to show preorder section variants, apply preorder discount UI, pass source section and dates to POST for intents, and added notifications UI/modal listing DB notifications. 
- SettingsController: clamp/normalize `ui_preorder_discount_percent` and provide default `ui_preorder_price_hint` on save. 
- Tests: updated/extended unit tests for `ClientCatalogService` and `PurchaseBatchService` to cover new columns, statuses, transitions and behaviors (offer waves, cancellation, discounts and lifecycle transitions). 

### Testing

- Ran unit tests in `tests/ClientCatalogServiceTest.php` which were updated to reflect new product fields and grouping; tests passed. 
- Ran unit tests in `tests/PurchaseBatchServiceTest.php` which were extended with coverage for batch creation (`planned`), invalid legacy status rejection, status transition guards, `cancelPendingReservations`, `moveAllFreeToDiscountStock`, and end-to-end transition `planned -> purchased -> arrived` affecting preorder intents; tests passed. 
- Ran the full PHPUnit suite locally; all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f48e094c832ca63f49fc3554b2f5)