### PR TITLE
Fix fatal redeclaration in PurchaseBatchService

### DIFF
--- a/src/Services/PurchaseBatchService.php
+++ b/src/Services/PurchaseBatchService.php
@@ -260,18 +260,6 @@ class PurchaseBatchService
         return $boxes;
     }
 
-    public function moveAllFreeToDiscountStock(int $batchId): float
-    {
-        $batch = $this->loadBatch($batchId);
-        $boxes = (float)($batch['boxes_free'] ?? 0);
-        if ($boxes <= 0) {
-            return 0.0;
-        }
-
-        $this->moveToDiscountStock($batchId, $boxes);
-        return $boxes;
-    }
-
     public function writeOff(int $batchId, float $boxes, string $comment): void
     {
         if ($boxes <= 0) {


### PR DESCRIPTION
### Motivation
- Remove a duplicated method declaration that caused a fatal `Cannot redeclare` error on the `/admin/purchases` endpoint.

### Description
- Deleted the duplicate `public function moveAllFreeToDiscountStock(int $batchId): float` implementation in `src/Services/PurchaseBatchService.php` so the method is defined only once.

### Testing
- Ran `php -l src/Services/PurchaseBatchService.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0c32b27c832ca18c60453077e1ba)