### PR TITLE
Fix HY093 error during purchase batch write-off

### DIFF
--- a/src/Services/PurchaseBatchService.php
+++ b/src/Services/PurchaseBatchService.php
@@ -241,11 +241,11 @@ class PurchaseBatchService
 
         $stmt = $this->pdo->prepare(
             'UPDATE purchase_batches
-             SET boxes_free = boxes_free - :boxes,
-                 boxes_discount = boxes_discount + :boxes
+             SET boxes_free = boxes_free - :boxes_decrease,
+                 boxes_discount = boxes_discount + :boxes_increase
              WHERE id = :id'
         );
-        $stmt->execute(['boxes' => $boxes, 'id' => $batchId]);
+        $stmt->execute(['boxes_decrease' => $boxes, 'boxes_increase' => $boxes, 'id' => $batchId]);
     }
 
     public function moveAllFreeToDiscountStock(int $batchId): float
@@ -273,12 +273,17 @@ class PurchaseBatchService
 
         $stmt = $this->pdo->prepare(
             'UPDATE purchase_batches
-             SET boxes_written_off = boxes_written_off + :boxes,
-                 boxes_remaining = boxes_remaining - :boxes,
+             SET boxes_written_off = boxes_written_off + :boxes_written_off,
+                 boxes_remaining = boxes_remaining - :boxes_remaining,
                  comment = :comment
              WHERE id = :id'
         );
-        $stmt->execute(['boxes' => $boxes, 'comment' => $comment, 'id' => $batchId]);
+        $stmt->execute([
+            'boxes_written_off' => $boxes,
+            'boxes_remaining' => $boxes,
+            'comment' => $comment,
+            'id' => $batchId,
+        ]);
     }
 
     public function closeBatch(int $batchId): void


### PR DESCRIPTION
### Motivation
- SQL update statements reused the same named placeholder multiple times which caused `PDOException: SQLSTATE[HY093]: Invalid parameter number` during write-off operations. 
- The same placeholder reuse pattern existed in the free→discount stock transfer and could cause the same PDO error there.

### Description
- In `writeOff()` replaced the single `:boxes` placeholder with `:boxes_written_off` and `:boxes_remaining` and adjusted the bound parameters accordingly. 
- In `moveToDiscountStock()` replaced the single `:boxes` placeholder with `:boxes_decrease` and `:boxes_increase` and adjusted the bound parameters accordingly. 
- Updated the parameter arrays passed to `PDOStatement::execute()` to match the new placeholder names.

### Testing
- Ran `php -l src/Services/PurchaseBatchService.php` and it reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b07f2f9e8832cb97af23d48d02018)