### PR TITLE
Use active purchase batch prices/dates and switch admin UI to box-based purchase fields

### DIFF
--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -169,8 +169,12 @@ public function cart(): void
             }
 
             $priceStmt = $this->pdo->prepare(
-                "SELECT price, sale_price, box_size, preorder_unit_price, instant_unit_price, discount_unit_price, current_purchase_batch_id
-                 FROM products WHERE id = ?"
+                "SELECT p.price, p.sale_price, p.box_size, p.preorder_unit_price, p.instant_unit_price, p.discount_unit_price,
+                        p.current_purchase_batch_id,
+                        pb.preorder_price_per_box, pb.instant_price_per_box, pb.discount_price_per_box
+                 FROM products p
+                 LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id
+                 WHERE p.id = ? LIMIT 1"
             );
             $priceStmt->execute([$productId]);
             $row = $priceStmt->fetch(PDO::FETCH_ASSOC);
@@ -178,21 +182,38 @@ public function cart(): void
             $purchaseBatchId = null;
             if ($row) {
                 $boxSize = (float)($row['box_size'] ?? 0);
-                $sale    = (float)($row['sale_price'] ?? 0); // per kg
-                $regular = (float)($row['price'] ?? 0);      // per kg
+                $sale = (float)($row['sale_price'] ?? 0);
+                $regular = (float)($row['price'] ?? 0);
                 $fallbackKgPrice = $sale > 0 ? $sale : $regular;
-                $kgPrice = match ($stockMode) {
-                    'preorder' => (float)($row['preorder_unit_price'] ?? 0),
-                    'discount_stock' => (float)($row['discount_unit_price'] ?? 0),
-                    default => (float)($row['instant_unit_price'] ?? 0),
+                $fallbackBoxPrice = $fallbackKgPrice * $boxSize;
+
+                $priceBox = match ($stockMode) {
+                    'preorder' => (float)($row['preorder_price_per_box'] ?? 0),
+                    'discount_stock' => (float)($row['discount_price_per_box'] ?? 0),
+                    default => (float)($row['instant_price_per_box'] ?? 0),
                 };
-                if ($kgPrice <= 0) {
-                    $kgPrice = $fallbackKgPrice;
+                if ($priceBox <= 0) {
+                    $kgPrice = match ($stockMode) {
+                        'preorder' => (float)($row['preorder_unit_price'] ?? 0),
+                        'discount_stock' => (float)($row['discount_unit_price'] ?? 0),
+                        default => (float)($row['instant_unit_price'] ?? 0),
+                    };
+                    if ($kgPrice > 0 && $boxSize > 0) {
+                        $priceBox = $kgPrice * $boxSize;
+                    } else {
+                        $priceBox = $fallbackBoxPrice;
+                    }
                 }
-                $priceBox = $kgPrice * $boxSize;
                 if ($stockMode !== 'preorder') {
                     $purchaseBatchId = isset($row['current_purchase_batch_id']) ? (int)$row['current_purchase_batch_id'] : null;
                 }
+            }
+
+            if ($stockMode !== 'preorder' && $purchaseBatchId === null) {
+                $_SESSION['cart_error'] = 'Для этого товара сейчас нет активной закупки.';
+                $referer = $_SERVER['HTTP_REFERER'] ?? '/';
+                header('Location: ' . $referer);
+                exit;
             }
 
             $modeCheckStmt = $this->pdo->prepare(
@@ -1304,9 +1325,12 @@ public function cancelReservedOrder(int $orderId): void
 
     public function showProduct(string $alias, ?string $typeAlias = null): void
     {
-        $query = "SELECT p.*, t.name AS product, t.alias AS type_alias
+        $query = "SELECT p.*, t.name AS product, t.alias AS type_alias,
+                         COALESCE(pb.instant_unit_price, p.price) AS price,
+                         DATE(pb.purchased_at) AS delivery_date
                   FROM products p
                   JOIN product_types t ON t.id = p.product_type_id
+                  LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id
                   WHERE (p.alias = ? OR p.id = ?)";
         $params = [$alias, $alias];
         if ($typeAlias !== null) {
@@ -1352,7 +1376,7 @@ public function cancelReservedOrder(int $orderId): void
         }
 
         $pStmt = $this->pdo->prepare(
-            "SELECT p.id, p.alias, t.name AS product, t.alias AS type_alias, p.variety, p.description, p.origin_country, p.box_size, p.box_unit, p.price, p.sale_price, p.is_active, p.image_path, p.delivery_date,
+            "SELECT p.id, p.alias, t.name AS product, t.alias AS type_alias, p.variety, p.description, p.origin_country, p.box_size, p.box_unit, COALESCE(pb_latest.instant_unit_price, p.price) AS price, p.sale_price, p.is_active, p.image_path, DATE(pb_latest.purchased_at) AS delivery_date,
                     COALESCE(u.company_name,u.name,'berryGo') AS seller_name,
                     pb_latest.purchased_at AS latest_purchase_date
              FROM products p

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -92,10 +92,10 @@ class ProductsController
 
         $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
         if ($availabilityFilter === 'reserved') {
-            $sql .= (stripos($sql, ' WHERE ') !== false ? " AND " : " WHERE ") . "(p.delivery_date IS NULL OR p.delivery_date = ?)";
+            $sql .= (stripos($sql, ' WHERE ') !== false ? " AND " : " WHERE ") . "(pb.purchased_at IS NULL OR DATE(pb.purchased_at) = ?)";
             $params[] = $placeholder;
         } elseif ($availabilityFilter === 'available') {
-            $sql .= (stripos($sql, ' WHERE ') !== false ? " AND " : " WHERE ") . "(p.delivery_date IS NOT NULL AND p.delivery_date <> ?)";
+            $sql .= (stripos($sql, ' WHERE ') !== false ? " AND " : " WHERE ") . "(pb.purchased_at IS NOT NULL AND DATE(pb.purchased_at) <> ?)";
             $params[] = $placeholder;
         }
 
@@ -131,10 +131,20 @@ class ProductsController
         if ($id) {
             $role = $_SESSION['role'] ?? '';
             if ($role === 'seller') {
-                $stmt = $this->pdo->prepare("SELECT * FROM products WHERE id = ? AND seller_id = ?");
+                $stmt = $this->pdo->prepare(
+                    "SELECT p.*, DATE(pb.purchased_at) AS delivery_date, COALESCE(pb.purchase_price_per_box, p.price) AS price
+                     FROM products p
+                     LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id
+                     WHERE p.id = ? AND p.seller_id = ?"
+                );
                 $stmt->execute([(int)$id, $_SESSION['user_id'] ?? 0]);
             } else {
-                $stmt = $this->pdo->prepare("SELECT * FROM products WHERE id = ?");
+                $stmt = $this->pdo->prepare(
+                    "SELECT p.*, DATE(pb.purchased_at) AS delivery_date, COALESCE(pb.purchase_price_per_box, p.price) AS price
+                     FROM products p
+                     LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id
+                     WHERE p.id = ?"
+                );
                 $stmt->execute([(int)$id]);
             }
             $product = $stmt->fetch(PDO::FETCH_ASSOC);

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -69,13 +69,14 @@ class ProductsController
                 p.box_size,
                 p.box_unit,
                 p.unit,
-                p.price,
+                COALESCE(pb.purchase_price_per_box, p.price) AS price,
                 p.stock_boxes,
                 p.is_active,
                 p.image_path,
-                p.delivery_date
+                DATE(pb.purchased_at) AS delivery_date
              FROM products p
-             JOIN product_types t ON t.id = p.product_type_id";
+             JOIN product_types t ON t.id = p.product_type_id
+             LEFT JOIN purchase_batches pb ON pb.id = p.current_purchase_batch_id";
 
         if ($role === 'seller') {
             $selectedSeller = $_SESSION['user_id'] ?? 0;
@@ -364,22 +365,18 @@ class ProductsController
         exit;
     }
 
-    // Обновление цены за кг
+    // Обновление закупочной цены активной закупки
     public function updatePrice(): void
     {
         $id = (int)($_POST['id'] ?? 0);
         $raw = trim($_POST['price'] ?? '');
         if ($id && $raw !== '') {
             $price = (float)$raw;
-            $role = $_SESSION['role'] ?? '';
-            $params = [$price, $id];
-            $sql = "UPDATE products SET price = ? WHERE id = ?";
-            if ($role === 'seller') {
-                $sql .= " AND seller_id = ?";
-                $params[] = $_SESSION['user_id'] ?? 0;
+            $batchId = $this->resolveCurrentPurchaseBatchId($id);
+            if ($batchId !== null) {
+                $stmt = $this->pdo->prepare("UPDATE purchase_batches SET purchase_price_per_box = ? WHERE id = ?");
+                $stmt->execute([$price, $batchId]);
             }
-            $stmt = $this->pdo->prepare($sql);
-            $stmt->execute($params);
         }
         // Redirect back to the page where the price was updated.
         // If the "Referer" header is available, return to that page
@@ -397,25 +394,21 @@ class ProductsController
         exit;
     }
 
-    // Обновление даты поставки товара
+    // Обновление даты закупки активной закупки
     public function updateDeliveryDate(): void
     {
         $id = (int)($_POST['id'] ?? 0);
         $raw = trim($_POST['delivery_date'] ?? '');
         $date = $raw !== '' ? $raw : null;
-        if ($id) {
-            $role = $_SESSION['role'] ?? '';
-            $params = [$date, $id];
-            $sql = "UPDATE products SET delivery_date = ? WHERE id = ?";
-            if ($role === 'seller') {
-                $sql .= " AND seller_id = ?";
-                $params[] = $_SESSION['user_id'] ?? 0;
-            }
-            $stmt = $this->pdo->prepare($sql);
-            $stmt->execute($params);
-            $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
-            if ($date !== null && $date !== '' && $date !== $placeholder) {
-                $this->activateReservedOrdersByProduct($id, $date);
+        if ($id && $date !== null) {
+            $batchId = $this->resolveCurrentPurchaseBatchId($id);
+            if ($batchId !== null) {
+                $stmt = $this->pdo->prepare("UPDATE purchase_batches SET purchased_at = ? WHERE id = ?");
+                $stmt->execute([$date . ' 00:00:00', $batchId]);
+                $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
+                if ($date !== '' && $date !== $placeholder) {
+                    $this->activateReservedOrdersByProduct($id, $date);
+                }
             }
         }
         // Determine where to redirect after updating
@@ -434,6 +427,24 @@ class ProductsController
 
         header('Location: ' . $base);
         exit;
+    }
+
+
+    private function resolveCurrentPurchaseBatchId(int $productId): ?int
+    {
+        $role = $_SESSION['role'] ?? '';
+        $params = [$productId];
+        $sql = "SELECT current_purchase_batch_id FROM products WHERE id = ?";
+        if ($role === 'seller') {
+            $sql .= " AND seller_id = ?";
+            $params[] = (int)($_SESSION['user_id'] ?? 0);
+        }
+
+        $stmt = $this->pdo->prepare($sql . " LIMIT 1");
+        $stmt->execute($params);
+        $batchId = $stmt->fetchColumn();
+
+        return $batchId !== false && $batchId !== null ? (int)$batchId : null;
     }
 
     /**

--- a/src/Services/ClientCatalogService.php
+++ b/src/Services/ClientCatalogService.php
@@ -71,11 +71,11 @@ class ClientCatalogService
             'p.is_active = 1',
             "CASE WHEN p.sale_price > 0 THEN 0 ELSE 1 END,\n" .
             "CASE\n" .
-            "  WHEN p.delivery_date IS NULL THEN 3\n" .
-            "  WHEN p.delivery_date > ? THEN 2\n" .
+            "  WHEN pb.purchased_at IS NULL THEN 3\n" .
+            "  WHEN DATE(pb.purchased_at) > ? THEN 2\n" .
             "  ELSE 1\n" .
             "END,\n" .
-            "COALESCE(p.delivery_date, '9999-12-31'),\n" .
+            "COALESCE(DATE(pb.purchased_at), '9999-12-31'),\n" .
             "p.id DESC",
             [$today]
         );
@@ -105,11 +105,11 @@ class ClientCatalogService
             "       p.origin_country,\n" .
             "       p.box_size,\n" .
             "       p.box_unit,\n" .
-            "       p.price,\n" .
+            "       COALESCE(pb.instant_unit_price, p.price) AS price,\n" .
             "       p.sale_price,\n" .
             "       p.is_active,\n" .
             "       p.image_path,\n" .
-            "       p.delivery_date,\n" .
+            "       DATE(pb.purchased_at) AS delivery_date,\n" .
             "       COALESCE(u.company_name, u.name, 'berryGo') AS seller_name\n" .
             "FROM products p\n" .
             "JOIN product_types t ON t.id = p.product_type_id\n" .

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -119,7 +119,7 @@
 
     <!-- Дата поставки -->
     <div>
-      <label class="block mb-1">Дата следующей поставки</label>
+      <label class="block mb-1">Дата закупки (активная закупка)</label>
       <input
         type="date"
         name="delivery_date"
@@ -127,7 +127,7 @@
         class="w-full border px-2 py-1 rounded focus:ring-2 focus:ring-[#C86052] outline-none"
       >
       <p class="text-sm text-gray-500 mt-1">
-        Оставьте пустым, если дата неизвестна (под заказ)
+        Изменение влияет на активную закупку, а не на справочник товара.
       </p>
     </div>
 
@@ -166,7 +166,7 @@
 
     <!-- Цена за кг/л -->
     <div>
-      <label class="block mb-1">Цена за кг или л (₽)</label>
+      <label class="block mb-1">Закупочная цена за ящик (₽)</label>
       <input name="price" type="number" step="0.01"
              value="<?= htmlspecialchars($price_kg ?? '') ?>"
              class="w-full border px-2 py-1 rounded" required>

--- a/src/Views/admin/products/index.php
+++ b/src/Views/admin/products/index.php
@@ -31,7 +31,7 @@
       <?php endif; ?>
       <th class="p-3 text-left font-semibold">Сорт</th>
       <th class="p-3 text-left font-semibold">Вес ящика</th>
-      <th class="p-3 text-left font-semibold">Цена за кг/л</th>
+      <th class="p-3 text-left font-semibold">Закуп. цена за ящик</th>
       <?php if (!$isManager): ?>
       <th class="p-3 text-left font-semibold">Остаток (ящиков)</th>
       <?php endif; ?>
@@ -59,7 +59,7 @@
           <?= $p['box_size'] ?> <?= htmlspecialchars($p['box_unit']) ?>
         </td>
         <td class="p-3 text-gray-600">
-          <?= number_format($p['price'], 2, '.', ' ') ?> ₽/<?= htmlspecialchars($p['unit']) ?>
+          <?= number_format((float)($p['price'] ?? 0), 2, '.', ' ') ?> ₽
         </td>
         <?php if (!$isManager): ?>
         <td class="p-3 text-gray-600"><?= $p['stock_boxes'] ?></td>

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -96,8 +96,9 @@ $preorderPriceHint = (string)(get_setting('ui_preorder_price_hint', 'Цена о
           <form action="<?= $basePath ?>/products/update-date" method="post" class="flex items-center space-x-2">
             <input type="hidden" name="id" value="<?= $p['id'] ?>">
             <input type="date" name="delivery_date" value="<?= htmlspecialchars($d ?? '') ?>" class="border px-1 py-1 rounded text-sm">
-            <button type="submit" class="bg-blue-500 text-white rounded px-2 py-1 text-xs">Обновить</button>
+            <button type="submit" class="bg-blue-500 text-white rounded px-2 py-1 text-xs">Обновить закупку</button>
           </form>
+          <p class="mt-1 text-[10px] text-gray-500">Изменяется дата активной закупки.</p>
         </div>
       <?php endif; ?>
 
@@ -187,14 +188,15 @@ $preorderPriceHint = (string)(get_setting('ui_preorder_price_hint', 'Цена о
         <div class="mb-3"></div>
       <?php endif; ?>
 
-      <!-- Форма редактирования цены (только стафф) -->
+      <!-- Форма редактирования закупочной цены (только стафф) -->
       <?php if ($isStaff): ?>
         <div class="mt-2 hidden" data-price-form="<?= $p['id'] ?>">
           <form action="<?= $basePath ?>/products/update-price" method="post" class="flex items-center space-x-2">
             <input type="hidden" name="id" value="<?= $p['id'] ?>">
-            <input type="number" step="0.01" name="price" value="<?= htmlspecialchars($price) ?>" class="border px-1 py-1 rounded text-sm w-24">
-            <button type="submit" class="bg-blue-500 text-white rounded px-2 py-1 text-xs">Обновить</button>
+            <input type="number" step="0.01" name="price" value="<?= htmlspecialchars($price) ?>" class="border px-1 py-1 rounded text-sm w-24" title="Закупочная цена за ящик">
+            <button type="submit" class="bg-blue-500 text-white rounded px-2 py-1 text-xs">Обновить закупку</button>
           </form>
+          <p class="mt-1 text-[10px] text-gray-500">Изменяется цена активной закупки.</p>
         </div>
       <?php endif; ?>
 


### PR DESCRIPTION
### Motivation
- Move pricing and delivery date logic from product-level fields to the active `purchase_batches` so active purchase details (purchase price per box, instant/unit prices and purchased_at) drive client prices and availability.
- Ensure cart entries reference the active purchase batch and box-based unit prices so order totals and stock checks reflect the current procurement batch.

### Description
- Read instant/discount/preorder prices per box from `purchase_batches` in `ClientController::cart`, compute fallbacks to `products` prices when batch prices are missing, and require a `purchase_batch_id` for non-preorder adds to cart; store `purchase_batch_id`, `unit_price` (box price) and `sale_price_per_box` into `cart_items` on insert.
- Change product listing and detail queries to `LEFT JOIN purchase_batches pb` and expose `COALESCE(pb.instant_unit_price, p.price)` as `price` and `DATE(pb.purchased_at)` as `delivery_date` in `showProduct`, `showProductType`, `ProductsController::index` and `ClientCatalogService::fetchProducts` and adjust ordering to use `pb.purchased_at`.
- Update admin endpoints `updatePrice` and `updateDeliveryDate` to apply changes to the active `purchase_batches` row instead of the `products` table by resolving `current_purchase_batch_id` via `resolveCurrentPurchaseBatchId` helper and updating `purchase_batches.purchase_price_per_box` and `purchase_batches.purchased_at` respectively, while keeping seller role restrictions.
- Update admin and client views (`admin/products/edit.php`, `admin/products/index.php`, `client/_card.php`) to reflect box-based purchase terminology and UX hints (labels, helper text and button text) and to show/update active purchase price/date rather than product-level fields.

### Testing
- Ran the existing automated test suite (unit and integration tests where configured) and smoke tests for product listing, product detail rendering, cart add flow and admin price/date update flows; all executed tests passed.
- Ran quick local manual smoke checks for adding to cart with different `stock_mode` values and for admin updates to purchase price and purchase date; these automated-adjacent checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b076ab1c8832c99a8bf94c03d4cba)