### PR TITLE
Fix write-off to remove sellable stock from batches

### DIFF
--- a/src/Services/PurchaseBatchService.php
+++ b/src/Services/PurchaseBatchService.php
@@ -267,23 +267,37 @@ class PurchaseBatchService
         }
 
         $batch = $this->loadBatch($batchId);
-        if ((float)$batch['boxes_remaining'] < $boxes) {
+        $remaining = (float)($batch['boxes_remaining'] ?? 0);
+        if ($remaining < $boxes) {
             throw new RuntimeException('Not enough boxes remaining for write-off.');
         }
+
+        $freeBoxes = max(0.0, (float)($batch['boxes_free'] ?? 0));
+        $discountBoxes = max(0.0, (float)($batch['boxes_discount'] ?? 0));
+
+        $writeOffFromFree = min($freeBoxes, $boxes);
+        $leftToWriteOff = max(0.0, $boxes - $writeOffFromFree);
+        $writeOffFromDiscount = min($discountBoxes, $leftToWriteOff);
 
         $stmt = $this->pdo->prepare(
             'UPDATE purchase_batches
              SET boxes_written_off = boxes_written_off + :boxes_written_off,
+                 boxes_free = boxes_free - :boxes_free,
+                 boxes_discount = boxes_discount - :boxes_discount,
                  boxes_remaining = boxes_remaining - :boxes_remaining,
                  comment = :comment
              WHERE id = :id'
         );
         $stmt->execute([
             'boxes_written_off' => $boxes,
+            'boxes_free' => $writeOffFromFree,
+            'boxes_discount' => $writeOffFromDiscount,
             'boxes_remaining' => $boxes,
             'comment' => $comment,
             'id' => $batchId,
         ]);
+
+        $this->stockService->syncProductStock((int)$batch['product_id']);
     }
 
     public function closeBatch(int $batchId): void


### PR DESCRIPTION
### Motivation

- Write-off previously updated only `boxes_written_off` and `boxes_remaining`, leaving `boxes_free`/`boxes_discount` unchanged which allowed items to remain available for sale after write-off.
- The change ensures write-offs reduce sellable counters so storefront availability reflects the actual inventory.

### Description

- Changed `PurchaseBatchService::writeOff` to read `boxes_remaining` into a local `remaining` variable and keep the existing validation using it.
- Compute `boxes_free` and `boxes_discount`, then allocate the write-off first from `boxes_free` and then from `boxes_discount` using `min`/`max` to avoid negatives.
- Update `purchase_batches` to decrement `boxes_free`, `boxes_discount`, increase `boxes_written_off`, and decrement `boxes_remaining`, and preserve the `comment` field.
- Call `$this->stockService->syncProductStock((int)$batch['product_id']);` after DB update to refresh product-level stock/status used by the storefront.

### Testing

- Ran `php -l src/Services/PurchaseBatchService.php` and it reported no syntax errors.
- Verified file updated successfully (patch applied) and linting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c70649604832cb6345709fa15127a)