### PR TITLE
Make monetary prices integer-only in pricing, bot and admin UI

### DIFF
--- a/src/Controllers/BotController.php
+++ b/src/Controllers/BotController.php
@@ -407,7 +407,7 @@ class BotController
 
         // 5) Создаём запись в order_items
         // Для unit_price делим сумму на количество
-        $unitPrice = round($sum / $quantity, 2);
+        $unitPrice = round($sum / $quantity, 0);
         $stmtItem = $this->pdo->prepare("
             INSERT INTO order_items (order_id, product_id, quantity, unit_price)
             VALUES (?, ?, ?, ?)

--- a/src/Services/PricingService.php
+++ b/src/Services/PricingService.php
@@ -79,9 +79,9 @@ class PricingService
             'preorder_price_per_box' => $preorderPricePerBox,
             'instant_price_per_box' => $instantPricePerBox,
             'discount_price_per_box' => $discountPricePerBox,
-            'preorder_unit_price' => round($preorderPricePerBox / $safeBoxSize, 2),
-            'instant_unit_price' => round($instantPricePerBox / $safeBoxSize, 2),
-            'discount_unit_price' => round($discountPricePerBox / $safeBoxSize, 2),
+            'preorder_unit_price' => round($preorderPricePerBox / $safeBoxSize, 0),
+            'instant_unit_price' => round($instantPricePerBox / $safeBoxSize, 0),
+            'discount_unit_price' => round($discountPricePerBox / $safeBoxSize, 0),
         ];
     }
 }

--- a/src/Services/PurchaseBatchService.php
+++ b/src/Services/PurchaseBatchService.php
@@ -369,9 +369,9 @@ class PurchaseBatchService
             'preorder_price_per_box' => $preorderPricePerBox,
             'instant_price_per_box' => $instantPricePerBox,
             'discount_price_per_box' => $discountPricePerBox,
-            'preorder_unit_price' => round($preorderPricePerBox / $safeBoxSize, 2),
-            'instant_unit_price' => round($instantPricePerBox / $safeBoxSize, 2),
-            'discount_unit_price' => round($discountPricePerBox / $safeBoxSize, 2),
+            'preorder_unit_price' => round($preorderPricePerBox / $safeBoxSize, 0),
+            'instant_unit_price' => round($instantPricePerBox / $safeBoxSize, 0),
+            'discount_unit_price' => round($discountPricePerBox / $safeBoxSize, 0),
         ];
     }
 

--- a/src/Views/admin/orders/create.php
+++ b/src/Views/admin/orders/create.php
@@ -253,17 +253,17 @@
       if (q > 0) {
         const row = document.createElement('div');
         row.className = 'flex justify-between';
-        row.innerHTML = '<span>'+i.dataset.name+' × '+q+'</span><span>'+(price*q).toFixed(2)+' ₽</span>';
+        row.innerHTML = '<span>'+i.dataset.name+' × '+q+'</span><span>'+(price*q).toFixed(0)+' ₽</span>';
         itemsList.appendChild(row);
       }
       subtotal += q * price;
     });
-    subtotalEl.textContent = subtotal.toFixed(2) + ' ₽';
+    subtotalEl.textContent = subtotal.toFixed(0) + ' ₽';
     let total = subtotal;
     const referral = referralToggle && !referralToggleWrap.classList.contains('hidden') && referralToggle.checked;
     if (referral) {
       const d = subtotal * 0.1;
-      refEl.textContent = '-' + d.toFixed(2);
+      refEl.textContent = '-' + d.toFixed(0);
       refRow.classList.remove('hidden');
       total -= d;
     } else {
@@ -284,14 +284,14 @@
       isPickup = addressSelect.value === 'pickup';
     }
     const shipping = isPickup ? 0 : 300;
-    shippingEl.textContent = shipping.toFixed(2) + ' ₽';
+    shippingEl.textContent = shipping.toFixed(0) + ' ₽';
     if (shipping > 0) {
       shippingRow.classList.remove('hidden');
     } else {
       shippingRow.classList.add('hidden');
     }
     total += shipping;
