### PR TITLE
Add author label for staff-created orders on /admin/orders

### DIFF
--- a/database/2026_15_orders_created_by_user.sql
+++ b/database/2026_15_orders_created_by_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+  ADD COLUMN created_by_user_id INT NULL AFTER delivery_date;

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -259,9 +259,10 @@ class OrdersController
           $total += $shippingFee;
 
         $stmt = $this->pdo->prepare(
-            "INSERT INTO orders (user_id, address_id, slot_id, status, total_amount, discount_applied, points_used, points_accrued, coupon_code, delivery_date, created_at) VALUES (?, ?, ?, 'new', ?, 0, ?, 0, ?, ?, NOW())"
+            "INSERT INTO orders (user_id, address_id, slot_id, status, total_amount, discount_applied, points_used, points_accrued, coupon_code, delivery_date, created_by_user_id, created_at) VALUES (?, ?, ?, 'new', ?, 0, ?, 0, ?, ?, ?, NOW())"
         );
-        $stmt->execute([$userId, $addressId, $slotId, $total, $pointsUsed, $couponCode, $deliveryDate]);
+        $createdByUserId = (int)($_SESSION['user_id'] ?? 0);
+        $stmt->execute([$userId, $addressId, $slotId, $total, $pointsUsed, $couponCode, $deliveryDate, $createdByUserId > 0 ? $createdByUserId : null]);
         $orderId = (int)$this->pdo->lastInsertId();
 
         $stmtItem = $this->pdo->prepare(

--- a/src/Models/OrdersRepository.php
+++ b/src/Models/OrdersRepository.php
@@ -27,7 +27,8 @@ class OrdersRepository
                "FROM orders o\n" .
                "JOIN users u ON u.id = o.user_id\n" .
                "LEFT JOIN addresses a ON a.id = o.address_id\n" .
-               "LEFT JOIN delivery_slots d ON d.id = o.slot_id";
+               "LEFT JOIN delivery_slots d ON d.id = o.slot_id
+LEFT JOIN users au ON au.id = o.created_by_user_id";
         $params = [];
         if ($managerId > 0) {
             $sql .= " WHERE u.referred_by = ?";

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -62,7 +62,7 @@
       <div class="order-card block bg-white p-2 sm:p-4 rounded shadow hover:bg-gray-50 <?= $bg ?>" data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" data-created="<?= $createdAttr ?>" data-id="<?= $o['id'] ?>" data-delivery="<?= $deliveryAttr ?>" data-slot="<?= $slotAttr ?>">
         <div class="flex justify-between items-center">
           <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col font-bold<?php if($isStaff): ?> text-white decoration-white<?php endif; ?>">
-            #<?= $o['id'] ?> <?php if ($o['delivery_date']): ?> | <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?>
+            #<?= $o['id'] ?> <?php if ($o['delivery_date']): ?> | <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?><?php if (!empty($o['author_name']) && in_array($o['author_role'] ?? '', ['manager','partner','admin'], true)): ?> | автор: <?= htmlspecialchars($o['author_name']) ?><?php endif; ?>
           </a>
           <span class="inline-flex items-center px-2 py-0.5 rounded-full text-sm font-medium <?= order_status_info($o['status'])['badge'] ?>">
             <?= order_status_info($o['status'])['label'] ?>

--- a/tests/AdminOrdersPageServiceTest.php
+++ b/tests/AdminOrdersPageServiceTest.php
@@ -44,6 +44,7 @@ class AdminOrdersPageServiceTest extends TestCase
             coupon_code TEXT NULL,
             discount_applied INTEGER DEFAULT 0,
             comment TEXT NULL,
+            created_by_user_id INTEGER NULL,
             created_at TEXT
         )');
         $this->pdo->exec('CREATE TABLE product_types (id INTEGER PRIMARY KEY, name TEXT)');
@@ -73,13 +74,14 @@ class AdminOrdersPageServiceTest extends TestCase
 
         $this->pdo->exec("INSERT INTO users (id, name, phone, role, referral_code, has_used_referral_coupon) VALUES
             (1, 'Client', '79000000001', 'client', 'REF01', 0),
-            (2, 'Manager', '79000000002', 'manager', NULL, 0)");
+            (2, 'Manager', '79000000002', 'manager', NULL, 0),
+            (3, 'Admin', '79000000003', 'admin', NULL, 0)");
         $this->pdo->exec("INSERT INTO addresses (id, user_id, street, is_primary, created_at) VALUES
             (1, 1, 'Main st', 1, '2025-03-20 10:00:00'),
             (2, 1, 'Second st', 0, '2025-03-21 10:00:00')");
         $this->pdo->exec("INSERT INTO delivery_slots (id, time_from, time_to) VALUES (1, '09:00', '12:00')");
-        $this->pdo->exec("INSERT INTO orders (id, user_id, address_id, slot_id, status, total_amount, delivery_date, points_used, coupon_code, discount_applied, comment, created_at)
-            VALUES (1, 1, 1, 1, 'new', 1200, '2025-03-25', 70, 'POINTS70', 70, 'comment', '2025-03-20 10:00:00')");
+        $this->pdo->exec("INSERT INTO orders (id, user_id, address_id, slot_id, status, total_amount, delivery_date, points_used, coupon_code, discount_applied, comment, created_by_user_id, created_at)
+            VALUES (1, 1, 1, 1, 'new', 1200, '2025-03-25', 70, 'POINTS70', 70, 'comment', 3, '2025-03-20 10:00:00')");
         $this->pdo->exec("INSERT INTO product_types (id, name) VALUES (1, 'Клубника')");
         $this->pdo->exec("INSERT INTO products (id, product_type_id, variety, unit, box_size, box_unit, is_active) VALUES
             (1, 1, 'Клери', 'кг', 2, 'кг', 1)");


### PR DESCRIPTION
### Motivation
- Staff-created orders need an explicit author mark so admin views show who (manager/partner/admin) created an order. 

### Description
- Add a migration `database/2026_15_orders_created_by_user.sql` to add `orders.created_by_user_id` to persist the creator. 
- Save the current session user as `created_by_user_id` in manual order creation by updating `storeManual` insert in `src/Controllers/OrdersController.php`. 
- Extend the admin orders query path by joining `users au` to allow resolving the author when present in `src/Models/OrdersRepository.php`. 
- Show `| автор: <name>` in the `/admin/orders` list line when the creator exists and has role `manager`, `partner`, or `admin` by updating `src/Views/admin/orders/index.php`. 
- Update the test fixture in `tests/AdminOrdersPageServiceTest.php` schema and seed data to include the new `created_by_user_id` column and an admin user row. 

### Testing
- Ran PHP syntax checks with `php -l` on `src/Models/OrdersRepository.php`, `src/Controllers/OrdersController.php`, and `src/Views/admin/orders/index.php`, and all passed. 
- Attempted to run `phpunit --filter AdminOrdersPageServiceTest` but the container lacks the `phpunit` binary, so PHPUnit could not be executed (`phpunit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e80bd667c832cb55ff2bee3da489a)