### PR TITLE
Adjust order card title styling and author display in admin orders view

### DIFF
--- a/src/Views/admin/orders/index.php
+++ b/src/Views/admin/orders/index.php
@@ -134,13 +134,13 @@
       <?php $wa = normalize_phone($o['phone']); ?>
       <div class="order-card block bg-white p-2 sm:p-4 rounded shadow hover:bg-gray-50 <?= $bg ?>" data-status="<?= $o['status'] ?>" data-date="<?= $dateAttr ?>" data-created="<?= $createdAttr ?>" data-id="<?= $o['id'] ?>" data-delivery="<?= $deliveryAttr ?>" data-slot="<?= $slotAttr ?>">
         <div class="flex justify-between items-center">
-          <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="flex flex-col font-bold<?php if($isStaff): ?> text-white decoration-white<?php endif; ?>">
+          <a href="<?= $base ?>/orders/<?= $o['id'] ?>" class="block text-sm font-bold<?php if($isStaff): ?> text-white decoration-white<?php endif; ?>">
             #<?= $o['id'] ?> <?php if ($o['delivery_date']): ?> | <?= date('d.m', strtotime($o['delivery_date'])) ?> <?= htmlspecialchars(format_time_range($o['slot_from'], $o['slot_to'])) ?><?php endif; ?><?php
               $hasCreator = !empty($o['created_by_user_id']);
               $buyerId = isset($o['user_id']) ? (int)$o['user_id'] : 0;
               $creatorId = (int)($o['created_by_user_id'] ?? 0);
               $isCreatorDifferent = !$buyerId || ($creatorId !== $buyerId);
-            ?><?php if ($hasCreator && $isCreatorDifferent && !empty($o['author_name'])): ?> | добавил: <?= htmlspecialchars($o['author_name']) ?><?php endif; ?>
+            ?><?php if ($hasCreator && $isCreatorDifferent && !empty($o['author_name'])): ?> | <span class="font-normal"><?= htmlspecialchars($o['author_name']) ?></span><?php endif; ?>
           </a>
           <span class="inline-flex items-center px-2 py-0.5 rounded-full text-sm font-medium <?= order_status_info($o['status'])['badge'] ?>">
             <?= order_status_info($o['status'])['label'] ?>


### PR DESCRIPTION
### Motivation
- Tweak the order card header presentation to make the title sizing and the creator/author label display more consistent and less visually dominant.

### Description
- Updated the order link in `src/Views/admin/orders/index.php` to use `block text-sm font-bold` instead of `flex flex-col` to normalize sizing and layout across rows while preserving conditional staff classes. 
- Replaced the literal "добавил:" author prefix with a wrapped `<span class="font-normal">` around `<?= htmlspecialchars($o['author_name']) ?>` so the author's name renders with normal weight and integrates better with the title.

### Testing
- Ran a PHP syntax check with `php -l src/Views/admin/orders/index.php` and it passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0a871748832cb928f7103faba7b7)