-    totalEl.textContent = total.toFixed(2) + ' ₽';
+    totalEl.textContent = total.toFixed(0) + ' ₽';
   }
 
   function loadAddresses(uid) {

--- a/src/Views/admin/purchases/index.php
+++ b/src/Views/admin/purchases/index.php
@@ -162,7 +162,7 @@
             </div>
             <div class="purchase-row-subline text-sm text-gray-800">
               <a class="text-[#C86052] hover:underline font-medium" href="<?= $basePath ?>/purchases/<?= (int)$batch['id'] ?>"><?= htmlspecialchars(trim(($batch['product_name'] ?? '') . ' ' . ($batch['variety'] ?? ''))) ?></a>
-              · Стоимость закупки: <b><?= number_format((float)$batch['purchase_price_per_box'], 2, '.', ' ') ?> ₽</b>
+              · Стоимость закупки: <b><?= number_format((float)$batch['purchase_price_per_box'], 0, '.', ' ') ?> ₽</b>
               · Куплено: <b><?= (float)$batch['boxes_total'] ?></b>
               · Свободно: <b><?= (float)$batch['boxes_free'] ?></b>
             </div>

--- a/src/Views/admin/purchases/show.php
+++ b/src/Views/admin/purchases/show.php
@@ -49,9 +49,9 @@
       <input name="planned_supply_date" type="date" value="<?= htmlspecialchars(substr((string)$batch['purchased_at'], 0, 10)) ?>" class="border px-2 py-1 rounded">
       <select name="status" class="border px-2 py-1 rounded"><?php foreach (['planned','purchased','arrived'] as $st): ?><option value="<?= $st ?>" <?= (($batch['status'] ?? '') === $st) ? 'selected' : '' ?>><?= htmlspecialchars((string)$statusLabels[$st]) ?></option><?php endforeach; ?></select>
       <input name="boxes_total" type="number" step="0.01" value="<?= (float)$batch['boxes_total'] ?>" class="border px-2 py-1 rounded" required>
-      <input name="purchase_price_per_box" type="number" step="0.01" value="<?= (float)$batch['purchase_price_per_box'] ?>" class="border px-2 py-1 rounded" required>
-      <input name="instant_price_per_box" type="number" step="0.01" value="<?= (float)($batch['instant_price_per_box'] ?? 0) ?>" class="border px-2 py-1 rounded" placeholder="Свободная цена">
-      <input name="preorder_price_per_box" type="number" step="0.01" value="<?= (float)($batch['preorder_price_per_box'] ?? 0) ?>" class="border px-2 py-1 rounded" placeholder="Цена по брони">
+      <input name="purchase_price_per_box" type="number" step="1" value="<?= (int)round((float)$batch['purchase_price_per_box']) ?>" class="border px-2 py-1 rounded" required>
+      <input name="instant_price_per_box" type="number" step="1" value="<?= (int)round((float)($batch['instant_price_per_box'] ?? 0)) ?>" class="border px-2 py-1 rounded" placeholder="Свободная цена">
+      <input name="preorder_price_per_box" type="number" step="1" value="<?= (int)round((float)($batch['preorder_price_per_box'] ?? 0)) ?>" class="border px-2 py-1 rounded" placeholder="Цена по брони">
       <input name="boxes_free" type="number" step="0.01" value="<?= (float)$batch['boxes_free'] ?>" class="border px-2 py-1 rounded" required>
       <input name="boxes_reserved" type="number" step="0.01" value="<?= (float)$batch['boxes_reserved'] ?>" class="border px-2 py-1 rounded" required>
       <input name="extra_cost_per_box" type="number" step="0.01" value="<?= (float)$batch['extra_cost_per_box'] ?>" class="border px-2 py-1 rounded">
@@ -79,15 +79,15 @@
 <div class="bg-white p-4 rounded shadow mb-4">
   <h3 class="font-semibold mb-2">P&L партии</h3>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
-    <p><b>Выручка (продано):</b> <?= number_format((float)($pnl['revenue_sold'] ?? 0), 2, '.', ' ') ?> ₽</p>
-    <p><b>Выручка (выгодный остаток):</b> <?= number_format((float)($pnl['revenue_discount'] ?? 0), 2, '.', ' ') ?> ₽</p>
-    <p><b>Выручка (итого):</b> <?= number_format((float)($pnl['revenue_total'] ?? 0), 2, '.', ' ') ?> ₽</p>
-    <p><b>Себестоимость (продано):</b> <?= number_format((float)($pnl['cost_sold'] ?? 0), 2, '.', ' ') ?> ₽</p>
-    <p><b>Себестоимость (выгодный остаток):</b> <?= number_format((float)($pnl['cost_discount'] ?? 0), 2, '.', ' ') ?> ₽</p>
-    <p><b>Себестоимость (списано):</b> <?= number_format((float)($pnl['cost_written_off'] ?? 0), 2, '.', ' ') ?> ₽</p>
-    <p><b>Себестоимость (признано):</b> <?= number_format((float)($pnl['cost_total_recognized'] ?? 0), 2, '.', ' ') ?> ₽</p>
-    <p><b>Валовая маржа:</b> <?= number_format((float)($pnl['gross_margin'] ?? 0), 2, '.', ' ') ?> ₽</p>
-    <p><b>Остаток в деньгах:</b> <?= number_format((float)($pnl['inventory_value_remaining'] ?? 0), 2, '.', ' ') ?> ₽</p>
+    <p><b>Выручка (продано):</b> <?= number_format((float)($pnl['revenue_sold'] ?? 0), 0, '.', ' ') ?> ₽</p>
+    <p><b>Выручка (выгодный остаток):</b> <?= number_format((float)($pnl['revenue_discount'] ?? 0), 0, '.', ' ') ?> ₽</p>
+    <p><b>Выручка (итого):</b> <?= number_format((float)($pnl['revenue_total'] ?? 0), 0, '.', ' ') ?> ₽</p>
+    <p><b>Себестоимость (продано):</b> <?= number_format((float)($pnl['cost_sold'] ?? 0), 0, '.', ' ') ?> ₽</p>
+    <p><b>Себестоимость (выгодный остаток):</b> <?= number_format((float)($pnl['cost_discount'] ?? 0), 0, '.', ' ') ?> ₽</p>
+    <p><b>Себестоимость (списано):</b> <?= number_format((float)($pnl['cost_written_off'] ?? 0), 0, '.', ' ') ?> ₽</p>
+    <p><b>Себестоимость (признано):</b> <?= number_format((float)($pnl['cost_total_recognized'] ?? 0), 0, '.', ' ') ?> ₽</p>
+    <p><b>Валовая маржа:</b> <?= number_format((float)($pnl['gross_margin'] ?? 0), 0, '.', ' ') ?> ₽</p>
+    <p><b>Остаток в деньгах:</b> <?= number_format((float)($pnl['inventory_value_remaining'] ?? 0), 0, '.', ' ') ?> ₽</p>
   </div>
 </div>
 

--- a/src/Views/admin/seller_orders.php
+++ b/src/Views/admin/seller_orders.php
@@ -41,14 +41,14 @@
         <li>
           <?= htmlspecialchars($it['product_name']) ?><?php if ($it['variety']): ?> «<?= htmlspecialchars($it['variety']) ?>»<?php endif; ?>,
           <?= rtrim(rtrim(number_format($it['boxes'],2,'.',''), '0'), '.') ?> ящ. (<?= rtrim(rtrim(number_format($it['quantity'],2,'.',''), '0'), '.') ?> <?= htmlspecialchars($it['box_unit']) ?>)
-          <span class="float-right"><?= number_format($itemTotal, 2, '.', ' ') ?> ₽</span>
+          <span class="float-right"><?= number_format($itemTotal, 0, '.', ' ') ?> ₽</span>
         </li>
       <?php endforeach; ?>
     </ul>
-    <div class="text-sm flex justify-between"><span>Стоимость позиций (итого)</span><span><?= number_format($o['seller_subtotal'], 2, '.', ' ') ?> ₽</span></div>
-    <div class="text-sm flex justify-between"><span>Оплачено клубничками</span><span><?= number_format($o['points_applied'], 2, '.', ' ') ?> ₽</span></div>
-    <div class="text-sm flex justify-between"><span>Комиссия BerryGo (<?= (float)$o['commission_rate'] ?>%)</span><span><?= number_format($o['commission'], 2, '.', ' ') ?> ₽</span></div>
-    <div class="text-sm flex justify-between font-semibold"><span>Выплата селлеру</span><span><?= number_format($o['payout'], 2, '.', ' ') ?> ₽</span></div>
+    <div class="text-sm flex justify-between"><span>Стоимость позиций (итого)</span><span><?= number_format($o['seller_subtotal'], 0, '.', ' ') ?> ₽</span></div>
+    <div class="text-sm flex justify-between"><span>Оплачено клубничками</span><span><?= number_format($o['points_applied'], 0, '.', ' ') ?> ₽</span></div>
+    <div class="text-sm flex justify-between"><span>Комиссия BerryGo (<?= (float)$o['commission_rate'] ?>%)</span><span><?= number_format($o['commission'], 0, '.', ' ') ?> ₽</span></div>
+    <div class="text-sm flex justify-between font-semibold"><span>Выплата селлеру</span><span><?= number_format($o['payout'], 0, '.', ' ') ?> ₽</span></div>
     <div class="mt-2 flex flex-wrap gap-2 text-sm">
       <?php if ($o['status'] === 'new'): ?>
         <form method="post" action="/seller/orders/status">

--- a/src/Views/admin/sellers/show.php
+++ b/src/Views/admin/sellers/show.php
@@ -26,14 +26,14 @@
           <li>
             <?= htmlspecialchars($it['product_name']) ?><?php if ($it['variety']): ?> «<?= htmlspecialchars($it['variety']) ?>»<?php endif; ?>,
             <?= rtrim(rtrim(number_format($it['boxes'],2,'.',''), '0'), '.') ?> ящ. (<?= rtrim(rtrim(number_format($it['quantity'],2,'.',''), '0'), '.') ?> <?= htmlspecialchars($it['box_unit']) ?>)
-            <span class="float-right"><?= number_format($itemTotal, 2, '.', ' ') ?> ₽</span>
+            <span class="float-right"><?= number_format($itemTotal, 0, '.', ' ') ?> ₽</span>
           </li>
         <?php endforeach; ?>
       </ul>
-      <div class="text-sm flex justify-between"><span>Стоимость позиций (итого)</span><span><?= number_format($o['seller_subtotal'], 2, '.', ' ') ?> ₽</span></div>
-      <div class="text-sm flex justify-between"><span>Оплачено клубничками</span><span><?= number_format($o['points_applied'], 2, '.', ' ') ?> ₽</span></div>
-      <div class="text-sm flex justify-between"><span>Комиссия BerryGo (<?= (float)$o['commission_rate'] ?>%)</span><span><?= number_format($o['commission'], 2, '.', ' ') ?> ₽</span></div>
-      <div class="text-sm flex justify-between font-semibold"><span>Выплата селлеру</span><span><?= number_format($o['payout'], 2, '.', ' ') ?> ₽</span></div>
+      <div class="text-sm flex justify-between"><span>Стоимость позиций (итого)</span><span><?= number_format($o['seller_subtotal'], 0, '.', ' ') ?> ₽</span></div>
+      <div class="text-sm flex justify-between"><span>Оплачено клубничками</span><span><?= number_format($o['points_applied'], 0, '.', ' ') ?> ₽</span></div>
+      <div class="text-sm flex justify-between"><span>Комиссия BerryGo (<?= (float)$o['commission_rate'] ?>%)</span><span><?= number_format($o['commission'], 0, '.', ' ') ?> ₽</span></div>
+      <div class="text-sm flex justify-between font-semibold"><span>Выплата селлеру</span><span><?= number_format($o['payout'], 0, '.', ' ') ?> ₽</span></div>
     </div>
   <?php endforeach; ?>
 <?php else: ?>


### PR DESCRIPTION
### Motivation
- The app should display and accept monetary values in whole rubles only, removing fractional kopiykas in pricing and admin flows.
- Ensure pricing calculations and order item unit prices produce integer ruble values for consistent presentation and input.
- Update admin UI and summaries so all monetary fields and JS summaries show whole-ruble amounts.

### Description
- Round unit prices to whole rubles in pricing logic by changing `preorder_unit_price`, `instant_unit_price` and `discount_unit_price` to `round(..., 0)` in `src/Services/PricingService.php` and `src/Services/PurchaseBatchService.php`.
- Use integer rounding for bot order item unit price in `src/Controllers/BotController.php` by replacing `round(..., 2)` with `round(..., 0)` when creating `order_items`.
- Switch admin purchase per-box inputs to `step="1"` and output integer values via `(int)round(...)`, and change P&L and purchase list displays to `number_format(..., 0)` in `src/Views/admin/purchases/show.php` and `src/Views/admin/purchases/index.php`.
- Render seller/admin order sums without decimals and update admin order-creation JS to use `toFixed(0)` for line/subtotal/discount/shipping/total in `src/Views/admin/sellers/show.php`, `src/Views/admin/seller_orders.php`, and `src/Views/admin/orders/create.php`.

### Testing
- Ran PHP syntax checks for modified PHP files with `php -l` (`src/Controllers/BotController.php`, `src/Services/PricingService.php`, `src/Services/PurchaseBatchService.php`, `src/Views/admin/purchases/show.php`, `src/Views/admin/purchases/index.php`, `src/Views/admin/sellers/show.php`, `src/Views/admin/seller_orders.php`, `src/Views/admin/orders/create.php`) and there were no syntax errors.
- No additional automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcf8cb2b0832c96d46a0bd9892e16)