### PR TITLE
Use `free_stock_boxes` in listings and remove `stock_boxes` from product edit/save

### DIFF
--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -70,7 +70,7 @@ class ProductsController
                 p.box_unit,
                 p.unit,
                 COALESCE(pb.purchase_price_per_box, p.price) AS price,
-                p.stock_boxes,
+                p.free_stock_boxes AS stock_boxes,
                 p.is_active,
                 p.image_path,
                 DATE(pb.purchased_at) AS delivery_date
@@ -195,7 +195,6 @@ class ProductsController
         $unit          = ($unitRaw === 'л' ? 'л' : 'кг');
         $price        = (float)$_POST['price']; // price per kg/l
         $salePrice     = (float)($_POST['sale_price'] ?? 0);
-        $stockBoxes    = (float)$_POST['stock_boxes'];
         $isActive      = isset($_POST['is_active']) ? 1 : 0;
 
         // дата поставки (NULL → под заказ)
@@ -274,14 +273,13 @@ class ProductsController
                         unit            = ?,
                         price           = ?,
                         sale_price      = ?,
-                        stock_boxes     = ?,
                         delivery_date   = ?,
                         is_active       = ?";
             $params = [
                 $typeId, $alias, $variety, $description, $fullDesc, $compositionJson,
                 $metaTitle, $metaDesc, $metaKeys,
                 $manufacturer, $originCountry, $boxSize, $boxUnit,
-                $unit, $price, $salePrice, $stockBoxes,
+                $unit, $price, $salePrice,
                 $deliveryDate, $isActive
             ];
 
@@ -308,14 +306,14 @@ class ProductsController
 
         } else {
             // INSERT
-            $columns      = "product_type_id,alias,variety,description,full_description,composition,meta_title,meta_description,meta_keywords,manufacturer,origin_country,box_size,box_unit,unit,price,sale_price,stock_boxes,delivery_date,is_active";
-            // 19 placeholders corresponding to the columns above
-            $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
+            $columns      = "product_type_id,alias,variety,description,full_description,composition,meta_title,meta_description,meta_keywords,manufacturer,origin_country,box_size,box_unit,unit,price,sale_price,delivery_date,is_active";
+            // 18 placeholders corresponding to the columns above
+            $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
             $params       = [
                 $typeId, $alias, $variety, $description, $fullDesc, $compositionJson,
                 $metaTitle, $metaDesc, $metaKeys,
                 $manufacturer, $originCountry, $boxSize, $boxUnit,
-                $unit, $price, $salePrice, $stockBoxes,
+                $unit, $price, $salePrice,
                 $deliveryDate, $isActive
             ];
             if ($sellerId) {

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -172,13 +172,6 @@
              class="w-full border px-2 py-1 rounded" required>
     </div>
 
-    <!-- Остаток (ящиков) -->
-    <div>
-      <label class="block mb-1">Остаток (ящиков)</label>
-      <input name="stock_boxes" type="number" step="0.01"
-             value="<?= htmlspecialchars($product['stock_boxes'] ?? '') ?>"
-             class="w-full border px-2 py-1 rounded" required>
-    </div>
   </div>
 
   <button type="submit"


### PR DESCRIPTION
### Motivation

- Replace the legacy `stock_boxes` field usage with `free_stock_boxes` in the product listing and remove editing/persistence of `stock_boxes` to reflect updated inventory tracking.

### Description

- In the admin products list query, select `p.free_stock_boxes AS stock_boxes` instead of `p.stock_boxes` to display current free stock.
- Remove handling of `stock_boxes` from `ProductsController::save()`, including removing the POST read, update assignment, and insert column/placeholders so `stock_boxes` is no longer persisted by this form.
- Update the product insert column list and placeholders to match the removed field and adjust parameter arrays accordingly in `ProductsController::save()`.
- Remove the `stock_boxes` input from the admin product edit view (`src/Views/admin/products/edit.php`) so the field is no longer shown or editable in the UI.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8a8cd92c832c81fb854b35d0adba)