### PR TITLE
Move purchase-specific prices and delivery dates to purchase_batches and update cart/admin flows

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -169,8 +169,12 @@ public function cart(): void
             }
 
             $priceStmt = $this->pdo->prepare(
-                "SELECT price, sale_price, box_size, preorder_unit_price, instant_unit_price, discount_unit_price, current_purchase_batch_id
-                 FROM products WHERE id = ?"
+                "SELECT p.price, p.sale_price, p.box_size, p.preorder_unit_price, p.instant_unit_price, p.discount_unit_price,
+                        p.current_purchase_batch_id,
+                        pb.preorder_price_per_box, pb.instant_price_per_box, pb.discount_price_per_box
+                 FROM products p
+                 LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id
+                 WHERE p.id = ? LIMIT 1"
             );
             $priceStmt->execute([$productId]);
             $row = $priceStmt->fetch(PDO::FETCH_ASSOC);
@@ -178,21 +182,38 @@ public function cart(): void
             $purchaseBatchId = null;
             if ($row) {
                 $boxSize = (float)($row['box_size'] ?? 0);
-                $sale    = (float)($row['sale_price'] ?? 0); // per kg
-                $regular = (float)($row['price'] ?? 0);      // per kg
+                $sale = (float)($row['sale_price'] ?? 0);
+                $regular = (float)($row['price'] ?? 0);
                 $fallbackKgPrice = $sale > 0 ? $sale : $regular;
-                $kgPrice = match ($stockMode) {
-                    'preorder' => (float)($row['preorder_unit_price'] ?? 0),
-                    'discount_stock' => (float)($row['discount_unit_price'] ?? 0),
-                    default => (float)($row['instant_unit_price'] ?? 0),
+                $fallbackBoxPrice = $fallbackKgPrice * $boxSize;
+
+                $priceBox = match ($stockMode) {
+                    'preorder' => (float)($row['preorder_price_per_box'] ?? 0),
+                    'discount_stock' => (float)($row['discount_price_per_box'] ?? 0),
+                    default => (float)($row['instant_price_per_box'] ?? 0),
                 };
-                if ($kgPrice <= 0) {
-                    $kgPrice = $fallbackKgPrice;
+                if ($priceBox <= 0) {
+                    $kgPrice = match ($stockMode) {
+                        'preorder' => (float)($row['preorder_unit_price'] ?? 0),
+                        'discount_stock' => (float)($row['discount_unit_price'] ?? 0),
+                        default => (float)($row['instant_unit_price'] ?? 0),
+                    };
+                    if ($kgPrice > 0 && $boxSize > 0) {
+                        $priceBox = $kgPrice * $boxSize;
+                    } else {
+                        $priceBox = $fallbackBoxPrice;
+                    }
                 }
-                $priceBox = $kgPrice * $boxSize;
                 if ($stockMode !== 'preorder') {
                     $purchaseBatchId = isset($row['current_purchase_batch_id']) ? (int)$row['current_purchase_batch_id'] : null;
                 }
+            }
+
+            if ($stockMode !== 'preorder' && $purchaseBatchId === null) {
+                $_SESSION['cart_error'] = 'Для этого товара сейчас нет активной закупки.';
+                $referer = $_SERVER['HTTP_REFERER'] ?? '/';
+                header('Location: ' . $referer);
+                exit;
             }
 
             $modeCheckStmt = $this->pdo->prepare(
@@ -1304,9 +1325,12 @@ public function cancelReservedOrder(int $orderId): void
 
     public function showProduct(string $alias, ?string $typeAlias = null): void
     {
-        $query = "SELECT p.*, t.name AS product, t.alias AS type_alias
+        $query = "SELECT p.*, t.name AS product, t.alias AS type_alias,
+                         COALESCE(pb.instant_unit_price, p.price) AS price,
+                         DATE(pb.purchased_at) AS delivery_date
                   FROM products p
                   JOIN product_types t ON t.id = p.product_type_id
+                  LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id
                   WHERE (p.alias = ? OR p.id = ?)";
         $params = [$alias, $alias];
         if ($typeAlias !== null) {
@@ -1352,7 +1376,7 @@ public function cancelReservedOrder(int $orderId): void
         }
 
         $pStmt = $this->pdo->prepare(
-            "SELECT p.id, p.alias, t.name AS product, t.alias AS type_alias, p.variety, p.description, p.origin_country, p.box_size, p.box_unit, p.price, p.sale_price, p.is_active, p.image_path, p.delivery_date,
+            "SELECT p.id, p.alias, t.name AS product, t.alias AS type_alias, p.variety, p.description, p.origin_country, p.box_size, p.box_unit, COALESCE(pb_latest.instant_unit_price, p.price) AS price, p.sale_price, p.is_active, p.image_path, DATE(pb_latest.purchased_at) AS delivery_date,
                     COALESCE(u.company_name,u.name,'berryGo') AS seller_name,
                     pb_latest.purchased_at AS latest_purchase_date
              FROM products p

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -69,13 +69,14 @@ class ProductsController
                 p.box_size,
                 p.box_unit,
                 p.unit,
-                p.price,
+                COALESCE(pb.purchase_price_per_box, p.price) AS price,
                 p.stock_boxes,
                 p.is_active,
                 p.image_path,
-                p.delivery_date
+                DATE(pb.purchased_at) AS delivery_date
              FROM products p
-             JOIN product_types t ON t.id = p.product_type_id";
+             JOIN product_types t ON t.id = p.product_type_id
+             LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id";
 
         if ($role === 'seller') {
             $selectedSeller = $_SESSION['user_id'] ?? 0;
@@ -364,22 +365,18 @@ class ProductsController
         exit;
     }
 
-    // Обновление цены за кг
+    // Обновление закупочной цены активной закупки
     public function updatePrice(): void
     {
         $id = (int)($_POST['id'] ?? 0);
         $raw = trim($_POST['price'] ?? '');
         if ($id && $raw !== '') {
             $price = (float)$raw;
-            $role = $_SESSION['role'] ?? '';
-            $params = [$price, $id];
-            $sql = "UPDATE products SET price = ? WHERE id = ?";
-            if ($role === 'seller') {
-                $sql .= " AND seller_id = ?";
-                $params[] = $_SESSION['user_id'] ?? 0;
+            $batchId = $this->resolveCurrentPurchaseBatchId($id);
+            if ($batchId !== null) {
+                $stmt = $this->pdo->prepare("UPDATE purchase_batches SET purchase_price_per_box = ? WHERE id = ?");
+                $stmt->execute([$price, $batchId]);
             }
-            $stmt = $this->pdo->prepare($sql);
-            $stmt->execute($params);
         }
         // Redirect back to the page where the price was updated.
         // If the "Referer" header is available, return to that page
@@ -397,25 +394,21 @@ class ProductsController
         exit;
     }
 
-    // Обновление даты поставки товара
+    // Обновление даты закупки активной закупки
     public function updateDeliveryDate(): void
     {
         $id = (int)($_POST['id'] ?? 0);
         $raw = trim($_POST['delivery_date'] ?? '');
         $date = $raw !== '' ? $raw : null;
-        if ($id) {
-            $role = $_SESSION['role'] ?? '';
-            $params = [$date, $id];
-            $sql = "UPDATE products SET delivery_date = ? WHERE id = ?";
-            if ($role === 'seller') {
-                $sql .= " AND seller_id = ?";
-                $params[] = $_SESSION['user_id'] ?? 0;
-            }
-            $stmt = $this->pdo->prepare($sql);
-            $stmt->execute($params);
-            $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
-            if ($date !== null && $date !== '' && $date !== $placeholder) {
-                $this->activateReservedOrdersByProduct($id, $date);
+        if ($id && $date !== null) {
+            $batchId = $this->resolveCurrentPurchaseBatchId($id);
+            if ($batchId !== null) {
+                $stmt = $this->pdo->prepare("UPDATE purchase_batches SET purchased_at = ? WHERE id = ?");
+                $stmt->execute([$date . ' 00:00:00', $batchId]);
+                $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
+                if ($date !== '' && $date !== $placeholder) {
+                    $this->activateReservedOrdersByProduct($id, $date);
+                }
             }
         }
         // Determine where to redirect after updating
@@ -434,6 +427,24 @@ class ProductsController
 
         header('Location: ' . $base);
         exit;
+    }
+
+
+    private function resolveCurrentPurchaseBatchId(int $productId): ?int
+    {
+        $role = $_SESSION['role'] ?? '';
+        $params = [$productId];
+        $sql = "SELECT current_purchase_batch_id FROM products WHERE id = ?";
+        if ($role === 'seller') {
+            $sql .= " AND seller_id = ?";
+            $params[] = (int)($_SESSION['user_id'] ?? 0);
+        }
+
+        $stmt = $this->pdo->prepare($sql . " LIMIT 1");
+        $stmt->execute($params);
+        $batchId = $stmt->fetchColumn();
+
+        return $batchId !== false && $batchId !== null ? (int)$batchId : null;
     }
 
     /**

--- a/src/Services/ClientCatalogService.php
+++ b/src/Services/ClientCatalogService.php
@@ -71,11 +71,11 @@ class ClientCatalogService
             'p.is_active = 1',
             "CASE WHEN p.sale_price > 0 THEN 0 ELSE 1 END,\n" .
             "CASE\n" .
-            "  WHEN p.delivery_date IS NULL THEN 3\n" .
-            "  WHEN p.delivery_date > ? THEN 2\n" .
+            "  WHEN pb.purchased_at IS NULL THEN 3\n" .
+            "  WHEN DATE(pb.purchased_at) > ? THEN 2\n" .
             "  ELSE 1\n" .
             "END,\n" .
-            "COALESCE(p.delivery_date, '9999-12-31'),\n" .
+            "COALESCE(DATE(pb.purchased_at), '9999-12-31'),\n" .
             "p.id DESC",
             [$today]
         );
@@ -105,11 +105,11 @@ class ClientCatalogService
             "       p.origin_country,\n" .
             "       p.box_size,\n" .
             "       p.box_unit,\n" .
-            "       p.price,\n" .
+            "       COALESCE(pb.instant_unit_price, p.price) AS price,\n" .
             "       p.sale_price,\n" .
             "       p.is_active,\n" .
             "       p.image_path,\n" .
-            "       p.delivery_date,\n" .
+            "       DATE(pb.purchased_at) AS delivery_date,\n" .
             "       COALESCE(u.company_name, u.name, 'berryGo') AS seller_name\n" .
             "FROM products p\n" .
             "JOIN product_types t ON t.id = p.product_type_id\n" .

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -119,7 +119,7 @@
 
     <!-- Дата поставки -->
     <div>
-      <label class="block mb-1">Дата следующей поставки</label>
+      <label class="block mb-1">Дата закупки (активная закупка)</label>
       <input
         type="date"
         name="delivery_date"
@@ -127,7 +127,7 @@
         class="w-full border px-2 py-1 rounded focus:ring-2 focus:ring-[#C86052] outline-none"
       >
       <p class="text-sm text-gray-500 mt-1">
-        Оставьте пустым, если дата неизвестна (под заказ)
+        Изменение влияет на активную закупку, а не на справочник товара.
       </p>
     </div>
 
@@ -166,7 +166,7 @@
 
     <!-- Цена за кг/л -->
     <div>
-      <label class="block mb-1">Цена за кг или л (₽)</label>
+      <label class="block mb-1">Закупочная цена за ящик (₽)</label>
       <input name="price" type="number" step="0.01"
              value="<?= htmlspecialchars($price_kg ?? '') ?>"
              class="w-full border px-2 py-1 rounded" required>

--- a/src/Views/admin/products/index.php
+++ b/src/Views/admin/products/index.php
@@ -31,7 +31,7 @@
       <?php endif; ?>
       <th class="p-3 text-left font-semibold">Сорт</th>
       <th class="p-3 text-left font-semibold">Вес ящика</th>
-      <th class="p-3 text-left font-semibold">Цена за кг/л</th>
+      <th class="p-3 text-left font-semibold">Закуп. цена за ящик</th>
       <?php if (!$isManager): ?>
       <th class="p-3 text-left font-semibold">Остаток (ящиков)</th>
       <?php endif; ?>
@@ -59,7 +59,7 @@
           <?= $p['box_size'] ?> <?= htmlspecialchars($p['box_unit']) ?>
         </td>
         <td class="p-3 text-gray-600">
-          <?= number_format($p['price'], 2, '.', ' ') ?> ₽/<?= htmlspecialchars($p['unit']) ?>
+          <?= number_format((float)($p['price'] ?? 0), 2, '.', ' ') ?> ₽
         </td>
         <?php if (!$isManager): ?>
         <td class="p-3 text-gray-600"><?= $p['stock_boxes'] ?></td>


### PR DESCRIPTION
### Motivation
- Separate product catalog data from purchase-specific pricing and delivery dates so active purchase batches drive prices and arrival dates.
- Ensure cart and ordering use per-box prices from the active purchase batch and prevent ordering when no active batch exists for non-preorder modes.
- Update admin flows to edit the active purchase batch (purchase price and purchase date) instead of overwriting product master fields.

### Description
- Changed queries across `ClientController`, `ProductsController`, and `ClientCatalogService` to `LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id` and to use `pb.*` fields (e.g. `instant_unit_price`, `purchased_at`) with `COALESCE` fallbacks where appropriate.
- Reworked cart price logic in `ClientController::cart` to compute `sale_price_per_box` and `unit_price` using batch `*_price_per_box` columns with fallbacks to unit prices and `box_size`, and to block adding non-preorder items when `current_purchase_batch_id` is missing.
- Updated admin product endpoints to update the active purchase batch instead of the `products` table: `updatePrice` now updates `purchase_batches.purchase_price_per_box`, and `updateDeliveryDate` updates `purchase_batches.purchased_at`; added helper `resolveCurrentPurchaseBatchId` to locate the batch id with seller scoping.
- Adjusted public/catalog and admin list/detail queries to expose delivery date as `DATE(pb.purchased_at)` and price as batch-derived price where available, and updated views (`admin/products/edit.php`, `admin/products/index.php`) to relabel fields to reflect that price/date are for the active purchase batch.
- Preserved existing behavior for `preorder` mode while ensuring correct fallbacks and storing `purchase_batch_id` and `sale_price_per_box` in `cart_items`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b076ab1c8832c99a8bf94c03d4cba)