### PR TITLE
Уточнить наличие по закупке и предзаказ по дате поставки

### DIFF
--- a/src/Services/ClientCatalogService.php
+++ b/src/Services/ClientCatalogService.php
@@ -9,7 +9,7 @@ class ClientCatalogService
                  AND pb.status = 'arrived' AND p.discount_stock_boxes > 0";
     private const HOME_IN_STOCK_WHERE = "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL
                  AND p.seller_id IS NULL AND pb.status = 'purchased'
-                 AND p.free_stock_boxes > 0";
+                 AND pb.boxes_free > 0";
     private const HOME_PREORDER_WHERE = "p.is_active = 1 AND p.current_purchase_batch_id IS NOT NULL
                  AND p.seller_id IS NULL AND pb.status = 'planned'";
 
@@ -82,7 +82,7 @@ class ClientCatalogService
         foreach ($products as &$product) {
             $batchStatus = (string)($product['purchase_batch_status'] ?? '');
             $isSeller = !empty($product['seller_id']);
-            $freeStock = (float)($product['free_stock_boxes'] ?? 0);
+            $freeStock = (float)($product['batch_boxes_free'] ?? 0);
             $discountStock = (float)($product['discount_stock_boxes'] ?? 0);
 
             if (!$isSeller && $batchStatus === 'arrived' && $discountStock > 0) {
@@ -130,7 +130,8 @@ class ClientCatalogService
             "       p.is_active,\n" .
             "       p.image_path,\n" .
             "       DATE(pb.purchased_at) AS delivery_date,\n" .
-            "       COALESCE(u.company_name, u.name, 'berryGo') AS seller_name\n" .
+            "       COALESCE(u.company_name, u.name, 'berryGo') AS seller_name,\n" .
+            "       COALESCE(pb.boxes_free, 0) AS batch_boxes_free,\n" .
             "FROM products p\n" .
             "JOIN product_types t ON t.id = p.product_type_id\n" .
             "LEFT JOIN users u ON u.id = p.seller_id\n" .

--- a/src/Views/client/_card.php
+++ b/src/Views/client/_card.php
@@ -23,6 +23,8 @@ $today     = date('Y-m-d');
 $d         = $p['delivery_date']     ?? null;
 $placeholder = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
 $showDate = $d !== null && $d !== $placeholder;
+$preorderDateKnown = $showDate;
+$preorderDateText = $preorderDateKnown ? date('d.m.Y', strtotime((string)$d)) : '';
 $active    = (int)($p['is_active']    ?? 0);
 $price     = floatval($p['price']     ?? 0); // current sale price per box
 $sale      = floatval($p['sale_price']?? 0); // sale price per kg
@@ -250,8 +252,8 @@ $preorderPriceHint = (string)(get_setting('ui_preorder_price_hint', 'Цена о
 
         <!-- Предзаказ — вторичное действие: outline-стиль, меньше веса -->
         <button type="button"
-                <?= $isSaleSection ? 'disabled' : '' ?>
-                class="w-full h-9 flex items-center justify-center gap-1.5 border font-medium text-xs sm:text-sm rounded-xl transition-colors preorder-intent-btn <?= $isSaleSection ? 'border-gray-200 text-gray-400 bg-gray-50 cursor-not-allowed' : 'border-emerald-500 text-emerald-700 hover:bg-emerald-50 active:bg-emerald-100' ?>"
+                <?= ($isSaleSection || !$preorderDateKnown) ? 'disabled' : '' ?>
+                class="w-full h-9 flex items-center justify-center gap-1.5 border font-medium text-xs sm:text-sm rounded-xl transition-colors preorder-intent-btn <?= ($isSaleSection || !$preorderDateKnown) ? 'border-gray-200 text-gray-400 bg-gray-50 cursor-not-allowed' : 'border-emerald-500 text-emerald-700 hover:bg-emerald-50 active:bg-emerald-100' ?>"
                 data-product-id="<?= (int)$p['id'] ?>"
                 data-source-section="<?= htmlspecialchars($cardSection) ?>"
                 data-delivery-date="<?= htmlspecialchars((string)($d ?? '')) ?>">
@@ -259,10 +261,12 @@ $preorderPriceHint = (string)(get_setting('ui_preorder_price_hint', 'Цена о
           <?= $isInStockSection ? 'Предзаказ' : 'Предзаказ −10%' ?>
         </button>
 
-        <?php if ($preorderPurchaseDate !== ''): ?>
+        <?php if ($preorderDateKnown): ?>
+          <p class="mt-1.5 text-[11px] text-gray-400 text-center">Следующая поставка: <?= htmlspecialchars($preorderDateText) ?></p>
+        <?php elseif (!$isSaleSection): ?>
+          <p class="mt-1.5 text-[11px] text-gray-400 text-center">Дата следующей поставки уточняется</p>
+        <?php elseif ($preorderPurchaseDate !== ''): ?>
           <p class="mt-1.5 text-[11px] text-gray-400 text-center">Дата закупки: <?= htmlspecialchars($preorderPurchaseDate) ?></p>
-        <?php elseif ($isInStockSection): ?>
-          <p class="mt-1.5 text-[11px] text-gray-400 text-center">Предзаказ оформляется на ближайшую возможную дату</p>
         <?php endif; ?>
 
         <p class="mt-1.5 text-[11px] text-gray-400 hidden preorder-intent-hint"></p>

--- a/src/Views/client/product.php
+++ b/src/Views/client/product.php
@@ -74,6 +74,10 @@
         $pricePerKg = round($effectiveKg, 2);
         $regularBox = $price * $boxSize;
         $regularKg  = round($price, 2);
+        $deliveryDate = (string)($product['delivery_date'] ?? '');
+        $placeholderDate = defined('PLACEHOLDER_DATE') ? PLACEHOLDER_DATE : '2025-05-15';
+        $preorderDateKnown = ($deliveryDate !== '' && $deliveryDate !== $placeholderDate);
+        $preorderDateText = $preorderDateKnown ? date('d.m.Y', strtotime($deliveryDate)) : '';
         ?>
 
         <!-- Блок цены + кнопок (floating над навбаром на мобиле, встроенный на md+) -->
@@ -152,10 +156,12 @@
 
             <!-- Предзаказ — вторичное действие -->
             <button id="preorderBtn" type="button"
-                    class="w-full h-10 flex items-center justify-center gap-1.5 border border-emerald-500 text-emerald-700 hover:bg-emerald-50 active:bg-emerald-100 font-medium text-sm rounded-xl transition-colors mb-1">
+                    <?= $preorderDateKnown ? '' : 'disabled' ?>
+                    class="w-full h-10 flex items-center justify-center gap-1.5 border font-medium text-sm rounded-xl transition-colors mb-1 <?= $preorderDateKnown ? 'border-emerald-500 text-emerald-700 hover:bg-emerald-50 active:bg-emerald-100' : 'border-gray-200 text-gray-400 bg-gray-50 cursor-not-allowed' ?>">
               <span class="material-icons-round text-base leading-none">schedule</span>
-              Предзаказ −10%
+              <?= $preorderDateKnown ? ('Предзаказ −10% · ' . $preorderDateText) : 'Предзаказ −10%' ?>
             </button>
+            <p class="text-xs text-gray-400 text-center mb-1"><?= $preorderDateKnown ? ('Следующая поставка: ' . htmlspecialchars($preorderDateText)) : 'Дата следующей поставки уточняется' ?></p>
             <p id="preorderHint" class="text-xs text-gray-400 text-center hidden"></p>
 
             <script>


### PR DESCRIPTION
### Motivation
- Сделать отображение раздела «В наличии» корректным и привязанным к реальному свободному остатку в закупке (`purchase_batches.boxes_free`).
- Сделать поведение кнопки «Предзаказ −10%» предсказуемым: показывать дату следующей поставки, если она известна, и блокировать кнопку, если дата неизвестна.

### Description
- В `ClientCatalogService` изменён `HOME_IN_STOCK_WHERE`, теперь используется условие `pb.boxes_free > 0`, и в выборку добавлено поле `COALESCE(pb.boxes_free, 0) AS batch_boxes_free`, после чего логика каталога использует `batch_boxes_free` для определения секции `in_stock`.
- В карточке товара (`src/Views/client/_card.php`) добавлены вычисления `$preorderDateKnown` и `$preorderDateText`, кнопка предзаказа становится неактивной если дата поставки неизвестна или товар в разделе распродажи, и выводится подпись `Следующая поставка: dd.mm.YYYY` или `Дата следующей поставки уточняется`.
- На странице товара (`src/Views/client/product.php`) реализована аналогичная логика: дата поставки добавляется в текст кнопки предзаказа и кнопка блокируется при неизвестной дате, а под кнопкой показывается подсказка с датой или сообщением об её отсутствии.

### Testing
- Выполнены синтаксические проверки PHP командой `php -l` для файлов `src/Services/ClientCatalogService.php`, `src/Views/client/_card.php` и `src/Views/client/product.php`, все проверки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca4722f90832c8fdfb8527799846e)