### PR TITLE
Adjust order card header typography for creator name

### DIFF
--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -134,13 +134,13 @@
       <?php $wa = normalize_phone($o['phone']); ?>
       <div class="order-card block bg-white p-2 sm:p-4 rounded shadow hover:bg-gray-50 <?= $bg ?>" data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" data-created="<?= $createdAttr ?>" data-id="<?= $o['id'] ?>" data-delivery="<?= $deliveryAttr ?>" data-slot="<?= $slotAttr ?>">
         <div class="flex justify-between items-center">
-          <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col font-bold<?php if($isStaff): ?> text-white decoration-white<?php endif; ?>">
+          <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col text-sm font-bold<?php if($isStaff): ?> text-white decoration-white<?php endif; ?>">
             #<?= $o['id'] ?> <?php if ($o['delivery_date']): ?> | <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?><?php
               $hasCreator = !empty($o['created_by_user_id']);
               $buyerId = isset($o['user_id']) ? (int)$o['user_id'] : 0;
               $creatorId = (int)($o['created_by_user_id'] ?? 0);
               $isCreatorDifferent = !$buyerId || ($creatorId !== $buyerId);
-            ?><?php if ($hasCreator && $isCreatorDifferent && !empty($o['author_name'])): ?> | добавил: <?= htmlspecialchars($o['author_name']) ?><?php endif; ?>
+            ?><?php if ($hasCreator && $isCreatorDifferent && !empty($o['author_name'])): ?> | <span class="font-normal"><?= htmlspecialchars($o['author_name']) ?></span><?php endif; ?>
           </a>
           <span class="inline-flex items-center px-2 py-0.5 rounded-full text-sm font-medium <?= order_status_info($o['status'])['badge'] ?>">
             <?= order_status_info($o['status'])['label'] ?>


### PR DESCRIPTION
### Motivation
- Improve readability of the manager/partner orders list by reducing the first-line font size and de-emphasizing the creator name so the main order header remains the visual focus.

### Description
- Modified `src/Views/admin/orders/index.php` to add `text-sm` to the order header link and replace the `| добавил: NAME` segment with `| <span class="font-normal">NAME</span>`, removing the `добавил:` label and making the creator name non-bold.

### Testing
- Ran `git -C /workspace/yagodgo diff -- src/Views/admin/orders/index.php` and committed the change with `git -C /workspace/yagodgo commit`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0a871748832cb928f7103faba7b7)