### PR TITLE
Add product aggregate consistency check and repair script; remove manual stock_boxes from editor

### DIFF
--- a/bin/supply_repair_product_aggregates.php
+++ b/bin/supply_repair_product_aggregates.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+$baseDir = dirname(__DIR__);
+$dbConfig = require $baseDir . '/config/database.php';
+
+$dsn = sprintf(
+    'mysql:host=%s;dbname=%s;charset=%s',
+    $dbConfig['host'],
+    $dbConfig['dbname'],
+    $dbConfig['charset']
+);
+
+$dryRun = in_array('--dry-run', $argv, true);
+
+try {
+    $pdo = new PDO($dsn, $dbConfig['user'], $dbConfig['password'], $dbConfig['options']);
+} catch (PDOException $e) {
+    fwrite(STDERR, "Database connection failed: {$e->getMessage()}\n");
+    exit(2);
+}
+
+$sql = 'UPDATE products p
+LEFT JOIN (
+    SELECT
+        product_id,
+        COALESCE(SUM(boxes_free), 0) AS free_boxes,
+        COALESCE(SUM(boxes_reserved), 0) AS reserved_boxes,
+        COALESCE(SUM(boxes_discount), 0) AS discount_boxes,
+        COALESCE(SUM(boxes_sold), 0) AS sold_boxes,
+        COALESCE(SUM(boxes_written_off), 0) AS written_off_boxes
+    FROM purchase_batches
+    WHERE status IN ("active", "arrived", "purchased")
+    GROUP BY product_id
+) agg ON agg.product_id = p.id
+SET p.free_stock_boxes = COALESCE(agg.free_boxes, 0),
+    p.reserved_stock_boxes = COALESCE(agg.reserved_boxes, 0),
+    p.discount_stock_boxes = COALESCE(agg.discount_boxes, 0),
+    p.sold_stock_boxes = COALESCE(agg.sold_boxes, 0),
+    p.written_off_stock_boxes = COALESCE(agg.written_off_boxes, 0),
+    p.stock_status = CASE
+        WHEN COALESCE(agg.free_boxes, 0) > 0 THEN "in_stock"
+        WHEN COALESCE(agg.reserved_boxes, 0) > 0 THEN "preorder"
+        ELSE "sold_out"
+    END';
+
+if ($dryRun) {
+    $countSql = 'SELECT COUNT(*)
+FROM products p
+LEFT JOIN (
+    SELECT
+        product_id,
+        COALESCE(SUM(boxes_free), 0) AS free_boxes,
+        COALESCE(SUM(boxes_reserved), 0) AS reserved_boxes,
+        COALESCE(SUM(boxes_discount), 0) AS discount_boxes,
+        COALESCE(SUM(boxes_sold), 0) AS sold_boxes,
+        COALESCE(SUM(boxes_written_off), 0) AS written_off_boxes
+    FROM purchase_batches
+    WHERE status IN ("active", "arrived", "purchased")
+    GROUP BY product_id
+) agg ON agg.product_id = p.id
+WHERE ABS(COALESCE(p.free_stock_boxes, 0) - COALESCE(agg.free_boxes, 0)) > 0.01
+   OR ABS(COALESCE(p.reserved_stock_boxes, 0) - COALESCE(agg.reserved_boxes, 0)) > 0.01
+   OR ABS(COALESCE(p.discount_stock_boxes, 0) - COALESCE(agg.discount_boxes, 0)) > 0.01
+   OR ABS(COALESCE(p.sold_stock_boxes, 0) - COALESCE(agg.sold_boxes, 0)) > 0.01
+   OR ABS(COALESCE(p.written_off_stock_boxes, 0) - COALESCE(agg.written_off_boxes, 0)) > 0.01';
+    $count = (int)$pdo->query($countSql)->fetchColumn();
+    fwrite(STDOUT, json_encode(['dry_run' => true, 'products_to_fix' => $count], JSON_UNESCAPED_UNICODE) . PHP_EOL);
+    exit(0);
+}
+
+$affected = $pdo->exec($sql);
+fwrite(STDOUT, json_encode(['dry_run' => false, 'affected_rows' => (int)$affected], JSON_UNESCAPED_UNICODE) . PHP_EOL);

