### PR TITLE
Support updating and closing purchase batches; replace delete with close in several admin routes and UI

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -33,7 +33,7 @@ return [
     },
     static function (string $method, string $uri, array $c): bool {
         if (!routeExact('POST', '/admin/products/delete', $method, $uri)) return false;
-        requireAdmin(); (new App\Controllers\ProductsController($c['pdo']))->delete(); return true;
+        requireAdmin(); (new App\Controllers\ProductsController($c['pdo']))->close(); return true;
     },
 
     static function (string $method, string $uri, array $c): bool {
@@ -102,6 +102,14 @@ return [
         requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->deletePhoto(); return true;
     },
     static function (string $method, string $uri, array $c): bool {
+        if (!routeExact('POST', '/admin/purchases/update', $method, $uri)) return false;
+        requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->update(); return true;
+    },
+    static function (string $method, string $uri, array $c): bool {
+        if (!routeExact('POST', '/admin/purchases/close', $method, $uri)) return false;
+        requireAdmin(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->close(); return true;
+    },
+    static function (string $method, string $uri, array $c): bool {
         if (!routeExact('GET', '/admin/orders/create', $method, $uri)) return false;
         requireAdmin(); (new App\Controllers\OrdersController($c['pdo']))->create(); return true;
     },
@@ -134,7 +142,7 @@ return [
             'GET /admin/slots' => ['App\\Controllers\\SlotsController', 'index'],
             'GET /admin/slots/edit' => ['App\\Controllers\\SlotsController', 'edit'],
             'POST /admin/slots/save' => ['App\\Controllers\\SlotsController', 'save'],
-            'POST /admin/slots/delete' => ['App\\Controllers\\SlotsController', 'delete'],
+            'POST /admin/slots/delete' => ['App\\Controllers\\SlotsController', 'close'],
             'GET /admin/coupons' => ['App\\Controllers\\CouponsController', 'index'],
             'GET /admin/coupons/edit' => ['App\\Controllers\\CouponsController', 'edit'],
             'POST /admin/coupons/save' => ['App\\Controllers\\CouponsController', 'save'],
@@ -152,7 +160,7 @@ return [
             'GET /admin/users/addresses' => ['App\\Controllers\\UsersController', 'addresses'],
             'GET /admin/users/edit' => ['App\\Controllers\\UsersController', 'edit'],
             'POST /admin/users/save' => ['App\\Controllers\\UsersController', 'save'],
-            'POST /admin/users/delete' => ['App\\Controllers\\UsersController', 'delete'],
+            'POST /admin/users/delete' => ['App\\Controllers\\UsersController', 'close'],
             'POST /admin/users/toggle-block' => ['App\\Controllers\\UsersController', 'toggleBlock'],
             'POST /admin/users/reset-balance' => ['App\\Controllers\\UsersController', 'resetRubBalance'],
             'POST /admin/users/add-address' => ['App\\Controllers\\UsersController', 'addAddressAdmin'],

--- a/routes/buyer.php
+++ b/routes/buyer.php
@@ -16,6 +16,14 @@ return [
         requireBuyer(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->store(); return true;
     },
     static function (string $method, string $uri, array $c): bool {
+        if (!routeExact('POST', '/buyer/purchases/update', $method, $uri)) return false;
+        requireBuyer(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->update(); return true;
+    },
+    static function (string $method, string $uri, array $c): bool {
+        if (!routeExact('POST', '/buyer/purchases/close', $method, $uri)) return false;
+        requireBuyer(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->close(); return true;
+    },
+    static function (string $method, string $uri, array $c): bool {
         if (!routeRegex('GET', '#^/buyer/purchases/(\d+)$#', $method, $uri, $m)) return false;
         requireBuyer(); (new App\Controllers\PurchaseBatchesController($c['pdo']))->show((int)$m[1]); return true;
     },

--- a/routes/manager.php
+++ b/routes/manager.php
@@ -19,7 +19,7 @@ return [
             'POST /manager/orders/comment' => ['App\\Controllers\\OrdersController', 'updateComment'],
             'POST /manager/orders/referral' => ['App\\Controllers\\OrdersController', 'updateReferral'],
             'POST /manager/orders/update-delivery' => ['App\\Controllers\\OrdersController', 'updateDelivery'],
-            'POST /manager/orders/delete' => ['App\\Controllers\\OrdersController', 'delete'],
+            'POST /manager/orders/delete' => ['App\\Controllers\\OrdersController', 'close'],
             'GET /manager/products' => ['App\\Controllers\\ProductsController', 'index'],
             'GET /manager/products/edit' => ['App\\Controllers\\ProductsController', 'edit'],
             'POST /manager/products/save' => ['App\\Controllers\\ProductsController', 'save'],
@@ -27,7 +27,7 @@ return [
             'POST /manager/products/update-price' => ['App\\Controllers\\ProductsController', 'updatePrice'],
             'GET /manager/products/update-price' => ['App\\Controllers\\ProductsController', 'updatePrice'],
             'POST /manager/products/update-date' => ['App\\Controllers\\ProductsController', 'updateDeliveryDate'],
-            'POST /manager/products/delete' => ['App\\Controllers\\ProductsController', 'delete'],
+            'POST /manager/products/delete' => ['App\\Controllers\\ProductsController', 'close'],
             'GET /manager/users' => ['App\\Controllers\\UsersController', 'index'],
             'GET /manager/users/search' => ['App\\Controllers\\UsersController', 'searchPhone'],
             'GET /manager/users/addresses' => ['App\\Controllers\\UsersController', 'addresses'],
@@ -46,6 +46,8 @@ return [
             'POST /manager/purchases/preorders/maintenance' => ['App\\Controllers\\PurchaseBatchesController', 'maintenancePreorders'],
             'POST /manager/purchases/write-off' => ['App\\Controllers\\PurchaseBatchesController', 'writeOff'],
             'POST /manager/purchases/photos/delete' => ['App\\Controllers\\PurchaseBatchesController', 'deletePhoto'],
+            'POST /manager/purchases/update' => ['App\\Controllers\\PurchaseBatchesController', 'update'],
+            'POST /manager/purchases/close' => ['App\\Controllers\\PurchaseBatchesController', 'close'],
         ];
 
         $key = $method . ' ' . $uri;

--- a/src/Controllers/PurchaseBatchesController.php
+++ b/src/Controllers/PurchaseBatchesController.php
@@ -27,8 +27,9 @@ class PurchaseBatchesController
         $sql =
             'SELECT pb.*, p.variety, t.name AS product_name, u.name AS buyer_name,
 '
-          . '       TIMESTAMPDIFF(DAY, pb.purchased_at, NOW()) AS age_days
+          . '       TIMESTAMPDIFF(DAY, pb.purchased_at, NOW()) AS age_days,
 '
+          . "       CASE WHEN pb.boxes_free <= 0 OR pb.comment LIKE '[CLOSED]%' THEN 1 ELSE 0 END AS is_closed\n"
           . 'FROM purchase_batches pb
 '
           . 'JOIN products p ON p.id = pb.product_id
@@ -53,7 +54,7 @@ WHERE ' . implode(' AND ', $conditions);
         }
 
         $sql .= '
-ORDER BY pb.id DESC';
+ORDER BY is_closed ASC, pb.id DESC';
         $stmt = $this->pdo->prepare($sql);
         $stmt->execute($params);
         $batches = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -143,6 +144,13 @@ ORDER BY pb.id DESC';
         $photosStmt->execute([$id]);
 
         $pnl = $this->purchaseBatchService->calculateBatchPnl($id);
+        $products = $this->pdo->query(
+            'SELECT p.id, p.variety, p.box_size, p.box_unit, t.name AS product_name
+             FROM products p
+             JOIN product_types t ON t.id = p.product_type_id
+             WHERE p.is_active = 1
+             ORDER BY t.name, p.variety'
+        )->fetchAll(PDO::FETCH_ASSOC);
 
         viewAdmin('purchases/show', [
             'pageTitle' => 'Партия #' . $id,
@@ -151,6 +159,7 @@ ORDER BY pb.id DESC';
             'movements' => $movementsStmt->fetchAll(PDO::FETCH_ASSOC),
             'photos' => $photosStmt->fetchAll(PDO::FETCH_ASSOC),
             'pnl' => $pnl,
+            'products' => $products,
             'flash' => $this->pullFlash(),
         ]);
     }
@@ -371,6 +380,71 @@ ORDER BY pb.id DESC';
 
         $this->setFlash('success', 'Фото удалено.');
         header('Location: ' . $this->basePath() . '/purchases/' . (int)$photo['purchase_batch_id']);
+        exit;
+    }
+
+    public function update(): void
+    {
+        $this->ensureCsrfOrRedirect();
+        $batchId = (int)($_POST['batch_id'] ?? 0);
+        if ($batchId <= 0) {
+            $this->setFlash('error', 'Некорректная закупка.');
+            header('Location: ' . $this->basePath() . '/purchases');
+            exit;
+        }
+        $stmt = $this->pdo->prepare(
+            'UPDATE purchase_batches
+             SET product_id = :product_id, boxes_total = :boxes_total, boxes_reserved = :boxes_reserved, boxes_free = :boxes_free,
+                 purchase_price_per_box = :purchase_price_per_box, extra_cost_per_box = :extra_cost_per_box,
+                 status = :status, purchased_at = :purchased_at, comment = :comment
+             WHERE id = :id
+             LIMIT 1'
+        );
+        $stmt->execute([
+            'id' => $batchId,
+            'product_id' => (int)($_POST['product_id'] ?? 0),
+            'boxes_total' => (float)($_POST['boxes_total'] ?? 0),
+            'boxes_reserved' => (float)($_POST['boxes_reserved'] ?? 0),
+            'boxes_free' => (float)($_POST['boxes_free'] ?? 0),
+            'purchase_price_per_box' => (float)($_POST['purchase_price_per_box'] ?? 0),
+            'extra_cost_per_box' => (float)($_POST['extra_cost_per_box'] ?? 0),
+            'status' => (string)($_POST['status'] ?? 'planned'),
+            'purchased_at' => (string)($_POST['planned_supply_date'] ?? ''),
+            'comment' => trim((string)($_POST['comment'] ?? '')),
+        ]);
+        $this->storeBatchPhotos($batchId);
+        $this->setFlash('success', 'Закупка обновлена.');
+        header('Location: ' . $this->basePath() . '/purchases/' . $batchId);
+        exit;
+    }
+
+    public function close(): void
+    {
+        $this->ensureCsrfOrRedirect();
+        $batchId = (int)($_POST['batch_id'] ?? 0);
+        if ($batchId <= 0) {
+            $this->setFlash('error', 'Некорректная закупка.');
+            header('Location: ' . $this->basePath() . '/purchases');
+            exit;
+        }
+        $stmt = $this->pdo->prepare('SELECT comment FROM purchase_batches WHERE id = ? LIMIT 1');
+        $stmt->execute([$batchId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            $this->setFlash('error', 'Закупка не найдена.');
+            header('Location: ' . $this->basePath() . '/purchases');
+            exit;
+        }
+
+        $comment = trim((string)($row['comment'] ?? ''));
+        if (!str_starts_with($comment, '[CLOSED]')) {
+            $comment = trim('[CLOSED] ' . $comment);
+        }
+
+        $upd = $this->pdo->prepare('UPDATE purchase_batches SET boxes_free = 0, comment = :comment WHERE id = :id LIMIT 1');
+        $upd->execute(['id' => $batchId, 'comment' => $comment]);
+        $this->setFlash('success', 'Закупка закрыта (без удаления данных).');
+        header('Location: ' . $this->basePath() . '/purchases');
         exit;
     }
 

--- a/src/Views/admin/purchases/index.php
+++ b/src/Views/admin/purchases/index.php
@@ -74,20 +74,28 @@
   </thead>
   <tbody>
     <?php foreach ($batches as $batch): ?>
-      <tr class="border-b hover:bg-gray-50 transition-all duration-200">
+      <tr class="border-b transition-all duration-200 <?= ((int)($batch['is_closed'] ?? 0) === 1) ? 'bg-gray-50 text-gray-400' : 'hover:bg-orange-50 bg-white' ?>">
         <td class="p-3"><?= (int)$batch['id'] ?></td>
-        <td class="p-3"><?= htmlspecialchars(trim(($batch['product_name'] ?? '') . ' ' . ($batch['variety'] ?? ''))) ?></td>
+        <td class="p-3">
+          <a class="text-[#C86052] hover:underline font-medium" href="<?= $basePath ?>/purchases/<?= (int)$batch['id'] ?>">
+            <?= htmlspecialchars(trim(($batch['product_name'] ?? '') . ' ' . ($batch['variety'] ?? ''))) ?>
+          </a>
+        </td>
         <td class="p-3"><?= htmlspecialchars((string)($batch['buyer_name'] ?? '—')) ?></td>
         <td class="p-3"><?= (float)$batch['boxes_total'] ?></td>
         <td class="p-3"><?= (float)$batch['boxes_free'] ?></td>
         <td class="p-3"><?= (float)$batch['boxes_reserved'] ?></td>
         <td class="p-3"><?= number_format((float)$batch['purchase_price_per_box'], 2, '.', ' ') ?> ₽</td>
         <td class="p-3"><?= number_format((float)$batch['instant_price_per_box'], 2, '.', ' ') ?> ₽</td>
-        <td class="p-3"><?= htmlspecialchars((string)($statusLabels[(string)$batch['status']] ?? (string)$batch['status'])) ?></td>
+        <td class="p-3">
+          <?= htmlspecialchars((string)($statusLabels[(string)$batch['status']] ?? (string)$batch['status'])) ?>
+          <?php if ((int)($batch['is_closed'] ?? 0) === 1): ?>
+            <span class="ml-1 text-[11px] px-1 py-0.5 rounded bg-gray-200 text-gray-600">закрыта</span>
+          <?php endif; ?>
+        </td>
         <td class="p-3"><?= (int)($batch['age_days'] ?? 0) ?> дн.</td>
         <td class="p-3">
           <div class="flex flex-wrap gap-2">
-            <a class="text-xs bg-green-100 px-2 py-1 rounded" href="<?= $basePath ?>/purchases/<?= (int)$batch['id'] ?>">Открыть</a>
             <?php if (($batch['status'] ?? '') === 'planned'): ?>
               <form method="post" action="<?= $basePath ?>/purchases/purchased">
                 <?= csrf_field() ?>

--- a/src/Views/admin/purchases/show.php
+++ b/src/Views/admin/purchases/show.php
@@ -1,6 +1,7 @@
 <?php /** @var array<string,mixed> $batch */ ?>
 <?php /** @var array<int,array<string,mixed>> $movements */ ?>
 <?php /** @var array<int,array<string,mixed>> $photos */ ?>
+<?php /** @var array<int,array<string,mixed>> $products */ ?>
 <?php $basePath = $basePath ?? '/admin'; ?>
 <?php $flash = $flash ?? null; ?>
 <?php $statusLabels = [
@@ -27,6 +28,50 @@
   <p><b>Статус:</b> <?= htmlspecialchars((string)($statusLabels[(string)$batch['status']] ?? (string)$batch['status'])) ?></p>
   <p><b>Куплено:</b> <?= (float)$batch['boxes_total'] ?> | <b>Свободно:</b> <?= (float)$batch['boxes_free'] ?> | <b>Резерв:</b> <?= (float)$batch['boxes_reserved'] ?></p>
 </div>
+
+<?php if ($basePath !== '/buyer'): ?>
+<div class="bg-white p-4 rounded shadow mb-4">
+  <h3 class="font-semibold mb-3">Редактирование закупки</h3>
+  <form action="<?= $basePath ?>/purchases/update" method="post" enctype="multipart/form-data" class="space-y-3">
+    <?= csrf_field() ?>
+    <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
+    <div>
+      <label class="block mb-1 text-sm">Товар</label>
+      <select name="product_id" class="w-full border px-2 py-1 rounded" required>
+        <?php foreach (($products ?? []) as $p): ?>
+          <option value="<?= (int)$p['id'] ?>" <?= ((int)$batch['product_id'] === (int)$p['id']) ? 'selected' : '' ?>>
+            <?= htmlspecialchars(trim(($p['product_name'] ?? '') . ' ' . ($p['variety'] ?? '') . ' ' . ($p['box_size'] ?? '') . ' ' . ($p['box_unit'] ?? ''))) ?>
+          </option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="grid grid-cols-2 gap-3">
+      <input name="planned_supply_date" type="date" value="<?= htmlspecialchars(substr((string)$batch['purchased_at'], 0, 10)) ?>" class="border px-2 py-1 rounded">
+      <select name="status" class="border px-2 py-1 rounded"><?php foreach (['planned','purchased','arrived'] as $st): ?><option value="<?= $st ?>" <?= (($batch['status'] ?? '') === $st) ? 'selected' : '' ?>><?= htmlspecialchars((string)$statusLabels[$st]) ?></option><?php endforeach; ?></select>
+      <input name="boxes_total" type="number" step="0.01" value="<?= (float)$batch['boxes_total'] ?>" class="border px-2 py-1 rounded" required>
+      <input name="purchase_price_per_box" type="number" step="0.01" value="<?= (float)$batch['purchase_price_per_box'] ?>" class="border px-2 py-1 rounded" required>
+      <input name="boxes_free" type="number" step="0.01" value="<?= (float)$batch['boxes_free'] ?>" class="border px-2 py-1 rounded" required>
+      <input name="boxes_reserved" type="number" step="0.01" value="<?= (float)$batch['boxes_reserved'] ?>" class="border px-2 py-1 rounded" required>
+      <input name="extra_cost_per_box" type="number" step="0.01" value="<?= (float)$batch['extra_cost_per_box'] ?>" class="border px-2 py-1 rounded">
+    </div>
+    <textarea name="comment" rows="2" class="w-full border px-2 py-1 rounded"><?= htmlspecialchars((string)($batch['comment'] ?? '')) ?></textarea>
+    <div>
+      <label class="block mb-1 text-sm">Добавить фото</label>
+      <input type="file" name="photos[]" multiple accept="image/*" class="w-full border px-2 py-1 rounded">
+    </div>
+    <button type="submit" class="bg-[#C86052] text-white px-4 py-2 rounded">Сохранить изменения</button>
+  </form>
+</div>
+
+<div class="bg-white p-4 rounded shadow mb-4 border border-amber-200">
+  <h3 class="font-semibold text-amber-700 mb-2">Закрытие закупки</h3>
+  <form method="post" action="<?= $basePath ?>/purchases/close" onsubmit="return confirm('Закрыть закупку? Данные сохранятся, свободный остаток станет 0.');">
+    <?= csrf_field() ?>
+    <input type="hidden" name="batch_id" value="<?= (int)$batch['id'] ?>">
+    <button type="submit" class="bg-amber-600 text-white px-4 py-2 rounded">Закрыть закупку</button>
+  </form>
+</div>
+<?php endif; ?>
 
 
 <div class="bg-white p-4 rounded shadow mb-4">


### PR DESCRIPTION
### Motivation
- Enable editing and graceful closing of purchase batches instead of hard-deleting them and expose these operations via routes and UI.
- Treat closed batches specially in listings so they are visually de-emphasized and sorted after active ones.

### Description
- Added `update` and `close` handlers to `PurchaseBatchesController` to support editing batch fields (and uploading photos) and to mark a batch closed by setting `boxes_free = 0` and prefixing the comment with `[CLOSED]` instead of deleting rows.
- Exposed new routes for `POST /{admin,manager,buyer}/purchases/update` and `POST /{admin,manager,buyer}/purchases/close`, and replaced several `.../delete` controller mappings with `close` for users, slots, products and orders where appropriate.
- Adjusted `index()` SQL to compute `is_closed` and sort results with closed batches after active ones, and loaded product list in `show()` to populate the edit form.
- Updated admin views: `purchases/index.php` now visually de-emphasizes closed batches and links product names to the batch page, and `purchases/show.php` now provides an edit form (for non-buyers) and a close button that submit to the new endpoints.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4e6865f4832cb8c6c75fd0c94f8a)