### PR TITLE
Replace WhatsApp link with Telegram on admin orders page

### DIFF
--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -143,7 +143,7 @@
         </div>
         <div class="text-sm text-gray-600 mt-1">
           <?= htmlspecialchars($o['client_name']) ?>,
-          <a href="https://wa.me/<?= $wa ?>" class="<?php if($isStaff): ?>text-green-600 underline hover:text-green-700<?php else: ?>hover:underline<?php endif; ?>" target="_blank"><?= htmlspecialchars($o['phone']) ?></a>,
+          <a href="https://t.me/+<?= $wa ?>" class="<?php if($isStaff): ?>text-green-600 underline hover:text-green-700<?php else: ?>hover:underline<?php endif; ?>" target="_blank"><?= htmlspecialchars($o['phone']) ?></a>,
           <a href="#" class="copy-address hover:underline" data-address="<?= htmlspecialchars($o['address'], ENT_QUOTES) ?>"><?= htmlspecialchars($o['address']) ?></a>
         </div>
         <div class="font-semibold mt-2">Состав:</div>


### PR DESCRIPTION
### Motivation
- На странице заказов в админке для партнёров/менеджеров нужно открывать контакт в Telegram вместо WhatsApp.

### Description
- В файле `src/Views/admin/orders/index.php` заменена ссылка `https://wa.me/<?= $wa ?>` на `https://t.me/+<?= $wa ?>`, при этом разметка и стили сохранены.

### Testing
- Запущены автоматические проверки: `git status --short` показал изменённый файл, и `nl -ba src/Views/admin/orders/index.php | sed -n '142,149p'` подтвердил наличие `href="https://t.me/+<?= $wa ?>"`, обе проверки успешно выполнены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ecf16d9d0832c8348fc479c8f289f)