### PR TITLE
Add order creator tracking and surface it in admin UI with responsive tweaks

### DIFF
--- a/database/2026_15_orders_created_by_user.sql
+++ b/database/2026_15_orders_created_by_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+  ADD COLUMN created_by_user_id INT NULL AFTER delivery_date;

--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -259,9 +259,10 @@ class OrdersController
           $total += $shippingFee;
 
         $stmt = $this->pdo->prepare(
-            "INSERT INTO orders (user_id, address_id, slot_id, status, total_amount, discount_applied, points_used, points_accrued, coupon_code, delivery_date, created_at) VALUES (?, ?, ?, 'new', ?, 0, ?, 0, ?, ?, NOW())"
+            "INSERT INTO orders (user_id, address_id, slot_id, status, total_amount, discount_applied, points_used, points_accrued, coupon_code, delivery_date, created_by_user_id, created_at) VALUES (?, ?, ?, 'new', ?, 0, ?, 0, ?, ?, ?, NOW())"
         );
-        $stmt->execute([$userId, $addressId, $slotId, $total, $pointsUsed, $couponCode, $deliveryDate]);
+        $createdByUserId = (int)($_SESSION['user_id'] ?? 0);
+        $stmt->execute([$userId, $addressId, $slotId, $total, $pointsUsed, $couponCode, $deliveryDate, $createdByUserId > 0 ? $createdByUserId : null]);
         $orderId = (int)$this->pdo->lastInsertId();
 
         $stmtItem = $this->pdo->prepare(

--- a/src/Models/OrdersRepository.php
+++ b/src/Models/OrdersRepository.php
@@ -19,15 +19,17 @@ class OrdersRepository
      */
     public function fetchOrdersForIndex(int $managerId, int $limit, int $offset): array
     {
-        $sql = "SELECT o.id, o.status, o.total_amount, o.delivery_date,\n" .
+        $sql = "SELECT o.id, o.user_id, o.status, o.total_amount, o.delivery_date,\n" .
                "       o.points_used, o.coupon_code, o.discount_applied,\n" .
                "       o.slot_id, d.time_from AS slot_from, d.time_to AS slot_to,\n" .
                "       u.name AS client_name, u.phone, a.street AS address,\n" .
+               "       o.created_by_user_id, au.name AS author_name, au.role AS author_role,\n" .
                "       o.created_at, o.comment\n" .
                "FROM orders o\n" .
                "JOIN users u ON u.id = o.user_id\n" .
                "LEFT JOIN addresses a ON a.id = o.address_id\n" .
-               "LEFT JOIN delivery_slots d ON d.id = o.slot_id";
+               "LEFT JOIN delivery_slots d ON d.id = o.slot_id
+LEFT JOIN users au ON au.id = o.created_by_user_id";
         $params = [];
         if ($managerId > 0) {
             $sql .= " WHERE u.referred_by = ?";

--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -2,18 +2,91 @@
 <?php $role = $_SESSION['role'] ?? ''; $isManager = ($role === 'manager'); $isStaff = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 <?php $managers = $managers ?? []; $selectedManager = $selectedManager ?? 0; $slots = $slots ?? []; ?>
 <style>
-  @media (max-width: 640px) {
+  /* mobile-first compact layout */
+  .orders-filter {
+    margin-bottom: 0.5rem;
+    gap: 0.375rem;
+  }
+  .orders-filter a,
+  .orders-filter select,
+  .orders-filter button,
+  .orders-filter input,
+  .date-filter button {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1.1;
+  }
+  .date-filter {
+    margin-bottom: 0.5rem;
+    gap: 0.375rem;
+  }
+  #ordersCards {
+    gap: 0.375rem;
+  }
+  .order-card {
+    padding: 0.375rem 0.5rem !important;
+    border-radius: 0.5rem;
+  }
+  .order-card .font-bold {
+    font-size: 0.8rem;
+    line-height: 1.15;
+  }
+  .order-card .text-sm {
+    font-size: 0.75rem !important;
+    line-height: 1.2;
+  }
+  .order-card .font-semibold {
+    font-size: 0.8rem;
+    line-height: 1.2;
+  }
+  .order-card .mt-2 {
+    margin-top: 0.25rem;
+  }
+  .order-card .mt-1 {
+    margin-top: 0.2rem;
+  }
+  .order-card .pt-1 {
+    padding-top: 0.2rem;
+  }
+  .order-card .py-0\.5 {
+    padding-top: 0.05rem;
+    padding-bottom: 0.05rem;
+  }
+  .order-card .px-2 {
+    padding-left: 0.375rem;
+    padding-right: 0.375rem;
+  }
+
+  @media (min-width: 641px) {
+    .orders-filter {
+      margin-bottom: 1rem;
+      gap: 0.5rem;
+    }
+    .orders-filter a,
     .orders-filter select,
     .orders-filter button,
     .orders-filter input,
     .date-filter button {
-      padding: 0.25rem 0.5rem;
-      font-size: 0.75rem;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.875rem;
+      line-height: 1.25;
     }
-    .orders-table th,
-    .orders-table td {
-      padding: 0.25rem;
-      font-size: 0.75rem;
+    .date-filter {
+      margin-bottom: 1rem;
+      gap: 0.5rem;
+    }
+    .order-card {
+      padding: 0.75rem 1rem !important;
+      border-radius: 0.75rem;
+    }
+    .order-card .font-bold {
+      font-size: 1rem;
+    }
+    .order-card .text-sm {
+      font-size: 0.875rem !important;
+    }
+    .order-card .font-semibold {
+      font-size: 0.95rem;
     }
   }
 </style>
@@ -62,7 +135,7 @@
       <div class="order-card block bg-white p-2 sm:p-4 rounded shadow hover:bg-gray-50 <?= $bg ?>" data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" data-created="<?= $createdAttr ?>" data-id="<?= $o['id'] ?>" data-delivery="<?= $deliveryAttr ?>" data-slot="<?= $slotAttr ?>">
         <div class="flex justify-between items-center">
           <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col font-bold<?php if($isStaff): ?> text-white decoration-white<?php endif; ?>">
-            #<?= $o['id'] ?> <?php if ($o['delivery_date']): ?> | <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?>
+            #<?= $o['id'] ?> <?php if ($o['delivery_date']): ?> | <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?><?php if (!empty($o['created_by_user_id']) && (int)$o['created_by_user_id'] !== (int)$o['user_id']): ?> | id добавившего: <?= (int)$o['created_by_user_id'] ?><?php endif; ?>
           </a>
           <span class="inline-flex items-center px-2 py-0.5 rounded-full text-sm font-medium <?= order_status_info($o['status'])['badge'] ?>">
             <?= order_status_info($o['status'])['label'] ?>

--- a/src/Views/admin/orders/show.php
+++ b/src/Views/admin/orders/show.php
@@ -1,24 +1,63 @@
 <?php /** @var array $order @var array $items @var array $addresses @var array $slots @var array $products */ ?>
 <?php $role = $_SESSION['role'] ?? ''; $isManager = in_array($role, ['manager','partner'], true); $base = $role === 'manager' ? '/manager' : ($role === 'partner' ? '/partner' : '/admin'); ?>
 <style>
-  @media (max-width: 640px) {
-    .order-details { font-size: 0.8125rem; }
-    .order-details .card { padding: 0.5rem; }
+  /* Mobile-first compact page */
+  .order-details { font-size: 0.78rem; gap: 0.5rem; }
+  .order-details .card { padding: 0.5rem; border-radius: 0.5rem; }
+  .order-details .row-gap { gap: 0.35rem; }
+  .order-details .compact { margin: 0.1rem 0; }
+  .order-details button,
+  .order-details .action-link,
+  .order-details input,
+  .order-details select,
+  .order-details textarea {
+    padding: 0.2rem 0.4rem;
+    font-size: 0.75rem;
+    line-height: 1.15;
+  }
+  .order-details input[type="number"] { width: 4.2rem; }
+  .order-details .header-meta { gap: 0.25rem 0.5rem; }
+  .order-details .items-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.3rem;
+  }
+  .order-details .items-row form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.3rem;
+  }
+  .order-details .status-buttons { gap: 0.35rem; }
+  .order-details .status-buttons button { padding: 0.25rem 0.5rem; }
+  .order-details .status-buttons .delete-wrap { margin-left: 0; }
+
+  @media (min-width: 641px) {
+    .order-details { font-size: 0.875rem; gap: 1rem; }
+    .order-details .card { padding: 1rem; border-radius: 0.75rem; }
     .order-details button,
     .order-details .action-link,
     .order-details input,
     .order-details select,
     .order-details textarea {
-      padding: 0.2rem 0.4rem;
-      font-size: 0.75rem;
+      padding: 0.35rem 0.6rem;
+      font-size: 0.875rem;
+      line-height: 1.25;
     }
-    .order-details .row-gap { gap: 0.35rem; }
-    .order-details .compact { margin: 0.125rem 0; }
+    .order-details input[type="number"] { width: 5rem; }
+    .order-details .items-row {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .order-details .items-row form { gap: 0.5rem; }
+    .order-details .status-buttons { gap: 0.5rem; }
+    .order-details .status-buttons .delete-wrap { margin-left: auto; }
   }
 </style>
 <div class="order-details space-y-4">
   <div class="flex justify-between items-center bg-white p-4 rounded shadow card">
-    <div class="flex flex-wrap items-center gap-2">
+    <div class="flex flex-wrap items-center header-meta">
       <span class="font-semibold">Заказ #<?= $order['id'] ?></span>
       <span><?= htmlspecialchars($order['client_name']) ?></span>
       <span><?= htmlspecialchars($order['phone']) ?></span>
@@ -34,7 +73,7 @@
   <div class="bg-white p-4 rounded shadow card space-y-1">
     <?php foreach ($items as $it): ?>
       <?php $lineCost = $it['quantity'] * $it['unit_price']; ?>
-      <div class="flex justify-between items-center py-1 compact">
+      <div class="flex justify-between items-center py-1 compact items-row">
         <span>
           <?= htmlspecialchars($it['product_name']) ?>
           <?php if (!empty($it['variety'])): ?> <?= htmlspecialchars($it['variety']) ?><?php endif; ?>
@@ -138,7 +177,7 @@
     </div>
   </form>
 
-  <div class="flex flex-wrap gap-2 items-center">
+  <div class="flex flex-wrap gap-2 items-center status-buttons">
     <?php $btnClasses = [
         'processing' => 'bg-yellow-700 hover:bg-yellow-800',
         'assigned'   => 'bg-green-700 hover:bg-green-800',
@@ -157,7 +196,7 @@
         <button class="px-3 py-1 rounded text-white <?= $btnClasses[$st] ?>" type="submit"><?= $label ?></button>
       </form>
     <?php endforeach; ?>
-    <form class="ml-auto" action="<?= $base ?>/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
+    <form class="delete-wrap" action="<?= $base ?>/orders/delete" method="post" onsubmit="return confirm('Удалить этот заказ?');">
       <input type="hidden" name="order_id" value="<?= $order['id'] ?>">
       <button class="px-3 py-1 rounded text-white bg-red-700 hover:bg-red-800" type="submit" title="Удалить">🗑️</button>
     </form>

--- a/tests/AdminOrdersPageServiceTest.php
+++ b/tests/AdminOrdersPageServiceTest.php
@@ -44,6 +44,7 @@ class AdminOrdersPageServiceTest extends TestCase
             coupon_code TEXT NULL,
             discount_applied INTEGER DEFAULT 0,
             comment TEXT NULL,
+            created_by_user_id INTEGER NULL,
             created_at TEXT
         )');
         $this->pdo->exec('CREATE TABLE product_types (id INTEGER PRIMARY KEY, name TEXT)');
@@ -73,13 +74,14 @@ class AdminOrdersPageServiceTest extends TestCase
 
         $this->pdo->exec("INSERT INTO users (id, name, phone, role, referral_code, has_used_referral_coupon) VALUES
             (1, 'Client', '79000000001', 'client', 'REF01', 0),
-            (2, 'Manager', '79000000002', 'manager', NULL, 0)");
+            (2, 'Manager', '79000000002', 'manager', NULL, 0),
+            (3, 'Admin', '79000000003', 'admin', NULL, 0)");
         $this->pdo->exec("INSERT INTO addresses (id, user_id, street, is_primary, created_at) VALUES
             (1, 1, 'Main st', 1, '2025-03-20 10:00:00'),
             (2, 1, 'Second st', 0, '2025-03-21 10:00:00')");
         $this->pdo->exec("INSERT INTO delivery_slots (id, time_from, time_to) VALUES (1, '09:00', '12:00')");
-        $this->pdo->exec("INSERT INTO orders (id, user_id, address_id, slot_id, status, total_amount, delivery_date, points_used, coupon_code, discount_applied, comment, created_at)
-            VALUES (1, 1, 1, 1, 'new', 1200, '2025-03-25', 70, 'POINTS70', 70, 'comment', '2025-03-20 10:00:00')");
+        $this->pdo->exec("INSERT INTO orders (id, user_id, address_id, slot_id, status, total_amount, delivery_date, points_used, coupon_code, discount_applied, comment, created_by_user_id, created_at)
+            VALUES (1, 1, 1, 1, 'new', 1200, '2025-03-25', 70, 'POINTS70', 70, 'comment', 3, '2025-03-20 10:00:00')");
         $this->pdo->exec("INSERT INTO product_types (id, name) VALUES (1, 'Клубника')");
         $this->pdo->exec("INSERT INTO products (id, product_type_id, variety, unit, box_size, box_unit, is_active) VALUES
             (1, 1, 'Клери', 'кг', 2, 'кг', 1)");


### PR DESCRIPTION
### Motivation

- Record which staff/user created an order so admins can see the author of orders in listings and details. 
- Improve admin pages' responsive layout for more compact mobile presentation while surfacing the new creator metadata. 

### Description

- Add a migration `database/2026_15_orders_created_by_user.sql` that adds `created_by_user_id` to the `orders` table. 
- Update `src/Controllers/OrdersController.php` to include `created_by_user_id` in the `INSERT` using `(int)($_SESSION['user_id'] ?? 0)` and insert `NULL` when absent. 
- Extend `src/Models/OrdersRepository.php::fetchOrdersForIndex` to select `o.user_id`, `o.created_by_user_id` and join `users au` to expose the author name/role. 
- Update admin list view `src/Views/admin/orders/index.php` to show the creator ID when different from the client and apply compact/responsive CSS refinements for order cards. 
- Update order detail view `src/Views/admin/orders/show.php` with compact mobile-first styles, layout adjustments and minor class renames for status/delete buttons. 
- Adjust `tests/AdminOrdersPageServiceTest.php` to include the `created_by_user_id` column in the in-memory schema and seed an order with `created_by_user_id = 3` and an `Admin` user. 

### Testing

- Ran the PHPUnit suite with the modified tests and `AdminOrdersPageServiceTest` completed successfully. 
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e80bd667c832cb55ff2bee3da489a)