### PR TITLE
Восстановление свободных боксов при отмене или удалении заказа

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -8,6 +8,8 @@ use App\Helpers\ReferralHelper;
 use App\Helpers\PhoneNormalizer;
 use App\Models\OrdersRepository;
 use App\Services\AdminOrdersPageService;
+use App\Services\OrderStockOrchestrator;
+use App\Services\StockService;
 
 class OrdersController
 {
@@ -443,6 +445,12 @@ class OrdersController
                 $stmt->execute([$status, $orderId]);
 
                 if ($status === 'cancelled') {
+                    if ($order['status'] !== 'cancelled') {
+                        $stockService = new StockService($this->pdo);
+                        $orderStock = new OrderStockOrchestrator($this->pdo, $stockService);
+                        $orderStock->rollbackReservationByOrderId($orderId);
+                    }
+
                     $cnt = $this->pdo->prepare(
                         "SELECT COUNT(*) FROM orders WHERE user_id = ? AND id <> ? AND status <> 'cancelled'"
                     );
@@ -756,6 +764,12 @@ class OrdersController
             $stmt->execute([$orderId]);
             $order = $stmt->fetch(PDO::FETCH_ASSOC);
             $userId = (int)($order['user_id'] ?? 0);
+
+            if (($order['status'] ?? '') !== 'cancelled') {
+                $stockService = new StockService($this->pdo);
+                $orderStock = new OrderStockOrchestrator($this->pdo, $stockService);
+                $orderStock->rollbackReservationByOrderId($orderId);
+            }
 
             $this->pdo->prepare("DELETE FROM order_items WHERE order_id = ?")->execute([$orderId]);
             $this->pdo->prepare("DELETE FROM points_transactions WHERE order_id = ?")->execute([$orderId]);


### PR DESCRIPTION
### Motivation
- Исправить баг, при котором при переводе заказа в статус `cancelled` или при его удалении свободные боксы в партиях закупки не возвращались, что вело к неверным остатков.
- Обеспечить единообразный откат резервов через существующий оркестратор стока для всех кейсов отмены/удаления заказа.

### Description
- Добавлены импорты `OrderStockOrchestrator` и `StockService` в `src/Controllers/OrdersController.php`.
- В `updateStatus()` при переводе заказа в `cancelled` теперь при условии, что предыдущий статус отличался от `cancelled`, вызывается `OrderStockOrchestrator::rollbackReservationByOrderId($orderId)` для восстановления резервов.
- В `delete()` перед удалением элементов заказа для неотменённых заказов также вызывается `OrderStockOrchestrator::rollbackReservationByOrderId($orderId)`.
- Используется `StockService` при создании оркестратора для корректного вызова `unreserve`/восстановления боксов.

### Testing
- Запущена синтаксическая проверка `php -l src/Controllers/OrdersController.php`, которая прошла без ошибок.
- Попытка запустить юнит-тесты через `vendor/bin/phpunit tests/StockServiceTest.php tests/OrdersControllerTest.php` не выполнена, так как `vendor/bin/phpunit` отсутствует в окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6485a230832c97c27067cdfe5cb9)