--- a/bin/supply_smoke.php
+++ b/bin/supply_smoke.php
@@ -70,6 +70,33 @@ if (!$anomalyOk) {
     $failed = true;
 }
 
+
+$productAggregateAnomalySql = 'SELECT COUNT(*)
+    FROM products p
+    LEFT JOIN (
+        SELECT
+            product_id,
+            COALESCE(SUM(boxes_free), 0) AS free_boxes,
+            COALESCE(SUM(boxes_reserved), 0) AS reserved_boxes,
+            COALESCE(SUM(boxes_discount), 0) AS discount_boxes,
+            COALESCE(SUM(boxes_sold), 0) AS sold_boxes,
+            COALESCE(SUM(boxes_written_off), 0) AS written_off_boxes
+        FROM purchase_batches
+        WHERE status IN ("active", "arrived", "purchased")
+        GROUP BY product_id
+    ) agg ON agg.product_id = p.id
+    WHERE ABS(COALESCE(p.free_stock_boxes, 0) - COALESCE(agg.free_boxes, 0)) > 0.01
+       OR ABS(COALESCE(p.reserved_stock_boxes, 0) - COALESCE(agg.reserved_boxes, 0)) > 0.01
+       OR ABS(COALESCE(p.discount_stock_boxes, 0) - COALESCE(agg.discount_boxes, 0)) > 0.01
+       OR ABS(COALESCE(p.sold_stock_boxes, 0) - COALESCE(agg.sold_boxes, 0)) > 0.01
+       OR ABS(COALESCE(p.written_off_stock_boxes, 0) - COALESCE(agg.written_off_boxes, 0)) > 0.01';
+$productAggregateAnomalyCount = (int)$pdo->query($productAggregateAnomalySql)->fetchColumn();
+$productAggregateOk = $productAggregateAnomalyCount === 0;
+$checks[] = ['check' => 'product_aggregate_anomalies', 'ok' => $productAggregateOk, 'value' => $productAggregateAnomalyCount];
+if (!$productAggregateOk) {
+    $failed = true;
+}
+
 $result = [
     'generated_at' => (new DateTimeImmutable('now'))->format(DATE_ATOM),
     'ok' => !$failed,

--- a/docs/runbooks/supply-smoke.md
+++ b/docs/runbooks/supply-smoke.md
@@ -35,3 +35,20 @@ php bin/supply_release_check.php
 - `php bin/migrate.php status` (и проверяет, что `Pending: 0`),
 - `php bin/supply_smoke.php`,
 - `php bin/supply_digest.php --threshold=2`.
+
+
+## Дополнительная проверка агрегатов продуктов
+
+Скрипт также проверяет `product_aggregate_anomalies`: расхождения между агрегатами в `products` и суммами по `purchase_batches` (для статусов `active/arrived/purchased`).
+
+Если расхождения есть, можно сначала оценить объём:
+
+```bash
+php bin/supply_repair_product_aggregates.php --dry-run
+```
+
+Затем выполнить выравнивание:
+
+```bash
+php bin/supply_repair_product_aggregates.php
+```

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -70,7 +70,7 @@ class ProductsController
                 p.box_unit,
                 p.unit,
                 COALESCE(pb.purchase_price_per_box, p.price) AS price,
-                p.stock_boxes,
+                p.free_stock_boxes AS stock_boxes,
                 p.is_active,
                 p.image_path,
                 DATE(pb.purchased_at) AS delivery_date
@@ -195,7 +195,6 @@ class ProductsController
         $unit          = ($unitRaw === 'л' ? 'л' : 'кг');
         $price        = (float)$_POST['price']; // price per kg/l
         $salePrice     = (float)($_POST['sale_price'] ?? 0);
-        $stockBoxes    = (float)$_POST['stock_boxes'];
         $isActive      = isset($_POST['is_active']) ? 1 : 0;
 
         // дата поставки (NULL → под заказ)
@@ -274,14 +273,13 @@ class ProductsController
                         unit            = ?,
                         price           = ?,
                         sale_price      = ?,
-                        stock_boxes     = ?,
                         delivery_date   = ?,
                         is_active       = ?";
             $params = [
                 $typeId, $alias, $variety, $description, $fullDesc, $compositionJson,
                 $metaTitle, $metaDesc, $metaKeys,
                 $manufacturer, $originCountry, $boxSize, $boxUnit,
-                $unit, $price, $salePrice, $stockBoxes,
+                $unit, $price, $salePrice,
                 $deliveryDate, $isActive
             ];
 
@@ -308,14 +306,14 @@ class ProductsController
 
         } else {
             // INSERT
-            $columns      = "product_type_id,alias,variety,description,full_description,composition,meta_title,meta_description,meta_keywords,manufacturer,origin_country,box_size,box_unit,unit,price,sale_price,stock_boxes,delivery_date,is_active";
-            // 19 placeholders corresponding to the columns above
-            $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
+            $columns      = "product_type_id,alias,variety,description,full_description,composition,meta_title,meta_description,meta_keywords,manufacturer,origin_country,box_size,box_unit,unit,price,sale_price,delivery_date,is_active";
+            // 18 placeholders corresponding to the columns above
+            $placeholders = "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?";
             $params       = [
                 $typeId, $alias, $variety, $description, $fullDesc, $compositionJson,
                 $metaTitle, $metaDesc, $metaKeys,
                 $manufacturer, $originCountry, $boxSize, $boxUnit,
-                $unit, $price, $salePrice, $stockBoxes,
+                $unit, $price, $salePrice,
                 $deliveryDate, $isActive
             ];
             if ($sellerId) {

--- a/src/Views/admin/products/edit.php
+++ b/src/Views/admin/products/edit.php
@@ -172,13 +172,6 @@
              class="w-full border px-2 py-1 rounded" required>
     </div>
 
-    <!-- Остаток (ящиков) -->
-    <div>
-      <label class="block mb-1">Остаток (ящиков)</label>
-      <input name="stock_boxes" type="number" step="0.01"
-             value="<?= htmlspecialchars($product['stock_boxes'] ?? '') ?>"
-             class="w-full border px-2 py-1 rounded" required>
-    </div>
   </div>
 
   <button type="submit"


### PR DESCRIPTION
### Motivation
- Ensure product stock fields reflect sums from `purchase_batches` and detect discrepancies between `products` aggregates and batch sums. 
- Provide a safe way to measure and repair those discrepancies via a dedicated repair script with a `--dry-run` mode. 
- Remove the deprecated/manual `stock_boxes` product field from the admin editor/save flow to rely on aggregated `free_stock_boxes` instead.

### Description
- Added `bin/supply_repair_product_aggregates.php`, a script that updates `products` stock fields (`free_stock_boxes`, `reserved_stock_boxes`, `discount_stock_boxes`, `sold_stock_boxes`, `written_off_stock_boxes`, `stock_status`) from aggregated `purchase_batches` for statuses `active/arrived/purchased`, with a `--dry-run` mode to report affected products. 
- Extended `bin/supply_smoke.php` to check `product_aggregate_anomalies` by comparing `products` aggregates to summed `purchase_batches`, and mark the smoke as failed when discrepancies exist. 
- Updated `docs/runbooks/supply-smoke.md` to document the new aggregate check and repair workflow. 
- Modified `src/Controllers/ProductsController.php` to stop persisting a manual `stock_boxes` value (use `free_stock_boxes` in the list view) and removed `stock_boxes` handling from product `save`/`insert` flows. 
- Removed the `stock_boxes` input from the admin product edit view `src/Views/admin/products/edit.php` to prevent manual edits of aggregated stock.

### Testing
- Ran PHP lint (`php -l`) on the modified PHP files with no syntax errors reported. 
- Executed the smoke script via `php bin/supply_smoke.php` to validate the new `product_aggregate_anomalies` check (script completes and returns a non-zero exit when anomalies are present). 
- Performed a dry-run of the repair script with `php bin/supply_repair_product_aggregates.php --dry-run` to verify it reports the number of products that would be adjusted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8a8cd92c832c81fb854b35d0adba)